### PR TITLE
Make `RandomVariable.compute_bcast` use constant folding

### DIFF
--- a/aesara/graph/type.py
+++ b/aesara/graph/type.py
@@ -229,18 +229,6 @@ class Type(MetaObject):
         """
         return cls.values_eq(a, b)
 
-        #    def get_shape_info(self, obj):
-        """
-        Optional function. See TensorType().get_shape_info for definition.
-
-        """
-
-        #    def get_size(self, shape_info):
-        """
-        Optional function. See TensorType().get_size for definition.
-
-        """
-
 
 class CType(Type, CLinkerType):
     """Convenience wrapper combining `Type` and `CLinkerType`.

--- a/aesara/link/utils.py
+++ b/aesara/link/utils.py
@@ -254,7 +254,7 @@ def gc_helper(node_list: List[Apply]):
 
 
 def raise_with_op(
-    fgraph: FunctionGraph, node, thunk=None, exc_info=None, storage_map=None
+    fgraph: FunctionGraph, node: Apply, thunk=None, exc_info=None, storage_map=None
 ):
     """
     Re-raise an exception while annotating the exception object with
@@ -262,12 +262,16 @@ def raise_with_op(
 
     Parameters
     ----------
+    fgraph
+        The `FunctionGraph` that contains `node`.
     node : Apply node
         The Apply node object that resulted in the raised exception.
+    thunk :
+        An optional thunk.
     exc_info : tuple, optional
         A tuple containing the exception type, exception object and
         associated traceback, as would be returned by a call to
-        `sys.exc_info()` (which is done if `None` is passed).
+        `sys.exc_info` (which is done if ``None`` is passed).
     storage_map: dict, optional
         storage map of the aesara function that resulted in the
         raised exception.
@@ -279,12 +283,12 @@ def raise_with_op(
     object with several new members which may be helpful for debugging
     Aesara graphs. They are:
 
-     * __op_instance__: The Op that is responsible for the exception
+     * ``__op_instance__``: The `Op` that is responsible for the exception
        being raised.
-     * __thunk_trace__: A traceback corresponding to the code that
+     * ``__thunk_trace__``: A traceback corresponding to the code that
        actually generated the exception, if it is available.
-     * __applynode_index__: The index of the Apply node corresponding
-       to this op in `op.fgraph.toposort()`.
+     * ``__applynode_index__``: The index of the `Apply` node corresponding
+       to this `Op` in ``op.fgraph.toposort``.
 
     The exception is not annotated if it is of type `KeyboardInterrupt`.
 

--- a/aesara/link/vm.py
+++ b/aesara/link/vm.py
@@ -166,7 +166,8 @@ class VM:
     def __init__(self, fgraph, nodes, thunks, pre_call_clear):
 
         if len(nodes) != len(thunks):
-            raise ValueError()
+            raise ValueError("`nodes` and `thunks` must be the same length")
+
         self.fgraph = fgraph
         self.nodes = nodes
         self.thunks = thunks
@@ -188,7 +189,7 @@ class VM:
         what exactly this means and how it is done.
 
         """
-        raise NotImplementedError("override me")
+        raise NotImplementedError()
 
     def clear_storage(self):
         """
@@ -199,7 +200,7 @@ class VM:
         calls.
 
         """
-        raise NotImplementedError("override me")
+        raise NotImplementedError()
 
     def update_profile(self, profile):
         """
@@ -282,7 +283,9 @@ class LoopGC(VM):
         # Some other part of Aesara query that information
         self.allow_gc = True
         if not (len(nodes) == len(thunks) == len(post_thunk_clear)):
-            raise ValueError()
+            raise ValueError(
+                "`nodes`, `thunks` and `post_thunk_clear` are not the same lengths"
+            )
 
     def __call__(self):
         if self.time_thunks:
@@ -1138,13 +1141,9 @@ class VMLinker(LocalLinker):
                     # So if they didn't specify that its lazy or not, it isn't.
                     # If this member isn't present, it will crash later.
                     thunks[-1].lazy = False
-            except Exception as e:
-                e.args = (
-                    "The following error happened while" " compiling the node",
-                    node,
-                    "\n",
-                ) + e.args
-                raise
+            except Exception:
+                raise_with_op(fgraph, node)
+
         t1 = time.time()
 
         if self.profile:

--- a/aesara/tensor/random/type.py
+++ b/aesara/tensor/random/type.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 
 import aesara
@@ -29,10 +27,6 @@ class RandomType(Type):
             return data
         else:
             raise TypeError()
-
-    @staticmethod
-    def get_shape_info(obj):
-        return obj.get_value(borrow=True)
 
     @staticmethod
     def may_share_memory(a, b):
@@ -98,10 +92,6 @@ class RandomStateType(RandomType):
             return True
 
         return _eq(sa, sb)
-
-    @staticmethod
-    def get_size(shape_info):
-        return sys.getsizeof(shape_info.get_state(legacy=False))
 
 
 # Register `RandomStateType`'s C code for `ViewOp`.
@@ -183,11 +173,6 @@ class RandomGeneratorType(RandomType):
             return True
 
         return _eq(sa, sb)
-
-    @staticmethod
-    def get_size(shape_info):
-        state = shape_info.__getstate__()
-        return sys.getsizeof(state)
 
 
 # Register `RandomGeneratorType`'s C code for `ViewOp`.

--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -550,19 +550,19 @@ class TensorType(CType):
         return np.zeros(shape, dtype=self.dtype)
 
     def get_shape_info(self, obj):
-        """Return the information needed to compute the memory size of ``obj``.
+        """Return the information needed to compute the memory size of `obj`.
 
         The memory size is only the data, so this excludes the container.
         For an ndarray, this is the data, but not the ndarray object and
         other data structures such as shape and strides.
 
-        ``get_shape_info()`` and ``get_size()`` work in tandem for the memory
+        `get_shape_info` and `get_size` work in tandem for the memory
         profiler.
 
-        ``get_shape_info()`` is called during the execution of the function.
+        `get_shape_info` is called during the execution of the function.
         So it is better that it is not too slow.
 
-        ``get_size()`` will be called on the output of this function
+        `get_size` will be called on the output of this function
         when printing the memory profile.
 
         Parameters
@@ -573,7 +573,7 @@ class TensorType(CType):
         Returns
         -------
         object
-            Python object that ``self.get_size()`` understands.
+            Python object that can be passed to `get_size`.
 
         """
         return obj.shape
@@ -584,7 +584,7 @@ class TensorType(CType):
         Parameters
         ----------
         shape_info
-            The output of the call to get_shape_info().
+            The output of the call to `get_shape_info`.
 
         Returns
         -------

--- a/tests/link/test_vm.py
+++ b/tests/link/test_vm.py
@@ -11,14 +11,24 @@ from aesara.compile.mode import Mode, get_mode
 from aesara.compile.sharedvalue import shared
 from aesara.configdefaults import config
 from aesara.graph.basic import Apply
+from aesara.graph.fg import FunctionGraph
 from aesara.graph.op import Op
 from aesara.ifelse import ifelse
 from aesara.link.c.basic import OpWiseCLinker
 from aesara.link.c.exceptions import MissingGXX
-from aesara.link.vm import Loop, VMLinker
+from aesara.link.utils import map_storage
+from aesara.link.vm import VM, Loop, LoopGC, VMLinker
 from aesara.tensor.math import cosh, sin, tanh
 from aesara.tensor.type import dvector, lscalar, scalar, scalars, vector, vectors
 from aesara.tensor.var import TensorConstant
+
+
+class SomeOp(Op):
+    def perform(self, node, inputs, outputs):
+        pass
+
+    def make_node(self, x):
+        return Apply(self, [x], [x.type()])
 
 
 class TestCallbacks:
@@ -494,3 +504,58 @@ def test_VMLinker_make_vm_no_cvm():
 
             f = function([a], a, mode=Mode(optimizer=None, linker=linker))
             assert isinstance(f.fn, Loop)
+
+
+def test_VMLinker_exception():
+    class BadOp(Op):
+        def perform(self, node, inputs, outputs):
+            pass
+
+        def make_node(self, x):
+            return Apply(self, [x], [x.type()])
+
+        def make_thunk(self, *args, **kwargs):
+            raise Exception("bad Op")
+
+    a = scalar()
+    linker = VMLinker(allow_gc=False, use_cloop=True)
+
+    z = BadOp()(a)
+
+    with pytest.raises(Exception, match=".*Apply node that caused the error.*"):
+        function([a], z, mode=Mode(optimizer=None, linker=linker))
+
+
+def test_VM_exception():
+    class SomeVM(VM):
+        def __call__(self):
+            pass
+
+    a = scalar()
+    fg = FunctionGraph(outputs=[SomeOp()(a)])
+
+    with pytest.raises(ValueError, match="`nodes` and `thunks`.*"):
+        SomeVM(fg, fg.apply_nodes, [], [])
+
+
+def test_LoopGC_exception():
+
+    a = scalar()
+    fg = FunctionGraph(outputs=[SomeOp()(a)])
+
+    # Create valid(ish) `VM` arguments
+    nodes = fg.toposort()
+    input_storage, output_storage, storage_map = map_storage(
+        fg, nodes, None, None, None
+    )
+
+    compute_map = {}
+    for k in storage_map:
+        compute_map[k] = [k.owner is None]
+
+    thunks = [
+        node.op.make_thunk(node, storage_map, compute_map, True) for node in nodes
+    ]
+
+    with pytest.raises(ValueError, match="`nodes`, `thunks` and `post_thunk_clear`.*"):
+        LoopGC(fg, fg.apply_nodes, thunks, [], [])

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -135,6 +135,9 @@ def test_RandomVariable_bcast():
     res = rv.compute_bcast([mu, sd], size)
     assert res == [True, False, False]
 
+    res = rv(0, 1, size=aet.as_tensor(1, dtype=np.int64))
+    assert res.broadcastable == (True,)
+
 
 def test_RandomVariable_floatX():
     test_rv_op = RandomVariable(

--- a/tests/tensor/random/test_type.py
+++ b/tests/tensor/random/test_type.py
@@ -1,5 +1,4 @@
 import pickle
-import sys
 
 import numpy as np
 import pytest
@@ -95,21 +94,6 @@ class TestRandomStateType:
         assert not rng_type.values_eq(rng_g, rng_a)
         assert not rng_type.values_eq(rng_e, rng_g)
 
-    def test_get_shape_info(self):
-        rng = np.random.RandomState(12)
-        rng_a = shared(rng)
-
-        assert isinstance(
-            random_state_type.get_shape_info(rng_a), np.random.RandomState
-        )
-
-    def test_get_size(self):
-        rng = np.random.RandomState(12)
-        rng_a = shared(rng)
-        shape_info = random_state_type.get_shape_info(rng_a)
-        size = random_state_type.get_size(shape_info)
-        assert size == sys.getsizeof(rng.get_state(legacy=False))
-
     def test_may_share_memory(self):
         bg1 = np.random.MT19937()
         bg2 = np.random.MT19937()
@@ -119,16 +103,23 @@ class TestRandomStateType:
 
         rng_var_a = shared(rng_a, borrow=True)
         rng_var_b = shared(rng_b, borrow=True)
-        shape_info_a = random_state_type.get_shape_info(rng_var_a)
-        shape_info_b = random_state_type.get_shape_info(rng_var_b)
 
-        assert random_state_type.may_share_memory(shape_info_a, shape_info_b) is False
+        assert (
+            random_state_type.may_share_memory(
+                rng_var_a.get_value(borrow=True), rng_var_b.get_value(borrow=True)
+            )
+            is False
+        )
 
         rng_c = np.random.RandomState(bg2)
         rng_var_c = shared(rng_c, borrow=True)
-        shape_info_c = random_state_type.get_shape_info(rng_var_c)
 
-        assert random_state_type.may_share_memory(shape_info_b, shape_info_c) is True
+        assert (
+            random_state_type.may_share_memory(
+                rng_var_b.get_value(borrow=True), rng_var_c.get_value(borrow=True)
+            )
+            is True
+        )
 
 
 class TestRandomGeneratorType:
@@ -197,21 +188,6 @@ class TestRandomGeneratorType:
         assert rng_type.is_valid_value(bitgen_g, strict=True)
         assert rng_type.is_valid_value(bitgen_h.__getstate__(), strict=False)
 
-    def test_get_shape_info(self):
-        rng = np.random.default_rng(12)
-        rng_a = shared(rng)
-
-        assert isinstance(
-            random_generator_type.get_shape_info(rng_a), np.random.Generator
-        )
-
-    def test_get_size(self):
-        rng = np.random.Generator(np.random.PCG64(12))
-        rng_a = shared(rng)
-        shape_info = random_generator_type.get_shape_info(rng_a)
-        size = random_generator_type.get_size(shape_info)
-        assert size == sys.getsizeof(rng.__getstate__())
-
     def test_may_share_memory(self):
         bg_a = np.random.PCG64()
         bg_b = np.random.PCG64()
@@ -220,13 +196,20 @@ class TestRandomGeneratorType:
 
         rng_var_a = shared(rng_a, borrow=True)
         rng_var_b = shared(rng_b, borrow=True)
-        shape_info_a = random_state_type.get_shape_info(rng_var_a)
-        shape_info_b = random_state_type.get_shape_info(rng_var_b)
 
-        assert random_state_type.may_share_memory(shape_info_a, shape_info_b) is False
+        assert (
+            random_state_type.may_share_memory(
+                rng_var_a.get_value(borrow=True), rng_var_b.get_value(borrow=True)
+            )
+            is False
+        )
 
         rng_c = np.random.Generator(bg_b)
         rng_var_c = shared(rng_c, borrow=True)
-        shape_info_c = random_state_type.get_shape_info(rng_var_c)
 
-        assert random_state_type.may_share_memory(shape_info_b, shape_info_c) is True
+        assert (
+            random_state_type.may_share_memory(
+                rng_var_b.get_value(borrow=True), rng_var_c.get_value(borrow=True)
+            )
+            is True
+        )


### PR DESCRIPTION
This PR closes #536 by making `RandomVariable.compute_bcast` use constant folding to discover broadcastable dimensions more thoroughly.  It also fixes some docstring and `VMLinker` exception issues and removes some mistaken `TensorType` class methods from `RandomType`.


The constant folding approach used by `RandomVariable.compute_bcast` in this PR is very thorough compared to the hodgepodge of logic that relied on `get_scalar_constant_value`; however, the graphs resulting from the `shape` variable in `RandomVariable.compute_bcast` need to be cloned, and those cloned graphs are constant folded, which is a little redundant when/if the same constant folding will end up being performed later as well.  

We need to be aware of these performance-related points, including the general scope and cost of constant folding and shape inference (via the `ShapeFeature` attached to `shape_fg`).  This doesn't prevent us from using constant folding to replace the misguided `get_scalar_constant_value` function in the long run, we just might need to limit the scope of it in special cases (e.g. very large constants in a graph, or constants passed to sophisticated `Op`s, etc.)

For instance, we could add options to dynamically restrict the scope of constant folding to certain `Op`s.  The result would be a function much more in line with `get_scalar_constant_value`, but without the inherent redundancy and scope creep.