### PR TITLE
Add an alternative, faster `AdvancedIncSubtensor` `Op`

### DIFF
--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -522,7 +522,7 @@ class TestSubtensor(utt.OptimizationTestMixin):
         # This test checks that using a long that does not fit raises an error.
         n = self.shared(np.arange(12, dtype=self.dtype).reshape((4, 3)))
         with pytest.raises(Exception):
-            (lambda: n[: (2 ** 63)])()
+            n[: (2 ** 63)]
 
     def test_list_slice(self):
         x = aet.arange(100).reshape((5, 5, 4))
@@ -1628,7 +1628,7 @@ class TestIncSubtensor1:
 
     def test_cant_adv_idx_into_scalar(self):
         with pytest.raises(IndexError):
-            (lambda: self.s[self.adv1q])()
+            self.s[self.adv1q]
 
     def test_index_into_vec_w_vec(self):
         a = self.v[self.adv1q]
@@ -1671,7 +1671,7 @@ class TestIncSubtensor1:
 
     def test_assigning_matrix_to_vector_selection(self):
         with pytest.raises(TypeError):
-            (lambda: inc_subtensor(self.v[self.adv1q](fmatrix())))()
+            inc_subtensor(self.v[self.adv1q](fmatrix()))
 
     def test_matrix_idx(self):
         idx = lmatrix()

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -1616,9 +1616,6 @@ class TestIncSubtensor:
 
 
 class TestIncSubtensor1:
-    # test inc_subtensor
-    # also tests set_subtensor
-
     def setup_method(self):
         self.rng = np.random.default_rng(seed=utt.fetch_seed())
 
@@ -1648,6 +1645,13 @@ class TestIncSubtensor1:
         f = aesara.function([self.v, self.adv1q], a, allow_input_downcast=True)
         aval = f([0.4, 0.9, 0.1], [1, 2])
         assert np.allclose(aval, [0.4, 0.9, 0.1])
+
+    @pytest.mark.parametrize("ignore_duplicates", [True, False])
+    def test_inc_subtensor_AdvancedSubtensor1(self, ignore_duplicates):
+        x = AdvancedSubtensor1()(self.v, self.adv1q)
+        a = inc_subtensor(x, self.v[self.adv1q], ignore_duplicates=ignore_duplicates)
+        assert isinstance(a.owner.op, (AdvancedIncSubtensor1, AdvancedIncSubtensor))
+        assert getattr(a.owner.op, "ignore_duplicates", False) == ignore_duplicates
 
     def test_1d_inc_adv_selection(self):
         a = inc_subtensor(self.v[self.adv1q], self.v[self.adv1q])
@@ -1885,83 +1889,142 @@ class TestAdvancedSubtensor:
         rval = ft4v[:, :, ix2v, None, :]
         utt.assert_allclose(rval, aval)
 
-    def test_inc_adv_subtensor_w_2vec(self):
+    @pytest.mark.parametrize(
+        "ignore_duplicates",
+        [
+            True,
+            False,
+        ],
+    )
+    def test_inc_adv_subtensor_w_2vec(self, ignore_duplicates):
         subt = self.m[self.ix1, self.ix12]
-        a = inc_subtensor(subt, subt)
+        a = inc_subtensor(subt, subt, ignore_duplicates=ignore_duplicates)
 
         typ = TensorType(self.m.type.dtype, self.ix2.type.broadcastable)
-        assert a.type == typ, (a.type, typ)
+        assert a.type == typ
+
         f = aesara.function(
             [self.m, self.ix1, self.ix12], a, allow_input_downcast=True, mode=self.mode
         )
-        aval = f([[0.4, 0.9, 0.1], [5, 6, 7], [0.5, 0.3, 0.15]], [1, 2, 1], [0, 1, 0])
-        assert np.allclose(
-            aval, [[0.4, 0.9, 0.1], [5 * 3, 6, 7], [0.5, 0.3 * 2, 0.15]]
-        ), aval
 
-    def test_inc_adv_subtensor_with_broadcasting(self):
+        m_val = [[0.4, 0.9, 0.1], [5, 6, 7], [0.5, 0.3, 0.15]]
+        ix1_val = [1, 2, 1]
+        ix2_val = [0, 1, 0]
+
+        exp_aval = np.array(m_val)
+        if ignore_duplicates:
+            exp_aval[ix1_val, ix2_val] += exp_aval[ix1_val, ix2_val]
+        else:
+            np.add.at(exp_aval, (ix1_val, ix2_val), exp_aval[ix1_val, ix2_val])
+
+        aval = f(m_val, ix1_val, ix2_val)
+        assert np.allclose(aval, exp_aval)
+
+    @pytest.mark.parametrize(
+        "ignore_duplicates",
+        [
+            True,
+            False,
+        ],
+    )
+    def test_inc_adv_subtensor_with_broadcasting(self, ignore_duplicates):
         inc = dscalar()
-        a = inc_subtensor(self.m[self.ix1, self.ix12], inc)
+        a = inc_subtensor(
+            self.m[self.ix1, self.ix12], inc, ignore_duplicates=ignore_duplicates
+        )
         g_inc = aesara.grad(a.sum(), inc)
 
-        assert a.type == self.m.type, (a.type, self.m.type)
+        assert a.type == self.m.type
+
         f = aesara.function(
             [self.m, self.ix1, self.ix12, inc],
             [a, g_inc],
             allow_input_downcast=True,
             mode=self.mode,
         )
-        aval, gval = f(
-            [[0.4, 0.9, 0.1], [5, 6, 7], [0.5, 0.3, 0.15]], [1, 2, 1], [0, 1, 0], 2.1
-        )
-        assert np.allclose(
-            aval, [[0.4, 0.9, 0.1], [5 + 2.1 * 2, 6, 7], [0.5, 0.3 + 2.1, 0.15]]
-        ), aval
-        assert np.allclose(gval, 3.0), gval
 
-    def test_inc_adv_subtensor1_with_broadcasting(self):
+        m_val = [[0.4, 0.9, 0.1], [5, 6, 7], [0.5, 0.3, 0.15]]
+        ix1_val = [1, 2, 1]
+        ix2_val = [0, 1, 0]
+        inc_val = 2.1
+
+        exp_aval = np.array(m_val)
+        if ignore_duplicates:
+            exp_aval[ix1_val, ix2_val] += inc_val
+        else:
+            np.add.at(exp_aval, (ix1_val, ix2_val), inc_val)
+
+        aval, gval = f(m_val, ix1_val, ix2_val, inc_val)
+        assert np.allclose(aval, exp_aval)
+        assert np.allclose(gval, 3.0)
+
+    @pytest.mark.parametrize(
+        "ignore_duplicates",
+        [
+            True,
+            False,
+        ],
+    )
+    def test_inc_adv_subtensor1_with_broadcasting(self, ignore_duplicates):
         inc = dscalar()
-        a = inc_subtensor(self.m[self.ix1], inc)
+        a = inc_subtensor(self.m[self.ix1], inc, ignore_duplicates=ignore_duplicates)
         g_inc = aesara.grad(a.sum(), inc)
 
-        assert a.type == self.m.type, (a.type, self.m.type)
+        assert a.type == self.m.type
+
         f = aesara.function(
             [self.m, self.ix1, inc],
             [a, g_inc],
             allow_input_downcast=True,
             mode=self.mode,
         )
-        aval, gval = f([[0.4, 0.9, 0.1], [5, 6, 7], [0.5, 0.3, 0.15]], [0, 1, 0], 2.1)
-        assert np.allclose(
-            aval,
-            [
-                [0.4 + 2.1 * 2, 0.9 + 2.1 * 2, 0.1 + 2.1 * 2],
-                [5 + 2.1, 6 + 2.1, 7 + 2.1],
-                [0.5, 0.3, 0.15],
-            ],
-        ), aval
-        assert np.allclose(gval, 9.0), gval
 
-    def test_inc_adv_subtensor_with_index_broadcasting(self):
-        a = inc_subtensor(self.m[self.ix1, self.ix2], 2.1)
+        m_val = [[0.4, 0.9, 0.1], [5, 6, 7], [0.5, 0.3, 0.15]]
+        ix1_val = [0, 1, 0]
+        inc_val = 2.1
 
-        assert a.type == self.m.type, (a.type, self.m.type)
+        exp_aval = np.array(m_val).copy()
+        if ignore_duplicates:
+            exp_aval[ix1_val] += inc_val
+        else:
+            np.add.at(exp_aval, ix1_val, inc_val)
+
+        aval, gval = f(m_val, ix1_val, inc_val)
+
+        assert np.allclose(aval, exp_aval)
+        assert np.allclose(gval, 9.0)
+
+    @pytest.mark.parametrize(
+        "ignore_duplicates",
+        [
+            True,
+            False,
+        ],
+    )
+    def test_inc_adv_subtensor_with_index_broadcasting(self, ignore_duplicates):
+        a = inc_subtensor(
+            self.m[self.ix1, self.ix2], 2.1, ignore_duplicates=ignore_duplicates
+        )
+
+        assert a.type == self.m.type
+
         f = aesara.function(
             [self.m, self.ix1, self.ix2], a, allow_input_downcast=True, mode=self.mode
         )
-        aval = f(
-            [[0.4, 0.9, 0.1], [5, 6, 7], [0.5, 0.3, 0.15]],
-            [0, 2, 0],
-            [[0, 1, 0], [2, 2, 2]],
-        )
-        assert np.allclose(
-            aval,
-            [
-                [0.4 + 2 * 2.1, 0.9, 0.1 + 2 * 2.1],
-                [5, 6, 7],
-                [0.5, 0.3 + 2.1, 0.15 + 2.1],
-            ],
-        ), aval
+
+        m_val = [[0.4, 0.9, 0.1], [5, 6, 7], [0.5, 0.3, 0.15]]
+        ix1_val = [0, 2, 0]
+        ix2_val = [[0, 1, 0], [2, 2, 2]]
+
+        inc_val = 2.1
+        exp_aval = np.array(m_val)
+        if ignore_duplicates:
+            exp_aval[ix1_val, ix2_val] += inc_val
+        else:
+            np.add.at(exp_aval, (ix1_val, ix2_val), inc_val)
+
+        aval = f(m_val, ix1_val, ix2_val)
+        assert np.allclose(aval, exp_aval)
 
     def test_2d_3d_tensors(self):
         rng = np.random.default_rng(utt.fetch_seed())


### PR DESCRIPTION
This PR changes `AdvancedIncSubtensor.perform` so that it uses `x[indices] += y` instead of `np.add.at(x, indices, y)`, since the latter appears to be much slower (e.g. ~4x for boolean indexing at array sizes around 10,000) than the former (see [here](https://stackoverflow.com/questions/67318786/numpy-add-at-slower-than-in-place-add) for some examples).

This changes the results of `AdvancedIncSubtensor`, since&mdash;unlike the descriptions given to these `*IncSubtensor` `Op`s&mdash;they are **not** all equal to `x[indices] += y`.  `AdvancedIncSubtensor*`s all implement behavior that follows `np.add.at`, and that differs from `x[indices] += y` in how it treats duplicate values in `indices`.

~For consistency, this PR should also change `AdvancedIncSubtensor` so that they both produce the same results as `x[indices] += y` and not `np.add.at`, or we should add an option that enables/disables this feature.  The latter seems like the more reasonable thing to do.~

An `ignore_duplicates` option has been added to `inc_subtensor` that determines which approach is used.