### PR TITLE
Make sure Numba's `reshape` gets C-ordered arrays

### DIFF
--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -1126,9 +1126,17 @@ def numba_funcify_Cast(op, node, **kwargs):
 def numba_funcify_Reshape(op, **kwargs):
     ndim = op.ndim
 
-    @numba.njit(inline="always")
-    def reshape(x, shape):
-        return np.reshape(x, to_fixed_tuple(shape, ndim))
+    if ndim == 0:
+
+        @numba.njit(inline="always")
+        def reshape(x, shape):
+            return x.item()
+
+    else:
+
+        @numba.njit(inline="always")
+        def reshape(x, shape):
+            return np.reshape(np.ascontiguousarray(x), to_fixed_tuple(shape, ndim))
 
     return reshape
 

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -783,6 +783,7 @@ def test_Cast(v, dtype):
 @pytest.mark.parametrize(
     "v, shape, ndim",
     [
+        (set_test_value(aet.vector(), np.array([4], dtype=config.floatX)), (), 0),
         (set_test_value(aet.vector(), np.arange(4, dtype=config.floatX)), (2, 2), 2),
         (
             set_test_value(aet.vector(), np.arange(4, dtype=config.floatX)),


### PR DESCRIPTION
This PR prevents issues involving non-C-ordered arrays and Numba's `reshape`.  An extra case for zero-dimensional reshapes was added as well.