### PR TITLE
Fix a bug in an aesara.scan warning message

### DIFF
--- a/aesara/scan/basic.py
+++ b/aesara/scan/basic.py
@@ -764,8 +764,8 @@ def scan(
             _logger.warning(
                 (
                     "When the number of steps is fixed and equal "
-                    "to 1, the provided stopping condition, {} is ignored",
-                ).format(condition)
+                    f"to 1, the provided stopping condition, {condition} is ignored"
+                )
             )
 
         for pos, inner_out in enumerate(outputs):


### PR DESCRIPTION
This PR fixes a mistaken comma in `aesara.scan`.

Reported https://github.com/aesara-devs/aehmc/pull/7#issuecomment-901132887.