### PR TITLE
Make sparse tensor types extend the existing tensor types

### DIFF
--- a/aesara/graph/fg.py
+++ b/aesara/graph/fg.py
@@ -485,7 +485,10 @@ class FunctionGraph(MetaObject):
         if verbose is None:
             verbose = config.optimizer_verbose
         if verbose:
-            print(reason, var, new_var)
+            print(
+                f"{reason}:\t{var.owner or var} [{var.name or var.auto_name}] -> "
+                f"{new_var.owner or new_var} [{new_var.name or new_var.auto_name}]"
+            )
 
         new_var = var.type.filter_variable(new_var, allow_convert=True)
 

--- a/aesara/graph/optdb.py
+++ b/aesara/graph/optdb.py
@@ -460,22 +460,19 @@ class LocalGroupDB(DB):
             self.__position__[name] = position
 
     def query(self, *tags, **kwtags):
-        # For the new `useless` optimizer
         opts = list(super().query(*tags, **kwtags))
         opts.sort(key=lambda obj: (self.__position__[obj.name], obj.name))
 
         ret = self.local_opt(
-            *opts, apply_all_opts=self.apply_all_opts, profile=self.profile
+            *opts,
+            apply_all_opts=self.apply_all_opts,
+            profile=self.profile,
         )
         return ret
 
 
 class TopoDB(DB):
-    """
-
-    Generate a `GlobalOptimizer` of type TopoOptimizer.
-
-    """
+    """Generate a `GlobalOptimizer` of type TopoOptimizer."""
 
     def __init__(
         self, db, order="in_to_out", ignore_newtrees=False, failure_callback=None

--- a/aesara/graph/toolbox.py
+++ b/aesara/graph/toolbox.py
@@ -571,7 +571,7 @@ class ReplaceValidate(History, Validator):
 
         for r, new_r in replacements:
             try:
-                fgraph.replace(r, new_r, reason=reason, verbose=False, **kwargs)
+                fgraph.replace(r, new_r, reason=reason, verbose=verbose, **kwargs)
             except Exception as e:
                 msg = str(e)
                 s1 = "The type of the replacement must be the same"
@@ -626,8 +626,6 @@ class ReplaceValidate(History, Validator):
                 print(
                     "Scan removed", nb, nb2, getattr(reason, "name", reason), r, new_r
                 )
-        if verbose:
-            print(reason, r, new_r)
         # The return is needed by replace_all_validate_remove
         return chk
 

--- a/aesara/sparse/type.py
+++ b/aesara/sparse/type.py
@@ -10,7 +10,7 @@ except ImportError:
 
 
 import aesara
-from aesara.graph.type import Type
+from aesara.tensor.type import TensorType
 
 
 def _is_sparse(x):
@@ -32,7 +32,7 @@ def _is_sparse(x):
     return isinstance(x, scipy.sparse.spmatrix)
 
 
-class SparseType(Type):
+class SparseType(TensorType):
     """
     Fundamental way to create a sparse node.
 
@@ -60,19 +60,19 @@ class SparseType(Type):
             "csc": scipy.sparse.csc_matrix,
             "bsr": scipy.sparse.bsr_matrix,
         }
-    dtype_set = {
-        "int8",
-        "int16",
-        "int32",
-        "int64",
-        "float32",
-        "uint8",
-        "uint16",
-        "uint32",
-        "uint64",
-        "float64",
-        "complex64",
-        "complex128",
+    dtype_specs_map = {
+        "float32": (float, "npy_float32", "NPY_FLOAT32"),
+        "float64": (float, "npy_float64", "NPY_FLOAT64"),
+        "uint8": (int, "npy_uint8", "NPY_UINT8"),
+        "int8": (int, "npy_int8", "NPY_INT8"),
+        "uint16": (int, "npy_uint16", "NPY_UINT16"),
+        "int16": (int, "npy_int16", "NPY_INT16"),
+        "uint32": (int, "npy_uint32", "NPY_UINT32"),
+        "int32": (int, "npy_int32", "NPY_INT32"),
+        "uint64": (int, "npy_uint64", "NPY_UINT64"),
+        "int64": (int, "npy_int64", "NPY_INT64"),
+        "complex128": (complex, "aesara_complex128", "NPY_COMPLEX128"),
+        "complex64": (complex, "aesara_complex64", "NPY_COMPLEX64"),
     }
     ndim = 2
 
@@ -80,27 +80,31 @@ class SparseType(Type):
     Variable = None
     Constant = None
 
-    def __init__(self, format, dtype):
+    def __init__(self, format, dtype, broadcastable=None, name=None):
         if not imported_scipy:
             raise Exception(
-                "You can't make SparseType object as SciPy" " is not available."
-            )
-        dtype = str(dtype)
-        if dtype in self.dtype_set:
-            self.dtype = dtype
-        else:
-            raise NotImplementedError(
-                f'unsupported dtype "{dtype}" not in list', list(self.dtype_set)
+                "You can't make SparseType object when SciPy is not available."
             )
 
-        assert isinstance(format, str)
+        if not isinstance(format, str):
+            raise TypeError("The sparse format parameter must be a string")
+
         if format in self.format_cls:
             self.format = format
         else:
             raise NotImplementedError(
                 f'unsupported format "{format}" not in list',
-                list(self.format_cls.keys()),
             )
+
+        if broadcastable is None:
+            broadcastable = [False, False]
+
+        super().__init__(dtype, broadcastable, name=name)
+
+    def clone(self, dtype=None, broadcastable=None):
+        new = super().clone(dtype=dtype, broadcastable=broadcastable)
+        new.format = self.format
+        return new
 
     def filter(self, value, strict=False, allow_downcast=None):
         if (
@@ -152,14 +156,10 @@ class SparseType(Type):
         return self.Variable(self, name=name)
 
     def __eq__(self, other):
-        return (
-            type(self) == type(other)
-            and other.dtype == self.dtype
-            and other.format == self.format
-        )
+        return super().__eq__(other) and other.format == self.format
 
     def __hash__(self):
-        return hash(self.dtype) ^ hash(self.format)
+        return super().__hash__() ^ hash(self.format)
 
     def __str__(self):
         return f"Sparse[{self.dtype}, {self.format}]"
@@ -207,6 +207,14 @@ class SparseType(Type):
             shape_info[1] * np.dtype(self.dtype).itemsize
             + (shape_info[2] + shape_info[3]) * np.dtype("int32").itemsize
         )
+
+    def value_zeros(self, shape):
+        matrix_constructor = getattr(scipy.sparse, f"{self.format}_matrix", None)
+
+        if matrix_constructor is None:
+            raise ValueError(f"Sparse matrix type {self.format} not found in SciPy")
+
+        return matrix_constructor(shape, dtype=self.dtype)
 
 
 # Register SparseType's C code for ViewOp.

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -341,8 +341,13 @@ def get_scalar_constant_value(
 
             if isinstance(data, np.ndarray):
                 return numpy_scalar(data).copy()
-            else:
-                return data
+
+            from aesara.sparse.type import SparseType
+
+            if isinstance(v.type, SparseType):
+                raise NotScalarConstantError()
+
+            return data
 
         if not only_process_constants and getattr(v, "owner", None) and max_recur > 0:
             max_recur -= 1

--- a/aesara/tensor/blas.py
+++ b/aesara/tensor/blas.py
@@ -166,7 +166,12 @@ from aesara.tensor.blas_headers import blas_header_text, blas_header_version
 from aesara.tensor.elemwise import DimShuffle, Elemwise
 from aesara.tensor.exceptions import NotScalarConstantError
 from aesara.tensor.math import Dot, add, mul, neg, sub
-from aesara.tensor.type import integer_dtypes, tensor, values_eq_approx_remove_inf_nan
+from aesara.tensor.type import (
+    DenseTensorType,
+    integer_dtypes,
+    tensor,
+    values_eq_approx_remove_inf_nan,
+)
 from aesara.utils import memoize
 
 
@@ -253,6 +258,7 @@ class Gemv(Op):
         A = aet.as_tensor_variable(A)
         alpha = aet.as_tensor_variable(alpha)
         beta = aet.as_tensor_variable(beta)
+
         if y.dtype != A.dtype or y.dtype != x.dtype:
             raise TypeError(
                 "Gemv requires matching dtypes", (y.dtype, A.dtype, x.dtype)
@@ -263,7 +269,13 @@ class Gemv(Op):
             raise TypeError("gemv requires vector for x", x.type)
         if y.ndim != 1:
             raise TypeError("gemv requires vector for y", y.type)
-        return Apply(self, [y, alpha, A, x, beta], [y.type()])
+
+        inputs = [y, alpha, A, x, beta]
+
+        if any(not isinstance(i.type, DenseTensorType) for i in inputs):
+            raise NotImplementedError("Only dense tensor types are supported")
+
+        return Apply(self, inputs, [y.type()])
 
     def perform(self, node, inputs, out_storage, params=None):
         y, alpha, A, x, beta = inputs
@@ -360,7 +372,12 @@ class Ger(Op):
 
         if x.dtype not in ("float32", "float64", "complex64", "complex128"):
             raise TypeError("only float and complex types supported", x.dtype)
-        return Apply(self, [A, alpha, x, y], [A.type()])
+
+        inputs = [A, alpha, x, y]
+        if any(not isinstance(i.type, DenseTensorType) for i in inputs):
+            raise NotImplementedError("Only dense tensor types are supported")
+
+        return Apply(self, inputs, [A.type()])
 
     def perform(self, node, inp, out, params=None):
         cA, calpha, cx, cy = inp
@@ -898,6 +915,10 @@ class Gemm(GemmRelated):
 
     def make_node(self, *inputs):
         inputs = list(map(aet.as_tensor_variable, inputs))
+
+        if any(not isinstance(i.type, DenseTensorType) for i in inputs):
+            raise NotImplementedError("Only dense tensor types are supported")
+
         if len(inputs) != 5:
             raise TypeError(
                 f"Wrong number of inputs for {self} (expected 5, got {len(inputs)})"
@@ -1580,6 +1601,10 @@ class Dot22(GemmRelated):
     def make_node(self, x, y):
         x = aet.as_tensor_variable(x)
         y = aet.as_tensor_variable(y)
+
+        if any(not isinstance(i.type, DenseTensorType) for i in (x, y)):
+            raise NotImplementedError("Only dense tensor types are supported")
+
         dtypes = ("float16", "float32", "float64", "complex64", "complex128")
         if x.type.ndim != 2 or x.type.dtype not in dtypes:
             raise TypeError(x)
@@ -1664,6 +1689,9 @@ def local_dot_to_dot22(fgraph, node):
     # produces a dot(dimshuffle,dimshuffle) of form 4 below
     if not isinstance(node.op, Dot):
         return
+
+    if any(not isinstance(i.type, DenseTensorType) for i in node.inputs):
+        return False
 
     x, y = node.inputs
     if y.type.dtype != x.type.dtype:
@@ -1847,6 +1875,10 @@ class Dot22Scalar(GemmRelated):
     check_input = False
 
     def make_node(self, x, y, a):
+
+        if any(not isinstance(i.type, DenseTensorType) for i in (x, y, a)):
+            raise NotImplementedError("Only dense tensor types are supported")
+
         if a.ndim != 0:
             raise TypeError(Gemm.E_scalar, a)
         if x.ndim != 2:
@@ -2065,6 +2097,9 @@ class BatchedDot(COp):
 
     def make_node(self, *inputs):
         inputs = list(map(aet.as_tensor_variable, inputs))
+
+        if any(not isinstance(i.type, DenseTensorType) for i in inputs):
+            raise NotImplementedError("Only dense tensor types are supported")
 
         if len(inputs) != 2:
             raise TypeError(f"Two arguments required, but {len(inputs)} given.")

--- a/aesara/tensor/math.py
+++ b/aesara/tensor/math.py
@@ -32,6 +32,7 @@ from aesara.tensor.elemwise import (
 )
 from aesara.tensor.shape import shape
 from aesara.tensor.type import (
+    DenseTensorType,
     complex_dtypes,
     continuous_dtypes,
     discrete_dtypes,
@@ -2005,6 +2006,11 @@ def dense_dot(a, b):
 
     """
     a, b = as_tensor_variable(a), as_tensor_variable(b)
+
+    if not isinstance(a.type, DenseTensorType) or not isinstance(
+        b.type, DenseTensorType
+    ):
+        raise TypeError("The dense dot product is only supported for dense types")
 
     if a.ndim == 0 or b.ndim == 0:
         return a * b

--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -7,6 +7,7 @@ from aesara import scalar as aes
 from aesara.configdefaults import config
 from aesara.graph.basic import Variable
 from aesara.graph.type import CType
+from aesara.graph.utils import MetaType
 from aesara.misc.safe_asarray import _asarray
 from aesara.utils import apply_across_args
 
@@ -67,6 +68,7 @@ class TensorType(CType):
 
     """
 
+    dtype_specs_map = dtype_specs_map
     context_name = "cpu"
     filter_checks_isfinite = False
     """
@@ -277,7 +279,7 @@ class TensorType(CType):
 
         """
         try:
-            return dtype_specs_map[self.dtype]
+            return self.dtype_specs_map[self.dtype]
         except KeyError:
             raise TypeError(
                 f"Unsupported dtype for {self.__class__.__name__}: {self.dtype}"
@@ -612,6 +614,17 @@ class TensorType(CType):
 
 
 aesara.compile.ops.expandable_types += (TensorType,)
+
+
+class DenseTypeMeta(MetaType):
+    def __instancecheck__(self, o):
+        if type(o) == TensorType or isinstance(o, DenseTypeMeta):
+            return True
+        return False
+
+
+class DenseTensorType(TensorType, metaclass=DenseTypeMeta):
+    """A `Type` for dense tensors."""
 
 
 def values_eq_approx(

--- a/aesara/tensor/var.py
+++ b/aesara/tensor/var.py
@@ -8,6 +8,7 @@ import numpy as np
 from aesara import tensor as aet
 from aesara.configdefaults import config
 from aesara.graph.basic import Constant, Variable
+from aesara.graph.utils import MetaType
 from aesara.scalar import ComplexError, IntegerDivisionError
 from aesara.tensor.exceptions import AdvancedIndexingError
 from aesara.tensor.type import TensorType
@@ -1038,3 +1039,25 @@ class TensorConstant(_tensor_py_operators, Constant):
 
 
 TensorType.Constant = TensorConstant
+
+
+class DenseVariableMeta(MetaType):
+    def __instancecheck__(self, o):
+        if type(o) == TensorVariable or isinstance(o, DenseVariableMeta):
+            return True
+        return False
+
+
+class DenseTensorVariable(TensorType, metaclass=DenseVariableMeta):
+    """A `Variable` for dense tensors."""
+
+
+class DenseConstantMeta(MetaType):
+    def __instancecheck__(self, o):
+        if type(o) == TensorConstant or isinstance(o, DenseConstantMeta):
+            return True
+        return False
+
+
+class DenseTensorConstant(TensorType, metaclass=DenseConstantMeta):
+    """A `Constant` for dense tensors."""

--- a/tests/tensor/test_sharedvar.py
+++ b/tests/tensor/test_sharedvar.py
@@ -429,12 +429,7 @@ def makeSharedTester(
                 topo_cst[0].op == aesara.compile.function.types.deep_copy_op
 
             # Test that we can take the grad.
-            if aesara.sparse.enable_sparse and isinstance(
-                x1_specify_shape.type, aesara.sparse.SparseType
-            ):
-                # SparseVariable don't support sum for now.
-                assert not hasattr(x1_specify_shape, "sum")
-            else:
+            if hasattr(x1_specify_shape, "sum"):
                 shape_grad = aesara.gradient.grad(x1_specify_shape.sum(), x1_shared)
                 shape_constant_fct_grad = aesara.function([], shape_grad)
                 # aesara.printing.debugprint(shape_constant_fct_grad)

--- a/tests/tensor/test_var.py
+++ b/tests/tensor/test_var.py
@@ -4,11 +4,12 @@ from numpy.testing import assert_equal, assert_string_equal
 
 import aesara
 import tests.unittest_tools as utt
+from aesara.tensor.basic import constant
 from aesara.tensor.elemwise import DimShuffle
 from aesara.tensor.subtensor import AdvancedSubtensor, AdvancedSubtensor1, Subtensor
 from aesara.tensor.type import TensorType, dmatrix, iscalar, ivector, matrix
 from aesara.tensor.type_other import MakeSlice
-from aesara.tensor.var import TensorConstant
+from aesara.tensor.var import DenseTensorConstant, DenseTensorVariable, TensorConstant
 
 
 @pytest.mark.parametrize(
@@ -170,3 +171,14 @@ def test__getitem__AdvancedSubtensor():
     z = x[i, None]
     op_types = [type(node.op) for node in aesara.graph.basic.io_toposort([x, i], [z])]
     assert op_types[-1] == AdvancedSubtensor
+
+
+def test_dense_types():
+
+    x = matrix()
+    assert isinstance(x, DenseTensorVariable)
+    assert not isinstance(x, DenseTensorConstant)
+
+    x = constant(1)
+    assert not isinstance(x, DenseTensorVariable)
+    assert isinstance(x, DenseTensorConstant)


### PR DESCRIPTION
This PR refactors the sparse tensor type structure so that sparse types extend the existing tensor types.  A new meta type is used to construct a `DenseTensorType` that can be used to distinguish dense from sparse `TensorType`s.  

Closes #142.

- [x] Create a `DenseTensorVariable` (using the same approach as `DenseTensorType`)
- [x] Update more optimizations so that they exclude `SparseTensor`s
- [ ] Convert sparse to dense when used with some `Op`s (e.g. `Elemwise`, `CAReduce`)