### PR TITLE
Fix openmp pragma statement in elemwise

### DIFF
--- a/aesara/tensor/elemwise.py
+++ b/aesara/tensor/elemwise.py
@@ -1145,7 +1145,7 @@ second dimension
                                 % locals()
                             )
                     if self.openmp:
-                        contig += """#pragma omp parallel for if(n>={int(config.openmp_elemwise_minsize)})
+                        contig += f"""#pragma omp parallel for if(n>={int(config.openmp_elemwise_minsize)})
                         """
                     contig += (
                         """


### PR DESCRIPTION
Currently setting `openmp=true`  generate C++ code that cannot be compiled. The offending line contains invalid openmp pragma call.

```
#pragma omp parallel for if(n>={int(config.openmp_elemwise_minsize)})
```

That's because [this line in tensor/elemwise.py](https://github.com/aesara-devs/aesara/blob/main/aesara/tensor/elemwise.py#L1148) was meant to be an f-string.

To reproduce the error you can run a `misc` script from the root directory

```
THEANO_FLAGS="openmp=true,nocleanup=true" OMP_NUM_THREADS=2 python theano/misc/elemwise_time_test.py
```
