### PR TITLE
Fix in-place updates performed on scalars in Numba

### DIFF
--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -448,7 +448,7 @@ def numba_funcify_Mul(op, node, **kwargs):
 
 
 def create_vectorize_func(op, node, use_signature=False, identity=None, **kwargs):
-    scalar_op_fn = numba_funcify(op.scalar_op, node, inline="always", **kwargs)
+    scalar_op_fn = numba_funcify(op.scalar_op, node=node, inline="always", **kwargs)
 
     if len(node.outputs) > 1:
         raise NotImplementedError(

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -1183,9 +1183,15 @@ def numba_funcify_Clip(op, **kwargs):
     @numba.njit
     def clip(_x, _min, _max):
         x = to_scalar(_x)
-        min = to_scalar(_min)
-        max = to_scalar(_max)
-        return np.where(x < min, min, to_scalar(np.where(x > max, max, x)))
+        _min_scalar = to_scalar(_min)
+        _max_scalar = to_scalar(_max)
+
+        if x < _min_scalar:
+            return _min_scalar
+        elif x > _max_scalar:
+            return _max_scalar
+        else:
+            return x
 
     return clip
 

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -1154,7 +1154,10 @@ def numba_funcify_Reshape(op, **kwargs):
 
         @numba.njit(inline="always")
         def reshape(x, shape):
-            return np.reshape(np.ascontiguousarray(x), to_fixed_tuple(shape, ndim))
+            # TODO: Use this until https://github.com/numba/numba/issues/7353 is closed.
+            return np.reshape(
+                np.ascontiguousarray(np.asarray(x)), to_fixed_tuple(shape, ndim)
+            )
 
     return reshape
 

--- a/aesara/link/numba/dispatch.py
+++ b/aesara/link/numba/dispatch.py
@@ -2087,8 +2087,10 @@ def {bcast_fn_name}({bcast_fn_input_names}):
     )
 
     # Now, create a Numba JITable function that implements the `size` parameter
+    out_dtype = node.outputs[1].type.numpy_dtype
     random_fn_global_env = {
         bcast_fn_name: bcast_fn,
+        "out_dtype": out_dtype,
     }
 
     if tuple_size > 0:
@@ -2096,7 +2098,7 @@ def {bcast_fn_name}({bcast_fn_input_names}):
             f"""
         size = to_fixed_tuple(size, tuple_size)
 
-        data = np.empty(size)
+        data = np.empty(size, dtype=out_dtype)
         for i in np.ndindex(size[:size_dims]):
             data[i] = {bcast_fn_name}({bcast_fn_input_names})
 

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -817,6 +817,21 @@ def test_Reshape(v, shape, ndim):
     )
 
 
+def test_Reshape_scalar():
+    v = aet.vector()
+    v.tag.test_value = np.array([1.0], dtype=config.floatX)
+    g = Reshape(1)(v[0], (1,))
+    g_fg = FunctionGraph(outputs=[g])
+    compare_numba_and_py(
+        g_fg,
+        [
+            i.tag.test_value
+            for i in g_fg.inputs
+            if not isinstance(i, (SharedVariable, Constant))
+        ],
+    )
+
+
 @pytest.mark.parametrize(
     "v, shape, fails",
     [

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -2807,6 +2807,16 @@ def test_shared():
             None,
         ),
         (
+            aer.bernoulli,
+            [
+                set_test_value(
+                    aet.dvector(),
+                    np.array([0.1, 0.9], dtype=np.float64),
+                ),
+            ],
+            None,
+        ),
+        (
             aer.randint,
             [
                 set_test_value(

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -917,6 +917,17 @@ def test_Clip(v, min, max):
     )
 
 
+def test_scalar_Elemwise_Clip():
+    a = aet.scalar("a")
+    b = aet.scalar("b")
+
+    z = aet.switch(1, a, b)
+    c = aet.clip(z, 1, 3)
+    c_fg = FunctionGraph(outputs=[c])
+
+    compare_numba_and_py(c_fg, [1, 1])
+
+
 @pytest.mark.parametrize(
     "vals, dtype",
     [


### PR DESCRIPTION
This PR fixes the use of `vectorize` when in-place updates are requested on scalar parameters.

Since Numba doesn't output NumPy `ndarray`s with zero dimensions in most cases, requesting in-place updates with the `out` parameter for a `vectorize`d Numba function will fail.  This update converts the Numba scalar term into an `ndarray` and then performs the in-place operation.