### PR TITLE
Require independent dimensions in `size` arguments to multivariate `RandomVariable`s

### DIFF
--- a/aesara/tensor/random/op.py
+++ b/aesara/tensor/random/op.py
@@ -190,15 +190,14 @@ class RandomVariable(Op):
 
         size_len = get_vector_length(size)
 
-        if self.ndim_supp == 0 and size_len > 0:
-            # In this case, we have a univariate distribution with a non-empty
-            # `size` parameter, which means that the `size` parameter
-            # completely determines the shape of the random variable.  More
-            # importantly, the `size` parameter may be the only correct source
-            # of information for the output shape, in that we would be misled
-            # by the `dist_params` if we tried to infer the relevant parts of
-            # the output shape from those.
-            return size
+        if size_len > 0:
+            if self.ndim_supp == 0:
+                return size
+            else:
+                supp_shape = self._shape_from_params(
+                    dist_params, param_shapes=param_shapes
+                )
+                return tuple(size) + tuple(supp_shape)
 
         # Broadcast the parameters
         param_shapes = params_broadcast_shapes(
@@ -307,19 +306,19 @@ class RandomVariable(Op):
             Existing Aesara `Generator` or `RandomState` object to be used.  Creates a
             new one, if `None`.
         size: int or Sequence
-            Numpy-like size of the output (i.e. replications).
+            NumPy-like size parameter.
         dtype: str
             The dtype of the sampled output.  If the value ``"floatX"`` is
-            given, then ``dtype`` is set to ``aesara.config.floatX``.  This
-            value is only used when `self.dtype` isn't set.
+            given, then `dtype` is set to ``aesara.config.floatX``.  This value is
+            only used when ``self.dtype`` isn't set.
         dist_params: list
             Distribution parameters.
 
         Results
         -------
-        out: `Apply`
-            A node with inputs `(rng, size, dtype) + dist_args` and outputs
-            `(rng_var, out_var)`.
+        out: Apply
+            A node with inputs ``(rng, size, dtype) + dist_args`` and outputs
+            ``(rng_var, out_var)``.
 
         """
         size = normalize_size_param(size)

--- a/aesara/tensor/random/opt.py
+++ b/aesara/tensor/random/opt.py
@@ -83,9 +83,19 @@ def local_rv_size_lift(fgraph, node):
     if get_vector_length(size) > 0:
         dist_params = [
             broadcast_to(
-                p, (tuple(size) + tuple(p.shape)) if node.op.ndim_supp > 0 else size
+                p,
+                (
+                    tuple(size)
+                    + (
+                        tuple(p.shape)[-node.op.ndims_params[i] :]
+                        if node.op.ndims_params[i] > 0
+                        else ()
+                    )
+                )
+                if node.op.ndim_supp > 0
+                else size,
             )
-            for p in dist_params
+            for i, p in enumerate(dist_params)
         ]
     else:
         return

--- a/tests/tensor/random/test_opt.py
+++ b/tests/tensor/random/test_opt.py
@@ -12,6 +12,7 @@ from aesara.graph.optdb import OptimizationQuery
 from aesara.tensor.elemwise import DimShuffle
 from aesara.tensor.random.basic import (
     dirichlet,
+    multinomial,
     multivariate_normal,
     normal,
     poisson,
@@ -120,12 +121,20 @@ def test_inplace_optimization():
                 np.array([[0], [10], [100]], dtype=config.floatX),
                 np.diag(np.array([1e-6], dtype=config.floatX)),
             ],
-            [2, 3],
+            [2, 3, 3],
         ),
         (
             dirichlet,
             [np.array([[100, 1, 1], [1, 100, 1], [1, 1, 100]], dtype=config.floatX)],
-            [2, 3],
+            [2, 3, 3],
+        ),
+        (
+            multinomial,
+            [
+                np.array([10, 20], dtype="int64"),
+                np.array([[0.999, 0.001], [0.001, 0.999]], dtype=config.floatX),
+            ],
+            [3, 2],
         ),
     ],
 )
@@ -288,7 +297,7 @@ def test_local_rv_size_lift(dist_op, dist_params, size):
                 np.array([[-1, 20], [300, -4000]], dtype=config.floatX),
                 np.eye(2).astype(config.floatX) * 1e-6,
             ),
-            (3,),
+            (3, 2),
             1e-3,
         ),
     ],


### PR DESCRIPTION
This PR implements the change proposed in https://github.com/pymc-devs/aesara/discussions/412.  It also changes `RandomVariable.compute_bcast` so that it uses constant folding, which is a lot more thorough than the `get_scalar_constant_value` heuristics that are currently in place.

With these changes, one must now add the independent dimensions to the `size` parameters for multivariate `RandomVariable`s.  For example,
```python
import numpy as np

from aesara.tensor.random.basic import multivariate_normal


multivariate_normal(np.zeros((1, 2)), np.ones((1, 2, 2)), size=(4,)).eval()
# ValueError: shape mismatch: objects cannot be broadcast to a single shape

multivariate_normal(np.zeros((1, 2)), np.ones((1, 2, 2)), size=(4, 1)).eval()
# array([[[ 2.407954  ,  2.407954  ]],
#        [[-0.01977264, -0.01977264]],
#        [[-0.15699972, -0.15699972]],
#        [[-0.52942611, -0.52942611]]])
```

I'll add the [proposed `reps` parameter](https://github.com/pymc-devs/aesara/discussions/412#discussioncomment-770036) later in a follow-up PR.