### PR TITLE
Implement `DeepCopyOp.infer_shape`

### DIFF
--- a/aesara/compile/ops.py
+++ b/aesara/compile/ops.py
@@ -206,6 +206,9 @@ class DeepCopyOp(COp):
         # Else, no C code
         raise NotImplementedError()
 
+    def infer_shape(self, fgraph, node, input_shapes):
+        return input_shapes
+
 
 deep_copy_op = DeepCopyOp()
 


### PR DESCRIPTION
This PR adds a missing `infer_shape` method implementation to `DeepCopyOp`.