### PR TITLE
avoid appending -m64 to CXXFLAGS for riscv

### DIFF
--- a/aesara/link/c/cmodule.py
+++ b/aesara/link/c/cmodule.py
@@ -2304,11 +2304,11 @@ class GCC_compiler(Compiler):
 
         # Figure out whether the current Python executable is 32
         # or 64 bit and compile accordingly. This step is ignored for
-        # ARM (32-bit and 64-bit) architectures in order to make
+        # ARM (32-bit and 64-bit) and RISC-V architectures in order to make
         # Aesara compatible with the Raspberry Pi, Raspberry Pi 2, or
-        # other systems with ARM processors.
-        if not any(["arm" in flag for flag in cxxflags]) and not any(
-            arch in platform.machine() for arch in ["arm", "aarch"]
+        # other systems with ARM or RISC-V processors.
+        if (not any("arm" in flag or "riscv" in flag for flag in cxxflags)) and (
+            not any(arch in platform.machine() for arch in ("arm", "aarch", "riscv"))
         ):
             n_bits = LOCAL_BITWIDTH
             cxxflags.append(f"-m{int(n_bits)}")


### PR DESCRIPTION
Hi,

I am testing aesara on riscv and find lots of test failures are due to invalid -m64 flags. Like arm, gcc for riscv does not have the -m64 flag. This pr makes those tests pass successfully.
