### PR TITLE
Add `take_along_axis`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,0 @@
-[run]
-relative_files = true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,6 @@ jobs:
             - '.github/**/*.yml'
             - 'setup.cfg'
             - 'requirements.txt'
-            - '.coveragerc'
-
 
   style:
     name: Check code style

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,23 @@ exclude =
     doc/
     aesara/_version.py
 
+[coverage:run]
+omit =
+    aesara/_version.py
+    aesara/gpuarray/*
+    tests/*
+branch = True
+relative_files = true
+
+[coverage:report]
+omit =
+    aesara/_version.py
+    aesara/gpuarray/*
+    tests/*
+exclude_lines =
+    pragma: no cover
+show_missing = 1
+
 [versioneer]
 VCS = git
 style = pep440


### PR DESCRIPTION
This PR adds a helper function for `numpy.take_along_axis`.  There's also a commit that fixes some coverage-related issues (e.g. not ignoring some files).