### PR TITLE
Add gammainc(c) derivatives

### DIFF
--- a/aesara/scalar/math.py
+++ b/aesara/scalar/math.py
@@ -1083,7 +1083,7 @@ betainc = BetaInc(upgrade_to_float_no_complex, name="betainc")
 class BetaIncDer(ScalarOp):
     """
     Gradient of the regularized incomplete beta function wrt to the first
-    argument (alpha) or the second argument (bbeta), depending on whether the
+    argument (alpha) or the second argument (beta), depending on whether the
     fourth argument to betainc_der is `True` or `False`, respectively.
 
     Reference: Boik, R. J., & Robison-Cox, J. F. (1998). Derivatives of the incomplete beta function.
@@ -1253,16 +1253,13 @@ class BetaIncDer(ScalarOp):
             derivative_old = derivative
 
             if d_errapx <= err_threshold:
-                break
+                return derivative
 
-            if n >= max_iters:
-                warnings.warn(
-                    f"_betainc_derivative did not converge after {n} iterations",
-                    RuntimeWarning,
-                )
-                return np.nan
-
-        return derivative
+        warnings.warn(
+            f"betainc_der did not converge after {n} iterations",
+            RuntimeWarning,
+        )
+        return np.nan
 
 
 betainc_der = BetaIncDer(upgrade_to_float_no_complex, name="betainc_der")

--- a/aesara/scalar/math.py
+++ b/aesara/scalar/math.py
@@ -592,7 +592,7 @@ class GammaIncC(BinaryScalarOp):
 
     @staticmethod
     def st_impl(k, x):
-        return scipy.special.gammaincc(x, k)
+        return scipy.special.gammaincc(k, x)
 
     def impl(self, k, x):
         return GammaIncC.st_impl(k, x)

--- a/tests/scalar/test_math.py
+++ b/tests/scalar/test_math.py
@@ -9,7 +9,15 @@ from aesara.link.c.basic import CLinker
 from aesara.scalar.math import betainc, betainc_der, gammainc, gammaincc, gammal, gammau
 
 
-def test_gammainc_nan():
+def test_gammainc_python():
+    x1 = aet.dscalar()
+    x2 = aet.dscalar()
+    y = gammainc(x1, x2)
+    test_func = function([x1, x2], y, mode=Mode("py"))
+    assert np.isclose(test_func(1, 2), sp.gammainc(1, 2))
+
+
+def test_gammainc_nan_c():
     x1 = aet.dscalar()
     x2 = aet.dscalar()
     y = gammainc(x1, x2)
@@ -19,7 +27,15 @@ def test_gammainc_nan():
     assert np.isnan(test_func(-1, -1))
 
 
-def test_gammaincc_nan():
+def test_gammaincc_python():
+    x1 = aet.dscalar()
+    x2 = aet.dscalar()
+    y = gammaincc(x1, x2)
+    test_func = function([x1, x2], y, mode=Mode("py"))
+    assert np.isclose(test_func(1, 2), sp.gammaincc(1, 2))
+
+
+def test_gammaincc_nan_c():
     x1 = aet.dscalar()
     x2 = aet.dscalar()
     y = gammaincc(x1, x2)
@@ -29,7 +45,7 @@ def test_gammaincc_nan():
     assert np.isnan(test_func(-1, -1))
 
 
-def test_gammal_nan():
+def test_gammal_nan_c():
     x1 = aet.dscalar()
     x2 = aet.dscalar()
     y = gammal(x1, x2)
@@ -39,7 +55,7 @@ def test_gammal_nan():
     assert np.isnan(test_func(-1, -1))
 
 
-def test_gammau_nan():
+def test_gammau_nan_c():
     x1 = aet.dscalar()
     x2 = aet.dscalar()
     y = gammau(x1, x2)


### PR DESCRIPTION
This PR adds a Python implementation of derivatives of the `gammainc` and `gamaincc`. Closes #74.

The algorithms were adapted from the STAN library. 