### PR TITLE
Replace `aesara.graph.unify` with `logical-unification` and add a `KanrenRelationSub` local optimizer

### DIFF
--- a/aesara/graph/kanren.py
+++ b/aesara/graph/kanren.py
@@ -1,0 +1,93 @@
+from typing import Callable, Iterator, List, Union
+
+from etuples.core import ExpressionTuple
+from kanren import run
+from unification import var
+from unification.variable import Var
+
+from aesara.graph.basic import Apply, Variable
+from aesara.graph.opt import LocalOptimizer
+from aesara.graph.unify import eval_if_etuple
+
+
+class KanrenRelationSub(LocalOptimizer):
+    r"""A local optimizer that uses `kanren` to match and replace terms.
+
+    See `kanren <https://github.com/pythological/kanren>`__ for more information
+    miniKanren and the API for constructing `kanren` goals.
+
+    Example
+    -------
+
+    ..code-block:: python
+
+        from kanren import eq, conso, var
+
+        import aesara.tensor as at
+        from aesara.graph.kanren import KanrenRelationSub
+
+
+        def relation(in_lv, out_lv):
+            # A `kanren` goal that changes `at.log` terms to `at.exp`
+            cdr_lv = var()
+            return eq(conso(at.log, cdr_lv, in_lv),
+                    conso(at.exp, cdr_lv, out_lv))
+
+
+        kanren_sub_opt = KanrenRelationSub(relation)
+
+    """
+
+    reentrant = True
+
+    def __init__(
+        self,
+        kanren_relation: Callable[[Variable, Var], Callable],
+        results_filter: Callable[
+            [Iterator], List[Union[ExpressionTuple, Variable]]
+        ] = lambda x: next(x, None),
+        node_filter: Callable[[Apply], bool] = lambda x: True,
+    ):
+        r"""Create a `KanrenRelationSub`.
+
+        Parameters
+        ----------
+        kanren_relation
+            A function that takes an input graph and an output logic variable and
+            returns a `kanren` goal.
+        results_filter
+            A function that takes the direct output of `kanren.run(None, ...)`
+            and returns a single result.  The default implementation returns
+            the first result.
+        node_filter
+            A function taking a single node and returns ``True`` when the node
+            should be processed.
+        """
+        self.kanren_relation = kanren_relation
+        self.results_filter = results_filter
+        self.node_filter = node_filter
+        super().__init__()
+
+    def transform(self, fgraph, node):
+        if self.node_filter(node) is False:
+            return False
+
+        try:
+            input_expr = node.default_output()
+        except ValueError:
+            input_expr = node.outputs
+
+        q = var()
+        kanren_results = run(None, q, self.kanren_relation(input_expr, q))
+
+        chosen_res = self.results_filter(kanren_results)
+
+        if chosen_res:
+            if isinstance(chosen_res, list):
+                new_outputs = [eval_if_etuple(v) for v in chosen_res]
+            else:
+                new_outputs = [eval_if_etuple(chosen_res)]
+
+            return new_outputs
+        else:
+            return False

--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -67,6 +67,8 @@ class TensorType(CType):
 
     """
 
+    __props__ = ("dtype", "broadcastable")
+
     context_name = "cpu"
     filter_checks_isfinite = False
     """

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ install_requires = [
     "filelock",
     "etuples",
     "logical-unification",
+    "miniKanren",
     "cons",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,15 @@ Programming Language :: Python :: 3.9
 """
 CLASSIFIERS = [_f for _f in CLASSIFIERS.split("\n") if _f]
 
-install_requires = ["numpy>=1.17.0", "scipy>=0.14", "filelock"]
+install_requires = [
+    "numpy>=1.17.0",
+    "scipy>=0.14",
+    "filelock",
+    "etuples",
+    "logical-unification",
+    "cons",
+]
+
 
 if sys.version_info[0:2] < (3, 7):
     install_requires += ["dataclasses"]

--- a/tests/graph/test_kanren.py
+++ b/tests/graph/test_kanren.py
@@ -1,0 +1,167 @@
+from copy import copy
+
+import numpy as np
+import pytest
+from etuples import etuple
+from kanren import eq, fact, run
+from kanren.assoccomm import associative, commutative, eq_assoccomm
+from kanren.core import lall
+from unification import var, vars
+
+import aesara.tensor as at
+from aesara.graph.basic import Apply
+from aesara.graph.fg import FunctionGraph
+from aesara.graph.kanren import KanrenRelationSub
+from aesara.graph.op import Op
+from aesara.graph.opt import EquilibriumOptimizer
+from aesara.graph.opt_utils import optimize_graph
+from aesara.graph.unify import eval_if_etuple
+from aesara.tensor.math import Dot, _dot
+from tests.graph.utils import MyType, MyVariable
+
+
+@pytest.fixture(autouse=True)
+def clear_assoccomm():
+    old_commutative_index = copy(commutative.index)
+    old_commutative_facts = copy(commutative.facts)
+    old_associative_index = copy(associative.index)
+    old_associative_facts = copy(associative.facts)
+    try:
+        yield
+    finally:
+        commutative.index = old_commutative_index
+        commutative.facts = old_commutative_facts
+        associative.index = old_associative_index
+        associative.facts = old_associative_facts
+
+
+def test_kanren_basic():
+    A_at = at.matrix("A")
+    x_at = at.vector("x")
+
+    y_at = at.dot(A_at, x_at)
+
+    q = var()
+    res = list(run(None, q, eq(y_at, etuple(_dot, q, x_at))))
+
+    assert res == [A_at]
+
+
+def test_KanrenRelationSub_filters():
+    x_at = at.vector("x")
+    y_at = at.vector("y")
+    z_at = at.vector("z")
+    A_at = at.matrix("A")
+
+    fact(commutative, _dot)
+    fact(commutative, at.add)
+    fact(associative, at.add)
+
+    Z_at = A_at.dot((x_at + y_at) + z_at)
+
+    fgraph = FunctionGraph(outputs=[Z_at], clone=False)
+
+    def distributes(in_lv, out_lv):
+        A_lv, x_lv, y_lv, z_lv = vars(4)
+        return lall(
+            # lhs == A * (x + y + z)
+            eq_assoccomm(
+                etuple(_dot, A_lv, etuple(at.add, x_lv, etuple(at.add, y_lv, z_lv))),
+                in_lv,
+            ),
+            # This relation does nothing but provide us with a means of
+            # generating associative-commutative matches in the `kanren`
+            # output.
+            eq((A_lv, x_lv, y_lv, z_lv), out_lv),
+        )
+
+    def results_filter(results):
+        _results = [eval_if_etuple(v) for v in results]
+
+        # Make sure that at least a couple permutations are present
+        assert (A_at, x_at, y_at, z_at) in _results
+        assert (A_at, y_at, x_at, z_at) in _results
+        assert (A_at, z_at, x_at, y_at) in _results
+
+        return None
+
+    _ = KanrenRelationSub(distributes, results_filter=results_filter).transform(
+        fgraph, fgraph.outputs[0].owner
+    )
+
+    res = KanrenRelationSub(distributes, node_filter=lambda x: False).transform(
+        fgraph, fgraph.outputs[0].owner
+    )
+    assert res is False
+
+
+def test_KanrenRelationSub_multiout():
+    class MyMultiOutOp(Op):
+        def make_node(self, *inputs):
+            outputs = [MyType()(), MyType()()]
+            return Apply(self, list(inputs), outputs)
+
+        def perform(self, node, inputs, outputs):
+            outputs[0] = np.array(inputs[0])
+            outputs[1] = np.array(inputs[0])
+
+    x = MyVariable("x")
+    y = MyVariable("y")
+    multi_op = MyMultiOutOp()
+    o1, o2 = multi_op(x, y)
+    fgraph = FunctionGraph([x, y], [o1], clone=False)
+
+    def relation(in_lv, out_lv):
+        return eq(in_lv, out_lv)
+
+    res = KanrenRelationSub(relation).transform(fgraph, fgraph.outputs[0].owner)
+
+    assert res == [o1, o2]
+
+
+def test_KanrenRelationSub_dot():
+    """Make sure we can run miniKanren "optimizations" over a graph until a fixed-point/normal-form is reached."""
+    x_at = at.vector("x")
+    c_at = at.vector("c")
+    d_at = at.vector("d")
+    A_at = at.matrix("A")
+    B_at = at.matrix("B")
+
+    Z_at = A_at.dot(x_at + B_at.dot(c_at + d_at))
+
+    fgraph = FunctionGraph(outputs=[Z_at], clone=False)
+
+    assert isinstance(fgraph.outputs[0].owner.op, Dot)
+
+    def distributes(in_lv, out_lv):
+        return lall(
+            # lhs == A * (x + b)
+            eq(
+                etuple(_dot, var("A"), etuple(at.add, var("x"), var("b"))),
+                in_lv,
+            ),
+            # rhs == A * x + A * b
+            eq(
+                etuple(
+                    at.add,
+                    etuple(_dot, var("A"), var("x")),
+                    etuple(_dot, var("A"), var("b")),
+                ),
+                out_lv,
+            ),
+        )
+
+    distribute_opt = EquilibriumOptimizer(
+        [KanrenRelationSub(distributes)], max_use_ratio=10
+    )
+
+    fgraph_opt = optimize_graph(fgraph, custom_opt=distribute_opt)
+    (expr_opt,) = fgraph_opt.outputs
+
+    assert expr_opt.owner.op == at.add
+    assert isinstance(expr_opt.owner.inputs[0].owner.op, Dot)
+    assert fgraph_opt.inputs[0] is A_at
+    assert expr_opt.owner.inputs[0].owner.inputs[0].name == "A"
+    assert expr_opt.owner.inputs[1].owner.op == at.add
+    assert isinstance(expr_opt.owner.inputs[1].owner.inputs[0].owner.op, Dot)
+    assert isinstance(expr_opt.owner.inputs[1].owner.inputs[1].owner.op, Dot)

--- a/tests/graph/test_unify.py
+++ b/tests/graph/test_unify.py
@@ -1,0 +1,352 @@
+import numpy as np
+import pytest
+from cons import car, cdr
+from cons.core import ConsError
+from etuples import apply, etuple, etuplize
+from etuples.core import ExpressionTuple
+from unification import reify, unify, var
+from unification.variable import Var
+
+import aesara.scalar as aes
+import aesara.tensor as at
+from aesara.graph.basic import Apply, Constant, equal_computations
+from aesara.graph.op import Op
+from aesara.graph.unify import ConstrainedVar, convert_strs_to_vars
+from aesara.tensor.type import TensorType
+from tests.graph.utils import MyType
+
+
+class CustomOp(Op):
+
+    __props__ = ("a",)
+
+    def __init__(self, a):
+        self.a = a
+
+    def make_node(self, *inputs):
+        return Apply(self, list(inputs), [at.vector()])
+
+    def perform(self, node, inputs, outputs):
+        raise NotImplementedError()
+
+
+class CustomOpNoPropsNoEq(Op):
+    def __init__(self, a):
+        self.a = a
+
+    def make_node(self, *inputs):
+        return Apply(self, list(inputs), [at.vector()])
+
+    def perform(self, node, inputs, outputs):
+        raise NotImplementedError()
+
+
+class CustomOpNoProps(CustomOpNoPropsNoEq):
+    def __eq__(self, other):
+        return type(self) == type(other) and self.a == other.a
+
+    def __hash__(self):
+        return hash((type(self), self.a))
+
+
+def test_cons():
+    x_at = at.vector("x")
+    y_at = at.vector("y")
+
+    z_at = x_at + y_at
+
+    res = car(z_at)
+    assert res == z_at.owner.op
+
+    res = cdr(z_at)
+    assert res == [x_at, y_at]
+
+    with pytest.raises(ConsError):
+        car(x_at)
+
+    with pytest.raises(ConsError):
+        cdr(x_at)
+
+    op1 = CustomOp(1)
+
+    assert car(op1) == CustomOp
+    assert cdr(op1) == (1,)
+
+    tt1 = TensorType("float32", [True, False])
+
+    assert car(tt1) == TensorType
+    assert cdr(tt1) == ("float32", (True, False))
+
+    op1_np = CustomOpNoProps(1)
+
+    with pytest.raises(ConsError):
+        car(op1_np)
+
+    with pytest.raises(ConsError):
+        cdr(op1_np)
+
+    atype_at = aes.float64
+    car_res = car(atype_at)
+    cdr_res = cdr(atype_at)
+    assert car_res is type(atype_at)
+    assert cdr_res == [atype_at.dtype]
+
+    atype_at = at.lvector
+    car_res = car(atype_at)
+    cdr_res = cdr(atype_at)
+    assert car_res is type(atype_at)
+    assert cdr_res == [atype_at.dtype, atype_at.broadcastable]
+
+
+def test_etuples():
+    x_at = at.vector("x")
+    y_at = at.vector("y")
+
+    z_at = etuple(x_at, y_at)
+
+    res = apply(at.add, z_at)
+
+    assert res.owner.op == at.add
+    assert res.owner.inputs == [x_at, y_at]
+
+    w_at = etuple(at.add, x_at, y_at)
+
+    res = w_at.evaled_obj
+    assert res.owner.op == at.add
+    assert res.owner.inputs == [x_at, y_at]
+
+    # This `Op` doesn't expand into an `etuple` (i.e. it's "atomic")
+    op1_np = CustomOpNoProps(1)
+
+    res = apply(op1_np, z_at)
+    assert res.owner.op == op1_np
+
+    q_at = op1_np(x_at, y_at)
+    res = etuplize(q_at)
+    assert res[0] == op1_np
+
+    with pytest.raises(TypeError):
+        etuplize(op1_np)
+
+    class MyMultiOutOp(Op):
+        def make_node(self, *inputs):
+            outputs = [MyType()(), MyType()()]
+            return Apply(self, list(inputs), outputs)
+
+        def perform(self, node, inputs, outputs):
+            outputs[0] = np.array(inputs[0])
+            outputs[1] = np.array(inputs[0])
+
+    x_at = at.vector("x")
+    op1_np = MyMultiOutOp()
+    res = apply(op1_np, etuple(x_at))
+    assert len(res) == 2
+    assert res[0].owner.op == op1_np
+    assert res[1].owner.op == op1_np
+
+
+def test_unify_Variable():
+    x_at = at.vector("x")
+    y_at = at.vector("y")
+
+    z_at = x_at + y_at
+
+    # `Variable`, `Variable`
+    s = unify(z_at, z_at)
+    assert s == {}
+
+    # These `Variable`s have no owners
+    v1 = MyType()()
+    v2 = MyType()()
+
+    assert v1 != v2
+
+    s = unify(v1, v2)
+    assert s is False
+
+    op_lv = var()
+    z_pat_et = etuple(op_lv, x_at, y_at)
+
+    # `Variable`, `ExpressionTuple`
+    s = unify(z_at, z_pat_et, {})
+
+    assert op_lv in s
+    assert s[op_lv] == z_at.owner.op
+
+    res = reify(z_pat_et, s)
+
+    assert isinstance(res, ExpressionTuple)
+    assert equal_computations([res.evaled_obj], [z_at])
+
+    z_et = etuple(at.add, x_at, y_at)
+
+    # `ExpressionTuple`, `ExpressionTuple`
+    s = unify(z_et, z_pat_et, {})
+
+    assert op_lv in s
+    assert s[op_lv] == z_et[0]
+
+    res = reify(z_pat_et, s)
+
+    assert isinstance(res, ExpressionTuple)
+    assert equal_computations([res.evaled_obj], [z_et.evaled_obj])
+
+    # `ExpressionTuple`, `Variable`
+    s = unify(z_et, x_at, {})
+    assert s is False
+
+    # This `Op` doesn't expand into an `ExpressionTuple`
+    op1_np = CustomOpNoProps(1)
+
+    q_at = op1_np(x_at, y_at)
+
+    a_lv = var()
+    b_lv = var()
+    # `Variable`, `ExpressionTuple`
+    s = unify(q_at, etuple(op1_np, a_lv, b_lv))
+
+    assert s[a_lv] == x_at
+    assert s[b_lv] == y_at
+
+
+def test_unify_Op():
+    # These `Op`s expand into `ExpressionTuple`s
+    op1 = CustomOp(1)
+    op2 = CustomOp(1)
+
+    # `Op`, `Op`
+    s = unify(op1, op2)
+    assert s == {}
+
+    # `ExpressionTuple`, `Op`
+    s = unify(etuplize(op1), op2)
+    assert s == {}
+
+    # These `Op`s don't expand into `ExpressionTuple`s
+    op1_np = CustomOpNoProps(1)
+    op2_np = CustomOpNoProps(1)
+
+    s = unify(op1_np, op2_np)
+    assert s == {}
+
+    # Same, but this one also doesn't implement `__eq__`
+    op1_np_neq = CustomOpNoPropsNoEq(1)
+
+    s = unify(op1_np_neq, etuplize(op1))
+    assert s is False
+
+
+def test_unify_Constant():
+    # Make sure `Constant` unification works
+    c1_at = at.as_tensor(np.r_[1, 2])
+    c2_at = at.as_tensor(np.r_[1, 2])
+
+    # `Constant`, `Constant`
+    s = unify(c1_at, c2_at)
+    assert s == {}
+
+
+def test_unify_Type():
+    t1 = TensorType(np.float64, (True, False))
+    t2 = TensorType(np.float64, (True, False))
+
+    # `Type`, `Type`
+    s = unify(t1, t2)
+    assert s == {}
+
+    # `Type`, `ExpressionTuple`
+    s = unify(t1, etuple(TensorType, "float64", (True, False)))
+    assert s == {}
+
+    from aesara.scalar.basic import Scalar
+
+    st1 = Scalar(np.float64)
+    st2 = Scalar(np.float64)
+
+    s = unify(st1, st2)
+    assert s == {}
+
+
+def test_ConstrainedVar():
+    cvar = ConstrainedVar(lambda x: isinstance(x, str))
+
+    assert repr(cvar).startswith("ConstrainedVar(")
+    assert repr(cvar).endswith(f", {cvar.token})")
+
+    s = unify(cvar, 1)
+    assert s is False
+
+    s = unify(1, cvar)
+    assert s is False
+
+    s = unify(cvar, "hi")
+    assert s[cvar] == "hi"
+
+    s = unify("hi", cvar)
+    assert s[cvar] == "hi"
+
+    x_lv = var()
+    s = unify(cvar, x_lv)
+    assert s == {cvar: x_lv}
+
+    s = unify(cvar, x_lv, {x_lv: "hi"})
+    assert s[cvar] == "hi"
+
+    s = unify(x_lv, cvar, {x_lv: "hi"})
+    assert s[cvar] == "hi"
+
+    s_orig = {cvar: "hi", x_lv: "hi"}
+    s = unify(x_lv, cvar, s_orig)
+    assert s == s_orig
+
+    s_orig = {cvar: "hi", x_lv: "bye"}
+    s = unify(x_lv, cvar, s_orig)
+    assert s is False
+
+    x_at = at.vector("x")
+    y_at = at.vector("y")
+    op1_np = CustomOpNoProps(1)
+    r_at = etuple(op1_np, x_at, y_at)
+
+    def constraint(x):
+        return isinstance(x, tuple)
+
+    a_lv = ConstrainedVar(constraint)
+    res = reify(etuple(op1_np, a_lv), {a_lv: r_at})
+
+    assert res[1] == r_at
+
+
+def test_convert_strs_to_vars():
+
+    res = convert_strs_to_vars("a")
+    assert isinstance(res, Var)
+    assert res.token == "a"
+
+    x_at = at.vector()
+    y_at = at.vector()
+    res = convert_strs_to_vars((("a", x_at), y_at))
+    assert res == etuple(etuple(var("a"), x_at), y_at)
+
+    def constraint(x):
+        return isinstance(x, str)
+
+    res = convert_strs_to_vars(
+        (({"pattern": "a", "constraint": constraint}, x_at), y_at)
+    )
+    assert res == etuple(etuple(ConstrainedVar(constraint, "a"), x_at), y_at)
+
+    # Make sure constrained logic variables are the same across distinct uses
+    # of their string names
+    res = convert_strs_to_vars(({"pattern": "a", "constraint": constraint}, "a"))
+    assert res[0] is res[1]
+
+    var_map = {"a": var("a")}
+    res = convert_strs_to_vars(("a",), var_map=var_map)
+    assert res[0] is var_map["a"]
+
+    # Make sure numbers and NumPy arrays are converted
+    val = np.r_[1, 2]
+    res = convert_strs_to_vars((val,))
+    assert isinstance(res[0], Constant)
+    assert np.array_equal(res[0].data, val)

--- a/tests/graph/utils.py
+++ b/tests/graph/utils.py
@@ -7,7 +7,7 @@ from aesara.graph.type import Type
 
 def is_variable(x):
     if not isinstance(x, Variable):
-        raise TypeError("not a Variable", x)
+        raise TypeError(f"not a Variable: {x}")
     return x
 
 


### PR DESCRIPTION
This PR adds [`kanren`](https://github.com/pythological/kanren), [`logical-unification`](https://github.com/pythological/unification), [`etuples`](https://github.com/pythological/etuples), and [`cons`](https://github.com/pythological/python-cons) support to Aesara graph objects (e.g. `Variable` and `Op`).  These libraries completely replace `aesara.graph.unify` and its related machinery.

It also introduces the `KanrenRelationSub` `LocalOptimizer` from [`symbolic-pymc`](https://github.com/pymc-devs/symbolic-pymc).  This rewriter allows one to apply `kanren` relations to Aesara graphs.

- [x] Replace `aesara.graph.unify` framework with`logical-unification`
- [x] Refactor `PatternSub` to work with `logical-unification`

Closes #67.