### PR TITLE
Update vectorize function in numba_funcify_Elemwise

### DIFF
--- a/aesara/link/utils.py
+++ b/aesara/link/utils.py
@@ -588,7 +588,9 @@ def compile_function_src(src, function_name, global_env=None, local_env=None):
     mod_code = compile(src, filename, mode="exec")
     exec(mod_code, global_env, local_env)
 
-    return local_env[function_name]
+    res = local_env[function_name]
+    res.__source__ = src
+    return res
 
 
 def get_name_for_object(x: Any):


### PR DESCRIPTION
This PR removes an unnecessary function call in the Numba conversion of `Elemwise` `Op`s.  It also fixes a bug in `test_Elemwise` when the `MyMultiOut` test `Op` is used with a more recent NumPy version.