### PR TITLE
Remove MKL warning.

### DIFF
--- a/aesara/link/c/cmodule.py
+++ b/aesara/link/c/cmodule.py
@@ -2738,9 +2738,8 @@ def default_blas_ldflags():
         # numpy and scipy.
         try:
             import mkl  # noqa
-        except ImportError as e:
-            if any([m for m in ("conda", "Continuum") if m in sys.version]):
-                warn_record.append(f"install mkl with `conda install mkl-service`: {e}")
+        except ImportError:
+            pass
         else:
             # This branch is executed if no exception was raised
             if sys.platform == "win32":

--- a/tests/link/c/test_cmodule.py
+++ b/tests/link/c/test_cmodule.py
@@ -90,4 +90,4 @@ def test_default_blas_ldflags(sys_mock, try_blas_flag_mock, caplog):
         with caplog.at_level(logging.WARNING):
             default_blas_ldflags()
 
-    assert "install mkl with" in caplog.text
+    assert caplog.text == ""


### PR DESCRIPTION
I think this warning is a bit too strong, there might be good reasons for not having mkl installed, like running an AMD or M1 processor, in which case this warning is annoying and confusing.