### PR TITLE
Add Numba config options

### DIFF
--- a/aesara/configdefaults.py
+++ b/aesara/configdefaults.py
@@ -1477,6 +1477,12 @@ def add_numba_configvars():
         EnumStr("cpu", ["parallel", "cuda"], mutable=True),
         in_c_key=False,
     )
+    config.add(
+        "numba__fastmath",
+        ("If True, use Numba's fastmath mode."),
+        BoolParam(True),
+        in_c_key=False,
+    )
 
 
 def _get_default_gpuarray__cache_path():

--- a/aesara/configdefaults.py
+++ b/aesara/configdefaults.py
@@ -1470,6 +1470,15 @@ def add_scan_configvars():
     )
 
 
+def add_numba_configvars():
+    config.add(
+        "numba__vectorize_target",
+        ("Default target for numba.vectorize."),
+        EnumStr("cpu", ["parallel", "cuda"], mutable=True),
+        in_c_key=False,
+    )
+
+
 def _get_default_gpuarray__cache_path():
     return os.path.join(config.compiledir, "gpuarray_kernels")
 
@@ -1701,6 +1710,7 @@ add_optimizer_configvars()
 add_metaopt_configvars()
 add_vm_configvars()
 add_deprecated_configvars()
+add_numba_configvars()
 
 # TODO: `gcc_version_str` is used by other modules.. Should it become an immutable config var?
 try:

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -609,7 +609,7 @@ def create_axis_reducer(
             x_axis_first = x.transpose(reaxis_first)
 
             res = np.full(res_shape, to_scalar(identity), dtype=dtype)
-            for m in range(x.shape[axis]):
+            for m in numba.prange(x.shape[axis]):
                 reduce_fn(res, x_axis_first[m], res)
 
             return set_out_dims(res)
@@ -631,8 +631,9 @@ def create_axis_reducer(
         @numba.njit(boundscheck=False)
         def careduce_axis(x):
             res = to_scalar(identity)
-            for val in x:
-                res = reduce_fn(res, val)
+            x_ravel = x.ravel()
+            for i in numba.prange(x_ravel.size):
+                res = reduce_fn(res, x_ravel[i])
             return set_out_dims(res)
 
     return careduce_axis
@@ -1307,7 +1308,7 @@ def numba_funcify_CumOp(op, node, **kwargs):
         x_axis_first = x.transpose(reaxis_first)
         res = np.empty(x_axis_first.shape, dtype=out_dtype)
 
-        for m in range(x.shape[axis]):
+        for m in numba.prange(x.shape[axis]):
             if m == 0:
                 np_func(identity, x_axis_first[m], res[m])
             else:

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -2892,3 +2892,13 @@ def test_random_Generator():
                 if not isinstance(i, (SharedVariable, Constant))
             ],
         )
+
+
+@pytest.mark.xfail(reason="https://github.com/numba/numba/issues/7409")
+def test_config_options_parallel():
+    x = aet.dvector()
+
+    with config.change_flags(numba__vectorize_target="parallel"):
+        aesara_numba_fn = function([x], x * 2, mode=numba_mode)
+        numba_res = aesara_numba_fn(np.array([1, 2, 3], dtype=np.float64))
+        assert np.array_equal(numba_res, np.array([2, 4, 6], dtype=np.float64))

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -2902,3 +2902,12 @@ def test_config_options_parallel():
         aesara_numba_fn = function([x], x * 2, mode=numba_mode)
         numba_res = aesara_numba_fn(np.array([1, 2, 3], dtype=np.float64))
         assert np.array_equal(numba_res, np.array([2, 4, 6], dtype=np.float64))
+
+
+def test_config_options_fastmath():
+    x = aet.dvector()
+
+    with config.change_flags(numba__fastmath=True):
+        aesara_numba_fn = function([x], x * 2, mode=numba_mode)
+        numba_res = aesara_numba_fn(np.array([1, 2, 3], dtype=np.float64))
+        assert np.array_equal(numba_res, np.array([2, 4, 6], dtype=np.float64))


### PR DESCRIPTION
This PR adds some Numba config options for `fastmath` and the `target` option for `numba.vectorize`.