### PR TITLE
Added infix dot product to `TensorVariable`

### DIFF
--- a/aesara/tensor/var.py
+++ b/aesara/tensor/var.py
@@ -642,6 +642,8 @@ class _tensor_py_operators:
         return aet.math.dense_dot(left, right)
 
     dot = __dot__
+    __matmul__ = __dot__
+    __rmatmul__ = __rdot__
 
     def sum(self, axis=None, dtype=None, keepdims=False, acc_dtype=None):
         """See `aesara.tensor.math.sum`."""

--- a/tests/tensor/test_var.py
+++ b/tests/tensor/test_var.py
@@ -4,9 +4,11 @@ from numpy.testing import assert_equal, assert_string_equal
 
 import aesara
 import tests.unittest_tools as utt
+from aesara.graph.basic import equal_computations
 from aesara.tensor.elemwise import DimShuffle
+from aesara.tensor.math import dot
 from aesara.tensor.subtensor import AdvancedSubtensor, Subtensor
-from aesara.tensor.type import TensorType, dmatrix, iscalar, ivector, matrix
+from aesara.tensor.type import TensorType, dmatrix, dvector, iscalar, ivector, matrix
 from aesara.tensor.type_other import MakeSlice
 from aesara.tensor.var import TensorConstant
 
@@ -47,6 +49,20 @@ def test_numpy_method(fct):
     y = fct(x)
     f = aesara.function([x], y)
     utt.assert_allclose(np.nan_to_num(f(data)), np.nan_to_num(fct(data)))
+
+
+def test_infix_dot_method():
+    X = dmatrix("X")
+    y = dvector("y")
+
+    res = X @ y
+    exp_res = X.dot(y)
+    assert equal_computations([res], [exp_res])
+
+    X_val = np.arange(2 * 3).reshape((2, 3))
+    res = X_val @ y
+    exp_res = dot(X_val, y)
+    assert equal_computations([res], [exp_res])
 
 
 def test_empty_list_indexing():


### PR DESCRIPTION
This PR adds the infix dot product (e.g. `X @ y`) to the `TensorVariable` classes.