### PR TITLE
Add specialization for subtraction and addition with negative terms

### DIFF
--- a/aesara/tensor/rewriting/math.py
+++ b/aesara/tensor/rewriting/math.py
@@ -1789,6 +1789,24 @@ def local_neg_div_neg(fgraph, node):
 
 
 @register_canonicalize
+@register_specialize
+@node_rewriter([sub])
+def local_sub_neg_to_add(fgraph, node):
+    """
+    x - (-y) -> x + y
+
+    """
+    if node.op == sub:
+        minuend, subtrahend = node.inputs
+
+        if subtrahend.owner:
+            if subtrahend.owner.op == neg:
+                pre_neg = subtrahend.owner.inputs[0]
+                new_out = add(minuend, pre_neg)
+                return [new_out]
+
+
+@register_canonicalize
 @node_rewriter([mul])
 def local_mul_zero(fgraph, node):
     """

--- a/aesara/tensor/rewriting/math.py
+++ b/aesara/tensor/rewriting/math.py
@@ -2575,8 +2575,6 @@ register_canonicalize(local_one_plus_erf)
 register_stabilize(local_one_plus_erf)
 register_specialize(local_one_plus_erf)
 
-# Only one of the two rewrites below is needed if a canonicalization is added
-# for sub(x, y) -> add(x, -y) or a specialization for add(x, -y) -> sub(x, y)
 # 1-erf(x)=>erfc(x)
 local_one_minus_erf = PatternNodeRewriter(
     (sub, 1, (erf, "x")),
@@ -2590,21 +2588,9 @@ register_canonicalize(local_one_minus_erf)
 register_stabilize(local_one_minus_erf)
 register_specialize(local_one_minus_erf)
 
-local_one_minus_erf2 = PatternNodeRewriter(
-    (add, 1, (neg, (erf, "x"))),
-    (erfc, "x"),
-    allow_multiple_clients=True,
-    name="local_one_minus_erf2",
-    tracks=[erf],
-    get_nodes=get_clients_at_depth2,
-)
-register_canonicalize(local_one_minus_erf2)
-register_stabilize(local_one_minus_erf2)
-register_specialize(local_one_minus_erf2)
-
 # (-1)+erf(x) => -erfc(x)
-# There is no need for erf(x)+(-1) nor erf(x) - 1, as the canonicalize will
-# convert those to the matched pattern
+# There is no need for erf(x)+(-1) nor erf(x) - 1, as the `local_add_mul`
+# canonicalize will convert those to the matched pattern
 local_erf_minus_one = PatternNodeRewriter(
     (add, -1, (erf, "x")),
     (neg, (erfc, "x")),
@@ -2617,8 +2603,6 @@ register_canonicalize(local_erf_minus_one)
 register_stabilize(local_erf_minus_one)
 register_specialize(local_erf_minus_one)
 
-# Only one of the two rewrites below is needed if a canonicalization is added
-# for sub(x, y) -> add(x, -y) or a specialization for add(x, -y) -> sub(x, y)
 # 1-erfc(x) => erf(x)
 local_one_minus_erfc = PatternNodeRewriter(
     (sub, 1, (erfc, "x")),
@@ -2632,21 +2616,9 @@ register_canonicalize(local_one_minus_erfc)
 register_stabilize(local_one_minus_erfc)
 register_specialize(local_one_minus_erfc)
 
-local_one_minus_erfc2 = PatternNodeRewriter(
-    (add, 1, (neg, (erfc, "x"))),
-    (erf, "x"),
-    allow_multiple_clients=True,
-    name="local_one_minus_erfc2",
-    tracks=[erfc],
-    get_nodes=get_clients_at_depth2,
-)
-register_canonicalize(local_one_minus_erfc2)
-register_stabilize(local_one_minus_erfc2)
-register_specialize(local_one_minus_erfc2)
-
-# (-1)+erfc(-x)=>erf(x)
+# erfc(-x)-1=>erf(x)
 local_erf_neg_minus_one = PatternNodeRewriter(
-    (add, -1, (erfc, (neg, "x"))),
+    (sub, (erfc, (neg, "x")), 1),
     (erf, "x"),
     allow_multiple_clients=True,
     name="local_erf_neg_minus_one",


### PR DESCRIPTION
```
x - (-y) -> x + y
x + (-y) -> x - y 
-x + y -> y - x
```

Adding these during canonicalization conflicted with a couple of other rewrites. 

1. `local_neg_to_mul` tries to convert `-x -> -1. * x`, so that the `local_mul_canonizer` can do its thing. 
1. When it comes to constants, the `local_add_canonizer` will try to place them on the left of the graph for "constant folding" and leave them as an `add`, even if they are negative. For example `x - 5 -> -5 + x`.

The new rewrites were registered or designed not to conflict with these preexisting rewrites

Closes #546