### PR TITLE
Register `log1p_neg_sigmoid` rewrite in specialize

### DIFF
--- a/aesara/tensor/math_opt.py
+++ b/aesara/tensor/math_opt.py
@@ -3096,7 +3096,8 @@ log1p_neg_sigmoid = PatternSub(
 register_stabilize(logsigm_to_softplus, name="logsigm_to_softplus")
 register_stabilize(log1msigm_to_softplus, name="log1msigm_to_softplus")
 register_stabilize(log1pexp_to_softplus, name="log1pexp_to_softplus")
-register_stabilize(log1p_neg_sigmoid, name="log1p_neg_sigmoid,")
+register_stabilize(log1p_neg_sigmoid, name="log1p_neg_sigmoid")
+register_specialize(log1p_neg_sigmoid, name="log1p_neg_sigmoid")
 
 
 def is_1pexp(t, only_process_constants=True):

--- a/tests/tensor/test_math_opt.py
+++ b/tests/tensor/test_math_opt.py
@@ -4456,6 +4456,19 @@ class TestSoftplusOpts:
         assert isinstance(topo[0].op.scalar_op, aesara.scalar.Softplus)
         f(np.random.random((54)).astype(config.floatX))
 
+    def test_log1p_neg_sigmoid_to_softpuls(self):
+        x = scalar()
+        out = log1p(-sigmoid(x))
+        f = aesara.function([x], out, mode=self.m)
+
+        topo = f.maker.fgraph.toposort()
+        assert len(topo) == 2
+        assert isinstance(topo[0].op.scalar_op, aesara.scalar.Softplus)
+        assert isinstance(topo[1].op.scalar_op, aesara.scalar.Neg)
+
+        # This value would underflow to -inf without rewrite
+        assert np.isclose(f(37.0), -37.0)
+
 
 class TestSigmoidUtils:
     """


### PR DESCRIPTION
The rewrite `log1p(-sigmoid(x)) -> -softplus(x)` seems to not work just in `canonicalize`. This came up in https://github.com/aesara-devs/aesara/issues/29#issuecomment-680818970 and in some precision benchmarks I have been doing.

By itself, this change should be enough to address https://github.com/pymc-devs/pymc3/pull/4620 and perhaps render #473 unnecessary.
