### PR TITLE
Add type hints and apply mypy fix for function attributes where needed

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,5 @@
 [run]
 relative_files = true
+[report]
+exclude_lines = 
+    if TYPE_CHECKING:

--- a/aesara/_version.py
+++ b/aesara/_version.py
@@ -14,9 +14,10 @@ import os
 import re
 import subprocess
 import sys
-from typing import Dict
+from typing import Callable, Dict
 
-def get_keywords():
+
+def get_keywords() -> Dict[str, str]:
     """Get the keywords needed to look up the version information."""
     # these strings will be replaced by git during git-archive.
     # setup.py/versioneer.py will grep for the variable names, so they must
@@ -55,7 +56,7 @@ LONG_VERSION_PY: Dict = {}
 HANDLERS: Dict = {}
 
 
-def register_vcs_handler(vcs, method):  # decorator
+def register_vcs_handler(vcs, method) -> Callable:  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
 
     def decorate(f):

--- a/aesara/compile/compilelock.py
+++ b/aesara/compile/compilelock.py
@@ -45,15 +45,15 @@ def force_unlock(lock_dir: os.PathLike):
 
 
 @contextmanager
-def lock_ctx(lock_dir: os.PathLike = None, *, timeout: Optional[float] = None):
+def lock_ctx(lock_dir: Optional[os.PathLike] = None, *, timeout: Optional[float] = -1):
     """Context manager that wraps around FileLock and SoftFileLock from filelock package.
 
     Parameters
     ----------
-    lock_dir : str
+    lock_dir : str or None
         A directory for which to acquire the lock.
         Defaults to the config.compiledir.
-    timeout : float
+    timeout : float or None
         Timeout in seconds for waiting in lock acquisition.
         Defaults to config.compile__timeout.
     """

--- a/aesara/compile/function/__init__.py
+++ b/aesara/compile/function/__init__.py
@@ -92,8 +92,8 @@ def function_dump(
 
 
 def function(
-    inputs: List[Variable],
-    outputs: Optional[List[Variable]] = None,
+    inputs: "List[Variable]",
+    outputs: "Optional[List[Variable]]" = None,
     mode: Union[str] = None,
     updates: Optional[Union[List, Tuple, Iterable]] = None,
     givens: Optional[Union[List, Tuple, Iterable]] = None,
@@ -102,7 +102,7 @@ def function(
     name: Optional[str] = None,
     rebuild_strict: bool = True,
     allow_input_downcast: Optional[bool] = None,
-    profile: Optional[Union[ProfileStats, bool]] = None,
+    profile: "Optional[Union[ProfileStats, bool]]" = None,
     on_unused_input: Optional[str] = None,
 ):
     """

--- a/aesara/compile/function/__init__.py
+++ b/aesara/compile/function/__init__.py
@@ -3,9 +3,15 @@ import re
 import traceback as tb
 import warnings
 from collections import OrderedDict
+from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Union
 
 from aesara.compile.function.pfunc import pfunc
 from aesara.compile.function.types import orig_function
+
+
+if TYPE_CHECKING:
+    from aesara.compile.profiling import ProfileStats
+    from aesara.graph.basic import Variable
 
 
 __all__ = ["types", "pfunc"]
@@ -86,18 +92,18 @@ def function_dump(
 
 
 def function(
-    inputs,
-    outputs=None,
-    mode=None,
-    updates=None,
-    givens=None,
-    no_default_updates=False,
-    accept_inplace=False,
-    name=None,
-    rebuild_strict=True,
-    allow_input_downcast=None,
-    profile=None,
-    on_unused_input=None,
+    inputs: List[Variable],
+    outputs: Optional[List[Variable]] = None,
+    mode: Union[str] = None,
+    updates: Optional[Union[List, Tuple, Iterable]] = None,
+    givens: Optional[Union[List, Tuple, Iterable]] = None,
+    no_default_updates: bool = False,
+    accept_inplace: bool = False,
+    name: Optional[str] = None,
+    rebuild_strict: bool = True,
+    allow_input_downcast: Optional[bool] = None,
+    profile: Optional[Union[ProfileStats, bool]] = None,
+    on_unused_input: Optional[str] = None,
 ):
     """
     Return a :class:`callable object <aesara.compile.function.types.Function>`
@@ -109,12 +115,11 @@ def function(
         Function parameters, these are not allowed to be shared variables.
     outputs : list or dict of Variables or Out instances.
         If it is a dict, the keys must be strings. Expressions to compute.
-    mode : string or `Mode` instance.
+    mode : string or `Mode` instance or None
         Compilation mode.
-    updates : iterable over pairs (shared_variable, new_expression). List, tuple
-              or OrderedDict.
-        Updates the values for SharedVariable inputs according to these
-        expressions.
+    updates : iterable over pairs (shared_variable, new_expression). List, tuple,
+        OrderedDict or None. Updates the values for SharedVariable inputs
+        according to these expressions.
     givens : iterable over pairs (Var1, Var2) of Variables. List, tuple or dict.
              The Var1 and Var2 in each pair must have the same Type.
         Specific substitutions to make in the computation graph (Var2 replaces
@@ -127,7 +132,7 @@ def function(
         True iff the graph can contain inplace operations prior to the
         optimization phase (default is False). *Note* this parameter is unsupported,
         and its use is not recommended.
-    name : str
+    name : str or None
         An optional name for this function. The profile mode will print the time
         spent in this function.
     rebuild_strict : bool
@@ -152,7 +157,7 @@ def function(
         If argument is a string, a new ProfileStats instance will be created
         with that string as its ``message`` attribute.
         This profiling object will be available via self.profile.
-    on_unused_input
+    on_unused_input : str or None
         What to do if a variable in the 'inputs' list is not used in the graph.
         Possible values are 'raise', 'warn', 'ignore' and None.
 

--- a/aesara/compile/function/types.py
+++ b/aesara/compile/function/types.py
@@ -11,9 +11,10 @@ import pickle
 import time
 import warnings
 from itertools import chain
-from typing import List
+from typing import Any, List, Tuple
 
 import numpy as np
+from typing_extensions import Protocol
 
 import aesara
 import aesara.compile.profiling
@@ -155,7 +156,18 @@ class Supervisor:
                 raise InconsistencyError("Trying to destroy a protected" "Variable.", r)
 
 
-def std_fgraph(input_specs, output_specs, accept_inplace=False):
+class Std_fgraph(Protocol):
+    features: List
+
+
+def std_fgraph_decorator(func: Any) -> Std_fgraph:
+    return func
+
+
+@std_fgraph_decorator
+def std_fgraph(
+    input_specs, output_specs, accept_inplace: bool = False
+) -> Tuple[FunctionGraph, List]:
     """
     Makes an FunctionGraph corresponding to the input specs and the output
     specs.  Any SymbolicInput in the input_specs, if its update field

--- a/aesara/compile/io.py
+++ b/aesara/compile/io.py
@@ -64,9 +64,9 @@ class SymbolicInput:
 
     def __init__(
         self,
-        variable: Variable,
+        variable: "Variable",
         name: Any = None,
-        update: Optional[Variable] = None,
+        update: "Optional[Variable]" = None,
         mutable: Optional[bool] = None,
         strict: bool = False,
         allow_downcast: Optional[bool] = None,
@@ -176,10 +176,10 @@ class In(SymbolicInput):
     # try to keep it synchronized.
     def __init__(
         self,
-        variable: Variable,
+        variable: "Variable",
         name: Any = None,
         value: Any = None,
-        update: Optional[Variable] = None,
+        update: "Optional[Variable]" = None,
         mutable: Optional[bool] = None,
         strict: bool = False,
         allow_downcast: Optional[bool] = None,
@@ -243,7 +243,7 @@ class SymbolicOutput:
 
     """
 
-    def __init__(self, variable: Variable, borrow: bool = False):
+    def __init__(self, variable: "Variable", borrow: bool = False):
         self.variable = variable
         self.borrow = borrow
 

--- a/aesara/compile/io.py
+++ b/aesara/compile/io.py
@@ -5,8 +5,13 @@ Define `SymbolicInput`, `SymbolicOutput`, `In`, `Out`.
 
 
 import logging
+from typing import TYPE_CHECKING, Any, Optional
 
 from aesara.link.basic import Container
+
+
+if TYPE_CHECKING:
+    from aesara.graph.basic import Variable
 
 
 _logger = logging.getLogger("aesara.compile.io")
@@ -31,7 +36,7 @@ class SymbolicInput:
         Defaults to None. Value (see previous) will be replaced with this
         expression variable after each function call. If update is None, the
         update will be the default value of the input.
-    mutable : bool
+    mutable : bool or None
         Defaults to False if update is None, True if update is not None.
         True: permit the compiled function to modify the python object being
         passed as the input.
@@ -59,14 +64,14 @@ class SymbolicInput:
 
     def __init__(
         self,
-        variable,
-        name=None,
-        update=None,
-        mutable=None,
-        strict=False,
-        allow_downcast=None,
-        autoname=True,
-        implicit=False,
+        variable: Variable,
+        name: Any = None,
+        update: Optional[Variable] = None,
+        mutable: Optional[bool] = None,
+        strict: bool = False,
+        allow_downcast: Optional[bool] = None,
+        autoname: bool = True,
+        implicit: bool = False,
     ):
         assert implicit is not None  # Safety check.
         self.variable = variable
@@ -128,13 +133,13 @@ class In(SymbolicInput):
         Defaults to None. Value (see previous) will be replaced with this
         expression variable after each function call. If update is None, the
         update will be the default value of the input.
-    mutable : bool
+    mutable : bool or None
         Defaults to False if update is None, True if update is not None.
         True: permit the compiled function to modify the python object
         being passed as the input.
         False: do not permit the compiled function to modify the
         python object being passed as the input.
-    borrow : bool
+    borrow : bool or None
         Default : take the same value as mutable.
         True: permit the output of the compiled function to be aliased
         to the input.
@@ -171,17 +176,17 @@ class In(SymbolicInput):
     # try to keep it synchronized.
     def __init__(
         self,
-        variable,
-        name=None,
-        value=None,
-        update=None,
-        mutable=None,
-        strict=False,
-        allow_downcast=None,
-        autoname=True,
-        implicit=None,
-        borrow=None,
-        shared=False,
+        variable: Variable,
+        name: Any = None,
+        value: Any = None,
+        update: Optional[Variable] = None,
+        mutable: Optional[bool] = None,
+        strict: bool = False,
+        allow_downcast: Optional[bool] = None,
+        autoname: bool = True,
+        implicit: Optional[bool] = None,
+        borrow: Optional[bool] = None,
+        shared: bool = False,
     ):
         # if shared, an input's value comes from its persistent
         # storage, not from a default stored in the function or from
@@ -238,7 +243,7 @@ class SymbolicOutput:
 
     """
 
-    def __init__(self, variable, borrow=False):
+    def __init__(self, variable: Variable, borrow: bool = False):
         self.variable = variable
         self.borrow = borrow
 

--- a/aesara/compile/sharedvalue.py
+++ b/aesara/compile/sharedvalue.py
@@ -5,8 +5,10 @@ Provide a simple user friendly API to Aesara-managed memory.
 
 import copy
 import logging
+from typing import Any, List, Optional
 
 import numpy as np
+from typing_extensions import Protocol
 
 from aesara.graph.basic import Variable
 from aesara.graph.type import generic
@@ -233,7 +235,22 @@ def shared_constructor(ctor, remove=False):
     return ctor
 
 
-def shared(value, name=None, strict=False, allow_downcast=None, **kwargs):
+class Shared(Protocol):
+    constructors: List
+
+
+def shared_decorator(func: Any) -> Shared:
+    return func
+
+
+@shared_decorator
+def shared(
+    value,
+    name: Optional[str] = None,
+    strict: Optional[bool] = False,
+    allow_downcast=None,
+    **kwargs,
+):
     """Return a SharedVariable Variable, initialized with a copy or
     reference of `value`.
 
@@ -310,7 +327,12 @@ shared.constructors = []
 
 
 @shared_constructor
-def generic_constructor(value, name=None, strict=False, allow_downcast=None):
+def generic_constructor(
+    value,
+    name: Optional[str] = None,
+    strict: Optional[bool] = False,
+    allow_downcast: Optional[bool] = None,
+) -> SharedVariable:
     """
     SharedVariable Constructor.
 

--- a/aesara/configparser.py
+++ b/aesara/configparser.py
@@ -2,7 +2,6 @@ import logging
 import os
 import shlex
 import sys
-import typing
 import warnings
 from configparser import (
     ConfigParser,
@@ -13,7 +12,7 @@ from configparser import (
 )
 from functools import wraps
 from io import StringIO
-from typing import Optional
+from typing import Callable, Dict, Optional, Sequence, Union
 
 from aesara.utils import deprecated, hash_from_code
 
@@ -95,7 +94,7 @@ class AesaraConfigParser:
         self._flags_dict = flags_dict
         self._aesara_cfg = aesara_cfg
         self._aesara_raw_cfg = aesara_raw_cfg
-        self._config_var_dict: typing.Dict = {}
+        self._config_var_dict: Dict = {}
         super().__init__()
 
     def __str__(self, print_doc=True):
@@ -269,10 +268,10 @@ class ConfigParam:
 
     def __init__(
         self,
-        default: typing.Union[object, typing.Callable[[object], object]],
+        default: Union[object, Callable[[object], object]],
         *,
-        apply: typing.Optional[typing.Callable[[object], object]] = None,
-        validate: typing.Optional[typing.Callable[[object], bool]] = None,
+        apply: Optional[Callable[[object], object]] = None,
+        validate: Optional[Callable[[object], bool]] = None,
         mutable: bool = True,
     ):
         """
@@ -374,7 +373,7 @@ class ConfigParam:
 
 class EnumStr(ConfigParam):
     def __init__(
-        self, default: str, options: typing.Sequence[str], validate=None, mutable=True
+        self, default: str, options: Sequence[str], validate=None, mutable=True
     ):
         """Creates a str-based parameter that takes a predefined set of options.
 

--- a/aesara/gpuarray/__init__.py
+++ b/aesara/gpuarray/__init__.py
@@ -2,6 +2,9 @@ import logging
 import os
 import sys
 import warnings
+from typing import Any, Callable, Dict, Optional, TypeVar
+
+from typing_extensions import Protocol
 
 import aesara
 from aesara.compile import optdb
@@ -79,7 +82,20 @@ def pygpu_parse_version(version_string):
     return version_type(major=major, minor=minor, patch=patch, fullversion=fullversion)
 
 
-def init_dev(dev, name=None, preallocate=None):
+F = TypeVar("F", bound=Callable[..., object])
+
+
+class Init_dev(Protocol[F]):
+    devmap: Dict
+    __call__: F
+
+
+def init_dev_decorator(func: Any) -> Init_dev:
+    return func
+
+
+@init_dev_decorator
+def init_dev(dev, name: Optional[str] = None, preallocate: Optional[int] = None):
     global pygpu_activated
     global aesara_gpu_is_already_active
     if (

--- a/aesara/gpuarray/cudnn_defs.py
+++ b/aesara/gpuarray/cudnn_defs.py
@@ -16,6 +16,8 @@ Currently supported cuDNN APIs:
 """
 
 
+from typing import Tuple, Union
+
 from aesara.graph.type import CEnumType
 
 
@@ -94,7 +96,9 @@ class CuDNNV51:
 
     conv3d_bwd_filter_algorithms = ("none", "small")
 
-    deterministic_bwd_filter_algorithms = ("deterministic", "fft", "winograd_non_fused")
+    deterministic_bwd_filter_algorithms: Union[
+        Tuple[str, str, str], Tuple[str, str, str, str]
+    ] = ("deterministic", "fft", "winograd_non_fused")
 
     cudnnConvolutionBwdDataAlgo_t = CEnumType(
         ("CUDNN_CONVOLUTION_BWD_DATA_ALGO_0", "none"),

--- a/aesara/gpuarray/elemwise.py
+++ b/aesara/gpuarray/elemwise.py
@@ -1,7 +1,9 @@
 import copy
 from io import StringIO
+from typing import Any, Dict
 
 import numpy as np
+from typing_extensions import Protocol
 
 from aesara import scalar as aes
 from aesara.graph.basic import Apply
@@ -2997,7 +2999,16 @@ class GpuErfcinv(Erfcinv):
 gpu_erfcinv = GpuErfcinv(upgrade_to_float_no_complex, name="gpu_erfcinv")
 
 
+class Gpu_ca_reduce(Protocol):
+    cache: Dict
+
+
+def gpu_ca_reduce_decorator(func: Any) -> Gpu_ca_reduce:
+    return func
+
+
 # Caching GpuCAReduceCuda
+@gpu_ca_reduce_decorator
 def gpu_ca_reduce_cuda(
     scalar_op,
     axis=None,

--- a/aesara/graph/basic.py
+++ b/aesara/graph/basic.py
@@ -110,7 +110,7 @@ class Apply(Node):
 
     """
 
-    def __init__(self, op: Op, inputs: "List[Variable]", outputs: "List[Variable]"):
+    def __init__(self, op: "Op", inputs: "List[Variable]", outputs: "List[Variable]"):
         self.op = op
         self.inputs = []
         self.tag = Scratchpad()
@@ -393,7 +393,7 @@ class Variable(Node):
 
     def __init__(
         self,
-        type: Type,
+        type: "Type",
         owner: Optional[Apply] = None,
         index: Optional[int] = None,
         name: Optional[str] = None,
@@ -624,7 +624,7 @@ class Constant(Variable):
 
     # __slots__ = ['data']
 
-    def __init__(self, type: Type, data, name: Optional[str] = None):
+    def __init__(self, type: "Type", data, name: Optional[str] = None):
         super().__init__(type, None, None, name)
         self.data = type.filter(data)
         add_tag_trace(self)

--- a/aesara/graph/callcache.py
+++ b/aesara/graph/callcache.py
@@ -1,12 +1,13 @@
 import logging
 import pickle
+from typing import Callable, Dict, NoReturn, Optional, Tuple
 
 
 _logger = logging.getLogger("aesara.graph.callcache")
 
 
 class CallCache:
-    def __init__(self, filename=None):
+    def __init__(self, filename: Optional[str] = None):
         self.filename = filename
         try:
             if filename is None:
@@ -14,9 +15,9 @@ class CallCache:
             with open(filename) as f:
                 self.cache = pickle.load(f)
         except OSError:
-            self.cache = {}
+            self.cache: Dict = {}
 
-    def persist(self, filename=None):
+    def persist(self, filename: Optional[str] = None) -> NoReturn:
         """
         Cache "filename" as a pickle file
         """
@@ -25,7 +26,7 @@ class CallCache:
         with open(filename, "w") as f:
             pickle.dump(self.cache, f)
 
-    def call(self, fn, args=(), key=None):
+    def call(self, fn: Callable, args: Tuple = (), key: Optional[Tuple] = None):
         """
         Retrieve item from the cache(if available)
         based on a key
@@ -34,7 +35,7 @@ class CallCache:
         ----------
         key
             parameter to retrieve cache item
-        fn,args
+        fn, args
             key to retrieve if "key" is None
         """
         if key is None:
@@ -46,7 +47,7 @@ class CallCache:
             _logger.debug("cache hit %i", len(self.cache))
         return self.cache[key]
 
-    def __del__(self):
+    def __del__(self) -> NoReturn:
         try:
             if self.filename:
                 self.persist()

--- a/aesara/graph/callcache.py
+++ b/aesara/graph/callcache.py
@@ -1,6 +1,6 @@
 import logging
 import pickle
-from typing import Callable, Dict, NoReturn, Optional, Tuple
+from typing import Callable, Dict, Optional, Tuple
 
 
 _logger = logging.getLogger("aesara.graph.callcache")
@@ -17,7 +17,7 @@ class CallCache:
         except OSError:
             self.cache: Dict = {}
 
-    def persist(self, filename: Optional[str] = None) -> NoReturn:
+    def persist(self, filename: Optional[str] = None) -> None:
         """
         Cache "filename" as a pickle file
         """
@@ -47,7 +47,7 @@ class CallCache:
             _logger.debug("cache hit %i", len(self.cache))
         return self.cache[key]
 
-    def __del__(self) -> NoReturn:
+    def __del__(self) -> None:
         try:
             if self.filename:
                 self.persist()

--- a/aesara/graph/fg.py
+++ b/aesara/graph/fg.py
@@ -1,7 +1,7 @@
 """A container for specifying and manipulating a graph with distinct inputs and outputs."""
 import time
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import aesara
 from aesara.configdefaults import config
@@ -127,31 +127,31 @@ class FunctionGraph(MetaObject):
             inputs = [memo[i] for i in inputs]
 
         self.execute_callbacks_time = 0
-        self.execute_callbacks_times = {}
+        self.execute_callbacks_times: Dict = {}
 
         if features is None:
             features = []
 
-        self._features = []
+        self._features: List = []
 
         # All apply nodes in the subgraph defined by inputs and
         # outputs are cached in this field
-        self.apply_nodes = set()
+        self.apply_nodes: Set = set()
 
         # Ditto for variable nodes.
         # It must contain all fgraph.inputs and all apply_nodes
         # outputs even if they aren't used in the graph.
-        self.variables = set()
+        self.variables: Set = set()
 
         self.outputs = list(outputs)
-        self.clients = {}
+        self.clients: Dict = {}
 
         for f in features:
             self.attach_feature(f)
 
         self.attach_feature(ReplaceValidate())
 
-        self.inputs = []
+        self.inputs: List = []
         for in_var in inputs:
             if in_var.owner is not None:
                 raise ValueError(
@@ -267,6 +267,7 @@ class FunctionGraph(MetaObject):
         client_to_remove : pair of (Apply, int)
             A `(node, i)` pair such that `node.inputs[i]` will no longer be
             `var` in this `FunctionGraph`.
+        reason : str or None
 
         """
 
@@ -368,7 +369,7 @@ class FunctionGraph(MetaObject):
         check : bool
             Check that the inputs for the imported nodes are also present in
             the `FunctionGraph`.
-        reason : str
+        reason : str or None
             The name of the optimization or operation in progress.
         import_missing : bool
             Add missing inputs instead of raising an exception.
@@ -500,7 +501,7 @@ class FunctionGraph(MetaObject):
             The variable to replace `var`.
         reason : str
             The name of the optimization or operation in progress.
-        verbose : bool
+        verbose : bool or None
             Print `reason`, `var`, and `new_var`.
         import_missing : bool
             Import missing variables.

--- a/aesara/graph/fg.py
+++ b/aesara/graph/fg.py
@@ -662,7 +662,8 @@ class FunctionGraph(MetaObject):
         return order
 
     def orderings(self) -> Dict[Apply, List[Apply]]:
-        """Return `dict` `d` s.t. `d[node]` is a list of nodes that must be evaluated before `node` itself can be evaluated.
+        """Return `dict` `d` s.t. `d[node]` is a list of nodes that must
+        be evaluated before `node` itself can be evaluated.
 
         This is used primarily by the destroy_handler feature to ensure that
         the clients of any destroyed inputs have already computed their

--- a/aesara/graph/op.py
+++ b/aesara/graph/op.py
@@ -179,9 +179,9 @@ class Op(MetaObject):
     """
 
     default_output: Optional[int] = None
-    itypes: Optional[List[TypeVar]] = None
-    otypes: Optional[List[TypeVar]] = None
-    params_type: Optional[Union[ParamsType, GpuContextType, EnumList]] = None
+    itypes: Optional[List] = None
+    otypes: Optional[List] = None
+    params_type: "Optional[Union[ParamsType, GpuContextType, EnumList]]" = None
     """
     An `int` that specifies which output `Op.__call__` should return.  If
     `None`, then all outputs are returned.
@@ -386,8 +386,9 @@ class Op(MetaObject):
         inputs : a Variable or list of Variables
         eval_points
             A Variable or list of Variables with the same length as inputs.
-            Each element of eval_points specifies the value of the corresponding
-            input at the point where the R op is to be evaluated.
+            Each element of eval_points specifies the value of the
+            corresponding input at the point where the R op is to be
+            evaluated.
 
         Returns
         -------

--- a/aesara/link/c/cmodule.py
+++ b/aesara/link/c/cmodule.py
@@ -19,9 +19,10 @@ import textwrap
 import time
 import warnings
 from io import BytesIO, StringIO
-from typing import Dict, List, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import numpy.distutils
+from typing_extensions import Protocol
 
 import aesara
 
@@ -1648,6 +1649,15 @@ def std_include_dirs():
     return numpy_inc_dirs + python_inc_dirs + [gof_inc_dir]
 
 
+class Std_lib_dirs_and_libs(Protocol):
+    data: Optional[Tuple]
+
+
+def std_lib_dirs_and_libs_decorator(func: Any) -> Std_lib_dirs_and_libs:
+    return func
+
+
+@std_lib_dirs_and_libs_decorator
 def std_lib_dirs_and_libs():
     # We cache the results as on Windows, this trigger file access and
     # this method is called many times.
@@ -1770,6 +1780,15 @@ def gcc_version():
     return gcc_version_str
 
 
+class Gcc_llvm(Protocol):
+    is_llvm: Optional[bool]
+
+
+def gcc_llvm_decorator(func: Any) -> Gcc_llvm:
+    return func
+
+
+@gcc_llvm_decorator
 def gcc_llvm():
     """
     Detect if the g++ version used is the llvm one or not.

--- a/aesara/link/c/interface.py
+++ b/aesara/link/c/interface.py
@@ -200,7 +200,7 @@ class CLinkerOp(CLinkerObject):
         """
         raise NotImplementedError()
 
-    def c_code_cache_version_apply(self, node: Apply) -> Tuple[int]:
+    def c_code_cache_version_apply(self, node: Apply) -> Union[Tuple[int], Tuple]:
         """Return a tuple of integers indicating the version of this `Op`.
 
         An empty tuple indicates an 'unversioned' `Op` that will not be

--- a/aesara/link/c/lazylinker_c.py
+++ b/aesara/link/c/lazylinker_c.py
@@ -108,7 +108,7 @@ except ImportError:
             _logger.info("Compiling new CVM")
             dirname = "lazylinker_ext"
             cfile = os.path.join(
-                aesara.__path__[0], "link", "c", "c_code", "lazylinker_c.c"
+                aesara.__path__[0], "link", "c", "c_code", "lazylinker_c.c"  # type: ignore
             )
             if not os.path.exists(cfile):
                 # This can happen in not normal case. We just

--- a/aesara/sandbox/rng_mrg.py
+++ b/aesara/sandbox/rng_mrg.py
@@ -14,8 +14,10 @@ P. L'Ecuyer and R. Simard and E. Jack Chen and W. David Kelton, An Object-Orient
 """
 
 import warnings
+from typing import Any, Callable, Optional
 
 import numpy as np
+from typing_extensions import Protocol
 
 from aesara import function, gradient
 from aesara import scalar as aes
@@ -43,6 +45,15 @@ def matVecModM(A, s, m):
     return np.int32(np.sum((A * s) % m, 1) % m)
 
 
+class MultMatVect(Protocol):
+    dot_modulo: Optional[Callable]
+
+
+def multMatVect_decorator(func: Any) -> MultMatVect:
+    return func
+
+
+@multMatVect_decorator
 def multMatVect(v, A, m1, B, m2):
     # TODO : need description for parameter and return
     """

--- a/aesara/scalar/basic.py
+++ b/aesara/scalar/basic.py
@@ -15,9 +15,10 @@ from collections.abc import Callable
 from copy import copy
 from itertools import chain
 from textwrap import dedent
-from typing import Dict, Mapping, Optional, Tuple, Type, Union
+from typing import Any, Dict, Mapping, Optional, Tuple, Type, TypeVar, Union
 
 import numpy as np
+from typing_extensions import Protocol
 
 import aesara
 from aesara import printing
@@ -101,6 +102,19 @@ def as_common_dtype(*vars):
     return (v.astype(dtype) for v in vars)
 
 
+F = TypeVar("F", bound=Callable[..., object])
+
+
+class Get_scalar_type(Protocol[F]):
+    cache: Dict
+    __call__: F
+
+
+def get_scalar_type_decorator(func: Any) -> Get_scalar_type:
+    return func
+
+
+@get_scalar_type_decorator
 def get_scalar_type(dtype):
     """
     Return a Scalar(dtype) object.

--- a/aesara/scalar/basic.py
+++ b/aesara/scalar/basic.py
@@ -11,11 +11,11 @@ you probably want to use aesara.tensor.[c,z,f,d,b,w,i,l,]scalar!
 """
 
 import math
-from collections.abc import Callable
+from collections.abc import Callable as abcCallable
 from copy import copy
 from itertools import chain
 from textwrap import dedent
-from typing import Any, Dict, Mapping, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Callable, Dict, Mapping, Optional, Tuple, Type, TypeVar, Union
 
 import numpy as np
 from typing_extensions import Protocol
@@ -1087,7 +1087,7 @@ class ScalarOp(COp):
     def __init__(self, output_types_preference=None, name=None):
         self.name = name
         if output_types_preference is not None:
-            if not isinstance(output_types_preference, Callable):
+            if not isinstance(output_types_preference, abcCallable):
                 raise TypeError(
                     f"Expected a callable for the 'output_types_preference' argument to {self.__class__}. "
                     f"(got: {output_types_preference})"

--- a/aesara/scan/scan_perform_ext.py
+++ b/aesara/scan/scan_perform_ext.py
@@ -70,7 +70,7 @@ except ImportError:
         except ImportError:
             _logger.info("Compiling C code for scan")
 
-            cfile = os.path.join(aesara.__path__[0], "scan", "c_code", "scan_perform.c")
+            cfile = os.path.join(aesara.__path__[0], "scan", "c_code", "scan_perform.c")  # type: ignore
 
             if not os.path.exists(cfile):
                 raise ImportError(

--- a/aesara/tensor/__init__.py
+++ b/aesara/tensor/__init__.py
@@ -3,7 +3,6 @@
 
 __docformat__ = "restructuredtext en"
 
-import warnings
 from functools import singledispatch
 from typing import TYPE_CHECKING, Any, Callable, List, NoReturn, Optional, Union
 

--- a/aesara/tensor/__init__.py
+++ b/aesara/tensor/__init__.py
@@ -47,7 +47,7 @@ def as_tensor_variable(
 
 @singledispatch
 def _as_tensor_variable(
-    x: Union[int, List, Apply, Variable],
+    x: "Union[int, List, Apply, Variable]",
     name: Optional[str],
     ndim: Optional[int],
     **kwargs,

--- a/aesara/tensor/__init__.py
+++ b/aesara/tensor/__init__.py
@@ -5,7 +5,11 @@ __docformat__ = "restructuredtext en"
 
 import warnings
 from functools import singledispatch
-from typing import Any, Callable, NoReturn, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, NoReturn, Optional, Union
+
+
+if TYPE_CHECKING:
+    from aesara.graph.basic import Apply, Variable
 
 
 def as_tensor_variable(
@@ -43,7 +47,10 @@ def as_tensor_variable(
 
 @singledispatch
 def _as_tensor_variable(
-    x, name: Optional[str], ndim: Optional[int], **kwargs
+    x: Union[int, List, Apply, Variable],
+    name: Optional[str],
+    ndim: Optional[int],
+    **kwargs,
 ) -> NoReturn:
     raise NotImplementedError(f"Cannot convert {x} to a tensor variable.")
 

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -316,8 +316,8 @@ def get_scalar_constant_value(
 
     Parameters
     ----------
-    orig_v :
-
+    orig_v : int, float, np.ndarray, Constant or None
+        The variable `v` where to find the constant scalar(0-D).
     elemwise : bool
         If False, we won't try to go into elemwise. So this call is faster.
         But we still investigate in Second Elemwise (as this is a substitute

--- a/aesara/tensor/blas.py
+++ b/aesara/tensor/blas.py
@@ -140,7 +140,9 @@ except ImportError:
     pass
 
 from functools import reduce
-from typing import Tuple, Union
+from typing import Any, Optional, Tuple, Union
+
+from typing_extensions import Protocol
 
 import aesara.scalar
 from aesara.compile.mode import optdb
@@ -205,7 +207,16 @@ except ImportError as e:
         )
 
 
+class Check_init_y(Protocol):
+    _result: Optional[bool]
+
+
+def check_init_y_decorator(func: Any) -> Check_init_y:
+    return func
+
+
 # If check_init_y() == True we need to initialize y when beta == 0.
+@check_init_y_decorator
 def check_init_y():
     if check_init_y._result is None:
         if not have_fblas:

--- a/aesara/tensor/blas_c.py
+++ b/aesara/tensor/blas_c.py
@@ -1,5 +1,9 @@
 # import aesara.tensor.basic as aet
 
+from typing import Any, Optional
+
+from typing_extensions import Protocol
+
 from aesara.configdefaults import config
 from aesara.graph.op import COp
 from aesara.graph.opt import in2out
@@ -644,6 +648,15 @@ cgemv_inplace = CGemv(inplace=True)
 cgemv_no_inplace = CGemv(inplace=False)
 
 
+class Check_force_gemv_init(Protocol):
+    _force_init_beta: Optional[bool]
+
+
+def check_force_gemv_init_decorator(func: Any) -> Check_force_gemv_init:
+    return func
+
+
+@check_force_gemv_init_decorator
 def check_force_gemv_init():
     if check_force_gemv_init._force_init_beta is None:
         from aesara.link.c.cmodule import GCC_compiler

--- a/aesara/tensor/blas_headers.py
+++ b/aesara/tensor/blas_headers.py
@@ -10,6 +10,9 @@ import os
 import sys
 import textwrap
 from os.path import dirname
+from typing import Any
+
+from typing_extensions import Protocol
 
 from aesara.configdefaults import config
 from aesara.link.c.cmodule import GCC_compiler
@@ -18,6 +21,17 @@ from aesara.link.c.cmodule import GCC_compiler
 _logger = logging.getLogger("aesara.tensor.blas")
 
 
+class Detect_macos_sdot_bug(Protocol):
+    tested: bool
+    present: bool
+    fix_works: bool
+
+
+def detect_macos_sdot_bug_decorator(func: Any) -> Detect_macos_sdot_bug:
+    return func
+
+
+@detect_macos_sdot_bug_decorator
 def detect_macos_sdot_bug():
     """
     Try to detect a bug in the default BLAS in MacOS.

--- a/aesara/tensor/elemwise.py
+++ b/aesara/tensor/elemwise.py
@@ -1278,7 +1278,12 @@ class CAReduce(COp):
     """
 
     __props__: Union[
-        Tuple[str], Tuple[str, str], Tuple[str, str, str], Tuple[str, str, str, str]
+        Tuple[str],
+        Tuple[str, str],
+        Tuple[str, str, str],
+        Tuple[str, str, str, str],
+        Tuple[str, str, str, str, str],
+        Tuple[str, str, str, str, str, str],
     ] = ("scalar_op", "axis")
 
     def __init__(self, scalar_op, axis=None):
@@ -1664,7 +1669,11 @@ class CAReduceDtype(CAReduce):
 
     """
 
-    __props__: Union[Tuple[str, str, str], Tuple[str, str, str, str]] = (
+    __props__: Union[
+        Tuple[str, str, str],
+        Tuple[str, str, str, str],
+        Tuple[str, str, str, str, str, str],
+    ] = (
         "scalar_op",
         "axis",
         "dtype",

--- a/aesara/tensor/nnet/ctc.py
+++ b/aesara/tensor/nnet/ctc.py
@@ -1,5 +1,8 @@
 import os
 import sys
+from typing import Any, Optional
+
+from typing_extensions import Protocol
 
 import aesara.tensor as aet
 from aesara.configdefaults import config
@@ -61,6 +64,17 @@ options.num_threads = 1;
     return True, None
 
 
+class Ctc_present(Protocol):
+    avail: Optional[bool]
+    msg: Optional[str]
+    path: Optional[str]
+
+
+def ctc_present_decorator(func: Any) -> Ctc_present:
+    return func
+
+
+@ctc_present_decorator
 def ctc_present():
     if ctc_present.avail is not None:
         return ctc_present.avail
@@ -75,6 +89,17 @@ ctc_present.msg = None
 ctc_present.path = None
 
 
+class Ctc_available(Protocol):
+    avail: Optional[bool]
+    msg: Optional[str]
+    path: Optional[str]
+
+
+def ctc_available_decorator(func: Any) -> Ctc_available:
+    return func
+
+
+@ctc_available_decorator
 def ctc_available():
     if os.name == "nt":
         ctc_available.msg = ("Windows platforms are currently not supported ",)

--- a/aesara/tensor/shape.py
+++ b/aesara/tensor/shape.py
@@ -1,7 +1,8 @@
 import warnings
-from typing import Dict
+from typing import Any, Dict
 
 import numpy as np
+from typing_extensions import Protocol
 
 import aesara
 from aesara.gradient import DisconnectedType
@@ -248,6 +249,15 @@ class Shape_i(COp):
         ]
 
 
+class Shape_i_decorator(Protocol):
+    cache: Dict
+
+
+def shape_i_decorator(func: Any) -> Shape_i_decorator:
+    return func
+
+
+@shape_i_decorator
 def shape_i(var, i, fgraph=None):
     """
     Equivalent of var.shape[i], but apply if possible the shape feature

--- a/aesara/tensor/var.py
+++ b/aesara/tensor/var.py
@@ -2,6 +2,7 @@ import copy
 import traceback as tb
 import warnings
 from collections.abc import Iterable
+from typing import Optional
 
 import numpy as np
 
@@ -26,7 +27,9 @@ class _tensor_py_operators:
     # def __float__(self): return convert_to_float64(self)
     # def __complex__(self): return convert_to_complex128(self)
 
-    _is_nonzero = True
+    _is_nonzero: bool = True
+    real: Optional[property] = None
+    imag: Optional[property] = None
 
     def __lt__(self, other):
         rval = aet.math.lt(self, other)
@@ -141,8 +144,6 @@ class _tensor_py_operators:
             raise
         except (NotImplementedError, TypeError):
             return NotImplemented
-
-    __truediv__ = __div__
 
     def __pow__(self, other):
         # See explanation in __add__ for the error catched

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,12 @@ if __name__ == "__main__":
         license=LICENSE,
         platforms=PLATFORMS,
         packages=find_packages(exclude=["tests", "tests.*"]),
-        install_requires=["numpy>=1.9.1", "scipy>=0.14", "filelock"],
+        install_requires=[
+            "numpy>=1.9.1",
+            "scipy>=0.14",
+            "filelock",
+            "typing_extensions",
+        ],
         package_data={
             "": [
                 "*.txt",


### PR DESCRIPTION
This PR adds various type hints to increase type coverage. It also fixes the mypy errors raised by the use of function attributes, using the workaround described [here](https://github.com/python/mypy/issues/2087#issuecomment-769266912). 

It will contribute to #200.

Several of the remaining errors returned by mypy are related to inconsistent type inherited from core classes (e.g `Variable`) and I think this is the next thing to be fixed if we want to solve the rest. I saw what is proposed in #134, but I think I will need a bit more guidance for the next step.