### PR TITLE
Remove assert_shape function (fix #269)

### DIFF
--- a/tests/tensor/nnet/test_abstract_conv.py
+++ b/tests/tensor/nnet/test_abstract_conv.py
@@ -13,7 +13,6 @@ from aesara.tensor.nnet.abstract_conv import (
     AbstractConv2d_gradInputs,
     AbstractConv2d_gradWeights,
     assert_conv_shape,
-    assert_shape,
     bilinear_kernel_1D,
     bilinear_kernel_2D,
     bilinear_upsampling,
@@ -306,29 +305,6 @@ class TestAssertConvShape:
 
 
 class TestAssertShape:
-    @config.change_flags(conv__assert_shape=True)
-    def test_basic(self):
-        x = tensor4()
-        s1 = iscalar()
-        s2 = iscalar()
-        expected_shape = [None, s1, s2, None]
-        f = aesara.function([x, s1, s2], assert_shape(x, expected_shape))
-
-        v = np.zeros((3, 5, 7, 11), dtype="float32")
-        assert 0 == np.sum(f(v, 5, 7))
-
-        with pytest.raises(AssertionError):
-            f(v, 5, 0)
-
-        with pytest.raises(AssertionError):
-            f(v, 5, 9)
-
-        with pytest.raises(AssertionError):
-            f(v, 0, 7)
-
-        with pytest.raises(AssertionError):
-            f(v, 7, 7)
-
     @config.change_flags(conv__assert_shape=True)
     def test_shape_check_conv2d(self):
         input = tensor4()


### PR DESCRIPTION
This PR is to fix #269. The `assert_shape` function has been removed, and now a direct `AssertionError` is raised instead.However, the tests in `tests/tensor/nnet/test_abstract_conv.py` will fail, because of the tests do not expect an AssertionError to be raised.

+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [ ] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.  If your commit description starts with "Fix...", then you're probably making this mistake.
+ [ ] There are tests covering the changes introduced in the PR.