### PR TITLE
Restrict Actions workflow concurrency group to pull requests

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,8 +9,11 @@ on:
   release:
     types: [published]
 
+# Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
-  group: ${{ github.head_ref }}-pypi
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,11 @@ on:
     branches:
       - main
 
+# Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
-  group: ${{ github.head_ref }}-tests
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
This PR updates the recent GitHub Actions `concurrency` setting so that run cancellations are limited to only pull requests.

I noticed that some `main` workflows were erroneously canceled&mdash;assumedly due to the current `concurrency` settings&mdash;after merging a couple PRs, so hopefully this change addresses any future occurrences of that.

These settings were taken from [here](https://core.trac.wordpress.org/changeset/50930/trunk/.github/workflows/coding-standards.yml).