### PR TITLE
Fix `RandomVariable` rewrite failures arising from "output" strings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython libgpuarray pygpu
+          mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython libgpuarray pygpu "numba>=0.52" numba-scipy
           if [[ "$PYTHON_VERSION" != "3.6" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib; fi
           pip install -q -r requirements.txt
           mamba list && pip freeze

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -921,7 +921,7 @@ def numba_funcify_ScalarFromTensor(op, **kwargs):
 @numba_funcify.register(AllocEmpty)
 def numba_funcify_AllocEmpty(op, node, **kwargs):
 
-    global_env = {"np": np, "to_scalar": to_scalar, "dtype": op.dtype}
+    global_env = {"np": np, "to_scalar": to_scalar, "dtype": np.dtype(op.dtype)}
 
     unique_names = unique_name_generator(
         ["np", "to_scalar", "dtype", "allocempty", "scalar_shape"], suffix_sep="_"
@@ -1114,7 +1114,6 @@ def direct_cast(typingctx, val, typ):
 def numba_funcify_Cast(op, node, **kwargs):
 
     dtype = np.dtype(op.o_type.dtype)
-    dtype = numba.np.numpy_support.from_dtype(dtype)
 
     @numba.njit(inline="always")
     def cast(x):
@@ -1169,7 +1168,6 @@ def numba_funcify_Clip(op, **kwargs):
 @numba_funcify.register(ARange)
 def numba_funcify_ARange(op, **kwargs):
     dtype = np.dtype(op.dtype)
-    dtype = numba.np.numpy_support.from_dtype(dtype)
 
     @numba.njit(inline="always")
     def arange(start, stop, step):
@@ -1213,7 +1211,6 @@ def numba_funcify_ExtractDiag(op, **kwargs):
 @numba_funcify.register(Eye)
 def numba_funcify_Eye(op, **kwargs):
     dtype = np.dtype(op.dtype)
-    dtype = numba.np.numpy_support.from_dtype(dtype)
 
     @numba.njit(inline="always")
     def eye(N, M, k):

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -593,8 +593,7 @@ def test_AllocEmpty():
     x = aet.empty((2, 3), dtype="float32")
     x_fg = FunctionGraph([], [x])
 
-    # We need cannot compare the values in the arrays, only the shapes and
-    # dtypes
+    # We cannot compare the values in the arrays, only the shapes and dtypes
     compare_numba_and_py(x_fg, [], assert_fn=compare_shape_dtype)
 
 


### PR DESCRIPTION
This PR fixes an issue in the `RandomVariable` rewrite checks that occurs when `fgraph.clients[base_rv]` contains `("output", ...)` entries.