### PR TITLE
Use alt_prefix field in `ScanArgs.get_alt_field`

### DIFF
--- a/aesara/scan/utils.py
+++ b/aesara/scan/utils.py
@@ -1163,7 +1163,7 @@ class ScanArgs:
             var_info = self.find_among_fields(var_info)
 
         alt_type = var_info.name[(var_info.name.index("_", 6) + 1) :]
-        alt_var = getattr(self, "inner_out_{}".format(alt_type))[var_info.index]
+        alt_var = getattr(self, f"{alt_prefix}_{alt_type}")[var_info.index]
         return alt_var
 
     def find_among_fields(

--- a/tests/scan/test_utils.py
+++ b/tests/scan/test_utils.py
@@ -239,6 +239,9 @@ def test_ScanArgs():
     alt_test_v = scan_args.get_alt_field(test_v, "inner_out")
     assert alt_test_v == scan_args.inner_out_sit_sot[0]
 
+    alt_test_v = scan_args.get_alt_field(test_v, "outer_in")
+    assert alt_test_v == scan_args.outer_in_sit_sot[0]
+
     # Check the `__repr__` and `__str__`
     scan_args_repr = repr(scan_args)
     # Just make sure it doesn't err-out


### PR DESCRIPTION
This PR fixes a bug in `ScanArgs.get_alt_field` that causes the `alt_prefix` argument to be ignored.