### PR TITLE
Expose `standard_normal` to RandomStream

### DIFF
--- a/aesara/tensor/random/basic.py
+++ b/aesara/tensor/random/basic.py
@@ -1,4 +1,5 @@
 import abc
+import functools
 from typing import List, Optional, Union
 
 import numpy as np
@@ -117,6 +118,11 @@ class NormalRV(RandomVariable):
 
 
 normal = NormalRV()
+# used as an alias of normal(loc=0, scale=1) in order to be consistent with np.random.RandomState
+standard_normal = functools.update_wrapper(
+    functools.partial(normal, loc=0.0, scale=1.0),
+    normal
+)
 
 
 class HalfNormalRV(ScipyRandomVariable):
@@ -815,4 +821,5 @@ __all__ = [
     "beta",
     "triangular",
     "uniform",
+    "standard_normal",
 ]

--- a/aesara/tensor/random/basic.py
+++ b/aesara/tensor/random/basic.py
@@ -1,5 +1,4 @@
 import abc
-import functools
 from typing import List, Optional, Union
 
 import numpy as np
@@ -118,11 +117,14 @@ class NormalRV(RandomVariable):
 
 
 normal = NormalRV()
-# used as an alias of normal(loc=0, scale=1) in order to be consistent with np.random.RandomState
-standard_normal = functools.update_wrapper(
-    functools.partial(normal, loc=0.0, scale=1.0),
-    normal
-)
+
+
+class StandardNormalRV(NormalRV):
+    def __call__(self, size=None, **kwargs):
+        return super().__call__(loc=0.0, scale=1.0, size=size, **kwargs)
+
+
+standard_normal = StandardNormalRV()
 
 
 class HalfNormalRV(ScipyRandomVariable):

--- a/tests/tensor/random/test_basic.py
+++ b/tests/tensor/random/test_basic.py
@@ -47,6 +47,7 @@ from aesara.tensor.random.basic import (
     poisson,
     polyagamma,
     randint,
+    standard_normal,
     triangular,
     truncexpon,
     uniform,
@@ -290,7 +291,7 @@ def test_normal_samples(mean, sigma, size):
 
 
 def test_normal_default_args():
-    rv_numpy_tester(normal)
+    rv_numpy_tester(standard_normal)
 
 
 @pytest.mark.parametrize(

--- a/tests/tensor/random/test_utils.py
+++ b/tests/tensor/random/test_utils.py
@@ -109,6 +109,9 @@ class TestSharedRandomStream:
         with pytest.raises(AttributeError):
             random.blah
 
+        # test if standard_normal is available in the namespace, See: GH issue #528
+        random.standard_normal
+
         with pytest.raises(AttributeError):
             np_random = RandomStream(namespace=np, rng_ctor=rng_ctor)
             np_random.ndarray


### PR DESCRIPTION
Exposes `standard_normal`  to the random namespace for convenience and to be more consistent with the behavior of `np.random.RandomState`.

closes #528 