### PR TITLE
Add log1mexp op and opt

### DIFF
--- a/aesara/tensor/inplace.py
+++ b/aesara/tensor/inplace.py
@@ -319,6 +319,11 @@ def softplus_inplace(x):
 
 
 @scalar_elemwise
+def log1mexp_inplace(x):
+    """Compute log(1 - exp(x)), also known as log1mexp"""
+
+
+@scalar_elemwise
 def second_inplace(a):
     """Fill `a` with `b`"""
 

--- a/aesara/tensor/math.py
+++ b/aesara/tensor/math.py
@@ -1425,6 +1425,11 @@ log1pexp = softplus
 
 
 @scalar_elemwise
+def log1mexp(x):
+    """Compute log(1 - exp(x)), also known as log1mexp"""
+
+
+@scalar_elemwise
 def real(z):
     """Return real component of complex-valued tensor `z`"""
 
@@ -2903,6 +2908,7 @@ __all__ = [
     "expit",
     "softplus",
     "log1pexp",
+    "log1mexp",
     "real",
     "imag",
     "angle",

--- a/aesara/tensor/math.py
+++ b/aesara/tensor/math.py
@@ -1421,6 +1421,9 @@ def softplus(x):
     """Compute log(1 + exp(x)), also known as softplus or log1pexp"""
 
 
+log1pexp = softplus
+
+
 @scalar_elemwise
 def real(z):
     """Return real component of complex-valued tensor `z`"""
@@ -2899,6 +2902,7 @@ __all__ = [
     "sigmoid",
     "expit",
     "softplus",
+    "log1pexp",
     "real",
     "imag",
     "angle",

--- a/aesara/tensor/math_opt.py
+++ b/aesara/tensor/math_opt.py
@@ -77,6 +77,7 @@ from aesara.tensor.math import (
     int_div,
     isinf,
     log,
+    log1mexp,
     log1p,
     makeKeepDims,
 )
@@ -3664,3 +3665,11 @@ register_local_1msigmoid = False
 
 if register_local_1msigmoid:
     register_canonicalize(local_1msigmoid)
+
+
+log1pmexp_to_log1mexp = PatternSub(
+    (log1p, (neg, (exp, "x"))),
+    (log1mexp, "x"),
+    allow_multiple_clients=True,
+)
+register_stabilize(log1pmexp_to_log1mexp, name="log1pmexp_to_log1mexp")

--- a/tests/tensor/test_math_scipy.py
+++ b/tests/tensor/test_math_scipy.py
@@ -567,6 +567,39 @@ class TestSoftplus:
         np.testing.assert_allclose(y_th, y_np, rtol=10e-10)
 
 
+_good_broadcast_unary_log1mexp = dict(
+    normal=(random_ranged(-10.0, 0, (2, 3)),),
+    float32=(random_ranged(-10.0, 0, (2, 3)).astype("float32"),),
+    empty=(np.asarray([], dtype=config.floatX),),
+    int=(integers_ranged(-10, -1, (2, 3)),),
+)
+
+_grad_broadcast_unary_log1mexp = dict(
+    normal=(random_ranged(-10.0, 0.0, (2, 3)),),
+)
+
+
+def expected_log1mexp(x):
+    return check_floatX(x, np.log(-np.expm1(x)))
+
+
+TestLog1mexpBroadcast = makeBroadcastTester(
+    op=aet.log1mexp,
+    expected=expected_log1mexp,
+    good=_good_broadcast_unary_log1mexp,
+    grad=_grad_broadcast_unary_log1mexp,
+    eps=1e-8,
+)
+
+TestLog1mexpInplaceBroadcast = makeBroadcastTester(
+    op=inplace.log1mexp_inplace,
+    expected=expected_log1mexp,
+    good=_good_broadcast_unary_log1mexp,
+    eps=1e-8,
+    inplace=True,
+)
+
+
 def test_deprecated_module():
     with pytest.warns(DeprecationWarning):
         import aesara.scalar.basic_scipy  # noqa: F401


### PR DESCRIPTION
This PR adds the numerically stable `log1mexp` `op` and `opt` for graphs of the form `log(1 - exp(x))`. Closes #360 

Question: Do I need to do anything for the `jax` / `numba` linkers?

Some other minor changes: 
1. Added a more intuitive alias to `Softplus` as `log1pexp`. 
1. Added rewrites for expressions of `exp(log1mexp(x))` and `exp(Softplus(x))` in line with existing rewrites for `exp(log...(x))`
1. Separated `local_exp_log` opt into two separate ones, with the ones that add a `nan switch` term appearing only during `specialization`.
