### PR TITLE
Cast output of `local_func_inv` and `local_exp_log` rewrites

### DIFF
--- a/aesara/tensor/math_opt.py
+++ b/aesara/tensor/math_opt.py
@@ -1742,16 +1742,6 @@ def local_opt_alloc(fgraph, node):
 
 @register_specialize
 @local_optimizer([neg])
-def local_neg_neg(fgraph, node):
-    # other specializations shouldn't put this in,
-    # but sometimes they do
-    if node.op == neg:
-        if node.inputs[0].owner and node.inputs[0].owner.op == neg:
-            return [node.inputs[0].owner.inputs[0]]
-
-
-@register_specialize
-@local_optimizer([neg])
 def local_neg_div_neg(fgraph, node):
     """
     - (-a / b) -> a / b


### PR DESCRIPTION
This PR fixes issues in two rewrites that could return invalid integer input types.

Also removed the redundant `local_neg_neg` rewrite which is covered by the `local_func_inv` ~~and added specific ops to track in some rewrites~~