### PR TITLE
Generalize `aesara.printing.debugprint` and create `Variable` getter functions

### DIFF
--- a/aesara/graph/basic.py
+++ b/aesara/graph/basic.py
@@ -1648,3 +1648,40 @@ def equal_computations(xs, ys, in_xs=None, in_ys=None):
                 return False
 
     return True
+
+
+def get_var_by_name(
+    graphs: Iterable[Variable], target_var_id: str, ids: str = "CHAR"
+) -> Tuple[Variable]:
+    r"""Get variables in a graph using their names.
+
+    Parameters
+    ----------
+    graphs:
+        The graph, or graphs, to search.
+    target_var_id:
+        The name to match against either ``Variable.name`` or
+        ``Variable.auto_name``.
+
+    Returns
+    -------
+    A ``tuple`` containing all the `Variable`\s that match `target_var_id`.
+
+    """
+    from aesara.graph.op import HasInnerGraph
+
+    def expand(r):
+        if r.owner:
+            res = r.owner.inputs
+
+            if isinstance(r.owner.op, HasInnerGraph):
+                res.extend(r.owner.op.inner_outputs)
+
+            return res
+
+    results = ()
+    for var in walk(graphs, expand, False):
+        if target_var_id == var.name or target_var_id == var.auto_name:
+            results += (var,)
+
+    return results

--- a/aesara/scan/op.py
+++ b/aesara/scan/op.py
@@ -1299,6 +1299,14 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
 
         return self._fn
 
+    @property
+    def inner_inputs(self):
+        return self.inputs
+
+    @property
+    def inner_outputs(self):
+        return self.outputs
+
     def make_thunk(self, node, storage_map, compute_map, no_recycling, impl=None):
         """
 

--- a/tests/graph/utils.py
+++ b/tests/graph/utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from aesara.graph.basic import Apply, Constant, Variable
-from aesara.graph.op import Op
+from aesara.graph.op import HasInnerGraph, Op
 from aesara.graph.type import Type
 
 
@@ -108,3 +108,33 @@ op_y = MyOp("OpY", x=1)
 op_z = MyOp("OpZ", x=1)
 
 op_cast_type2 = MyOpCastType2("OpCastType2")
+
+
+class MyInnerGraphOp(Op, HasInnerGraph):
+    __props__ = ()
+
+    def __init__(self, inner_inputs, inner_outputs):
+        self._inner_inputs = inner_inputs
+        self._inner_outputs = inner_outputs
+
+    def make_node(self, *inputs):
+        for input in inputs:
+            assert isinstance(input, Variable)
+            assert isinstance(input.type, MyType)
+        outputs = [inputs[0].type()]
+        return Apply(self, list(inputs), outputs)
+
+    def perform(self, *args, **kwargs):
+        raise NotImplementedError("No Python implementation available.")
+
+    @property
+    def fn(self):
+        raise NotImplementedError("No Python implementation available.")
+
+    @property
+    def inner_inputs(self):
+        return self._inner_inputs
+
+    @property
+    def inner_outputs(self):
+        return self._inner_outputs

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -51,7 +51,7 @@ def test_scan_debugprint1():
      | |ScalarConstant{1} [id U]
      |ScalarConstant{-1} [id V]
 
-    Inner graphs of the scan ops:
+    Inner graphs:
 
     for{cpu,scan_fn} [id C] ''
      >Elemwise{mul,no_inplace} [id W] ''
@@ -111,7 +111,7 @@ def test_scan_debugprint2():
        |Elemwise{scalar_minimum,no_inplace} [id C] ''
        |x [id W]
 
-    Inner graphs of the scan ops:
+    Inner graphs:
 
     for{cpu,scan_fn} [id B] ''
      >Elemwise{mul,no_inplace} [id X] ''
@@ -124,7 +124,6 @@ def test_scan_debugprint2():
         assert truth.strip() == out.strip()
 
 
-@aesara.config.change_flags(optimizer_verbose=True)
 def test_scan_debugprint3():
     coefficients = dvector("coefficients")
     max_coefficients_supported = 10
@@ -192,7 +191,7 @@ def test_scan_debugprint3():
        |A [id W]
        |k [id X]
 
-    Inner graphs of the scan ops:
+    Inner graphs:
 
     for{cpu,scan_fn} [id B] ''
      >Elemwise{mul,no_inplace} [id Y] ''
@@ -293,7 +292,7 @@ def test_scan_debugprint4():
        |for{cpu,scan_fn}.1 [id C] ''
        |ScalarConstant{2} [id BA]
 
-    Inner graphs of the scan ops:
+    Inner graphs:
 
     for{cpu,scan_fn}.0 [id C] ''
      >Elemwise{add,no_inplace} [id BB] ''
@@ -412,7 +411,7 @@ def test_scan_debugprint5():
     | |A [id P]
     |ScalarConstant{-1} [id CL]
 
-    Inner graphs of the scan ops:
+    Inner graphs:
 
     for{cpu,grad_of_scan_fn}.1 [id B] ''
     >Elemwise{add,no_inplace} [id CM] ''

--- a/tests/tensor/test_math_opt.py
+++ b/tests/tensor/test_math_opt.py
@@ -2015,7 +2015,7 @@ class TestLocalUselessElemwiseComparison:
          | |Subtensor{int64} [id C] ''
          |Y [id K]
 
-        Inner graphs of the scan ops:
+        Inner graphs:
 
         for{cpu,scan_fn} [id B] ''
          >Sum{acc_dtype=float64} [id L] ''
@@ -2050,7 +2050,7 @@ class TestLocalUselessElemwiseComparison:
          | |Shape_i{0} [id C] <TensorType(int64, scalar)> ''   0
          |Y [id M] <TensorType(float64, vector)>
 
-        Inner graphs of the scan ops:
+        Inner graphs:
 
         for{cpu,scan_fn} [id B] <TensorType(float64, vector)> ''
          >Sum{acc_dtype=float64} [id N] <TensorType(float64, scalar)> ''


### PR DESCRIPTION
This PR generalizes `aesara.printing.debugprint` so that it can handle arbitrary `HasInnerGraph` `Op`s.  Also, it introduces two new functions: `aesara.graph.basic.get_var_by_name` and `aesara.printing.get_var_by_id`.  The former will return all the `Variable`s in a graph with a given name (or `Variable.auto_name`), and the latter will do the same thing using the IDs produced by `aesara.printing.debugprint`.

Here's an example:
```python
import aesara
import aesara.tensor as at

from aesara.printing import get_node_by_id
from aesara.graph.basic import get_var_by_name


a = at.vector()
B = at.matrix("B")
x0 = at.scalar()

srng = at.random.RandomStream()


scan_out, _ = aesara.scan(lambda x_tm1: x_tm1 + srng.normal(name="epsilon"),
                          outputs_info=[{"initial": x0}],
                          n_steps=10)

aesara.dprint(scan_out)
# Subtensor{int64::} [id A] ''
#  |for{cpu,scan_fn}.0 [id B] ''
#  | |TensorConstant{10} [id C]
#  | |IncSubtensor{Set;:int64:} [id D] ''
#  | | |AllocEmpty{dtype='float64'} [id E] ''
#  | | | |Elemwise{add,no_inplace} [id F] ''
#  | | |   |TensorConstant{10} [id C]
#  | | |   |Subtensor{int64} [id G] ''
#  | | |     |Shape [id H] ''
#  | | |     | |Rebroadcast{0} [id I] ''
#  | | |     |   |InplaceDimShuffle{x} [id J] ''
#  | | |     |     |<TensorType(float64, scalar)> [id K]
#  | | |     |ScalarConstant{0} [id L]
#  | | |Rebroadcast{0} [id I] ''
#  | | |ScalarFromTensor [id M] ''
#  | |   |Subtensor{int64} [id G] ''
#  | |RandomGeneratorSharedVariable(<Generator(PCG64) at 0x7FF0853859B0>) [id N]
#  |ScalarConstant{1} [id O]
#
# Inner graphs:
#
# for{cpu,scan_fn}.0 [id B] ''
#  >Elemwise{add,no_inplace} [id P] ''
#  > |<TensorType(float64, scalar)> [id Q] -> [id D]
#  > |normal_rv{0, (0, 0), floatX, False}.1 [id R] 'epsilon'
#  >   |<RandomGeneratorType> [id S] -> [id N]
#  >   |TensorConstant{[]} [id T]
#  >   |TensorConstant{11} [id U]
#  >   |TensorConstant{0.0} [id V]
#  >   |TensorConstant{1.0} [id W]
#  >normal_rv{0, (0, 0), floatX, False}.0 [id X] ''
#  > |<RandomGeneratorType> [id S] -> [id N]
#  > |TensorConstant{[]} [id T]
#  > |TensorConstant{11} [id U]
#  > |TensorConstant{0.0} [id V]
#  > |TensorConstant{1.0} [id W]

get_node_by_id(scan_out, "R")
# normal_rv{0, (0, 0), floatX, False}(<RandomGeneratorType>, TensorConstant{[]}, TensorConstant{11}, TensorConstant{0.0}, TensorConstant{1.0})

get_var_by_name([scan_out], "epsilon")
# (epsilon,)

```