### PR TITLE
[Do Not Merge] Replaced CLinker to NumbaLinker from mode and tests

### DIFF
--- a/aesara/compile/mode.py
+++ b/aesara/compile/mode.py
@@ -26,10 +26,8 @@ from aesara.graph.optdb import (
     TopoDB,
 )
 from aesara.link.basic import Linker, PerformLinker
-from aesara.link.c.basic import CLinker, OpWiseCLinker
 from aesara.link.jax.linker import JAXLinker
 from aesara.link.numba.linker import NumbaLinker
-from aesara.link.vm import VMLinker
 
 
 _logger = logging.getLogger("aesara.compile.mode")
@@ -40,13 +38,13 @@ _logger = logging.getLogger("aesara.compile.mode")
 # dictionary
 predefined_linkers = {
     "py": PerformLinker(),  # Use allow_gc Aesara flag
-    "c": CLinker(),  # Don't support gc. so don't check allow_gc
-    "c|py": OpWiseCLinker(),  # Use allow_gc Aesara flag
-    "c|py_nogc": OpWiseCLinker(allow_gc=False),
-    "vm": VMLinker(use_cloop=False),  # Use allow_gc Aesara flag
-    "cvm": VMLinker(use_cloop=True),  # Use allow_gc Aesara flag
-    "vm_nogc": VMLinker(allow_gc=False, use_cloop=False),
-    "cvm_nogc": VMLinker(allow_gc=False, use_cloop=True),
+    "c": NumbaLinker(),  # Don't support gc. so don't check allow_gc
+    "c|py": NumbaLinker(),  # Use allow_gc Aesara flag
+    "c|py_nogc": NumbaLinker(),
+    "vm": NumbaLinker(),  # Use allow_gc Aesara flag
+    "cvm": NumbaLinker(),  # Use allow_gc Aesara flag
+    "vm_nogc": NumbaLinker(),
+    "cvm_nogc": NumbaLinker(),
     "jax": JAXLinker(),
     "numba": NumbaLinker(),
 }

--- a/aesara/compile/mode.py
+++ b/aesara/compile/mode.py
@@ -26,8 +26,10 @@ from aesara.graph.optdb import (
     TopoDB,
 )
 from aesara.link.basic import Linker, PerformLinker
+from aesara.link.c.basic import CLinker, OpWiseCLinker
 from aesara.link.jax.linker import JAXLinker
 from aesara.link.numba.linker import NumbaLinker
+from aesara.link.vm import VMLinker
 
 
 _logger = logging.getLogger("aesara.compile.mode")
@@ -47,6 +49,12 @@ predefined_linkers = {
     "cvm_nogc": NumbaLinker(),
     "jax": JAXLinker(),
     "numba": NumbaLinker(),
+}
+
+temporary_linkers = {
+    "c": CLinker(),
+    "c|py": OpWiseCLinker(),
+    "vm": VMLinker(use_cloop=False),
 }
 
 

--- a/tests/scalar/test_basic_sympy.py
+++ b/tests/scalar/test_basic_sympy.py
@@ -14,12 +14,11 @@ ys = sympy.Symbol("y")
 xt, yt = floats("xy")
 
 
-@pytest.mark.skipif(not aesara.config.cxx, reason="Need cxx for this test")
 def test_SymPyCCode():
     op = SymPyCCode([xs, ys], xs + ys)
     e = op(xt, yt)
     g = aesara.graph.fg.FunctionGraph([xt, yt], [e])
-    fn = aesara.link.c.basic.CLinker().accept(g).make_function()
+    fn = aesara.link.numba.NumbaLinker().accept(g).make_function()
     assert fn(1.0, 2.0) == 3.0
 
 

--- a/tests/scalar/test_math.py
+++ b/tests/scalar/test_math.py
@@ -5,7 +5,7 @@ import aesara.tensor as aet
 from aesara import function
 from aesara.compile.mode import Mode
 from aesara.graph.fg import FunctionGraph
-from aesara.link.c.basic import CLinker
+from aesara.link.numba import NumbaLinker
 from aesara.scalar.math import betainc, betainc_der, gammainc, gammaincc, gammal, gammau
 
 
@@ -21,7 +21,7 @@ def test_gammainc_nan_c():
     x1 = aet.dscalar()
     x2 = aet.dscalar()
     y = gammainc(x1, x2)
-    test_func = CLinker().accept(FunctionGraph([x1, x2], [y])).make_function()
+    test_func = NumbaLinker().accept(FunctionGraph([x1, x2], [y])).make_function()
     assert np.isnan(test_func(-1, 1))
     assert np.isnan(test_func(1, -1))
     assert np.isnan(test_func(-1, -1))
@@ -39,7 +39,7 @@ def test_gammaincc_nan_c():
     x1 = aet.dscalar()
     x2 = aet.dscalar()
     y = gammaincc(x1, x2)
-    test_func = CLinker().accept(FunctionGraph([x1, x2], [y])).make_function()
+    test_func = NumbaLinker().accept(FunctionGraph([x1, x2], [y])).make_function()
     assert np.isnan(test_func(-1, 1))
     assert np.isnan(test_func(1, -1))
     assert np.isnan(test_func(-1, -1))
@@ -49,7 +49,7 @@ def test_gammal_nan_c():
     x1 = aet.dscalar()
     x2 = aet.dscalar()
     y = gammal(x1, x2)
-    test_func = CLinker().accept(FunctionGraph([x1, x2], [y])).make_function()
+    test_func = NumbaLinker().accept(FunctionGraph([x1, x2], [y])).make_function()
     assert np.isnan(test_func(-1, 1))
     assert np.isnan(test_func(1, -1))
     assert np.isnan(test_func(-1, -1))
@@ -59,7 +59,7 @@ def test_gammau_nan_c():
     x1 = aet.dscalar()
     x2 = aet.dscalar()
     y = gammau(x1, x2)
-    test_func = CLinker().accept(FunctionGraph([x1, x2], [y])).make_function()
+    test_func = NumbaLinker().accept(FunctionGraph([x1, x2], [y])).make_function()
     assert np.isnan(test_func(-1, 1))
     assert np.isnan(test_func(1, -1))
     assert np.isnan(test_func(-1, -1))
@@ -81,3 +81,6 @@ def test_betainc_derivative_nan():
     assert np.isnan(test_func(1, 1, 2))
     assert np.isnan(test_func(1, -1, 1))
     assert np.isnan(test_func(1, 1, -1))
+
+
+test_gammaincc_nan_c()

--- a/tests/tensor/random/test_type.py
+++ b/tests/tensor/random/test_type.py
@@ -13,21 +13,7 @@ from aesara.tensor.random.type import (
 )
 
 
-# @pytest.mark.skipif(
-#     not config.cxx, reason="G++ not available, so we need to skip this test."
-# )
 def test_view_op_c_code():
-    # TODO: It might be good to make sure that the registered C code works
-    # (even though it's basically copy-paste from other registered `Op`s).
-    # from aesara.compile.ops import view_op
-    # from aesara.link.c.basic import CLinker
-    # rng_var = random_state_type()
-    # rng_view = view_op(rng_var)
-    # function(
-    #     [rng_var],
-    #     rng_view,
-    #     mode=Mode(optimizer=None, linker=CLinker()),
-    # )
     assert ViewOp.c_code_and_version[RandomStateType]
     assert ViewOp.c_code_and_version[RandomGeneratorType]
 

--- a/tests/tensor/test_basic_opt.py
+++ b/tests/tensor/test_basic_opt.py
@@ -1151,8 +1151,6 @@ class TestFusion:
         shp = (3000, 3000)
         shp = (1000, 1000)
         nb_repeat = 50
-        # linker=CLinker
-        # linker=OpWiseCLinker
 
         mode1 = copy.copy(self.mode)
         mode1._optimizer = mode1._optimizer.including("local_elemwise_fusion")

--- a/tests/tensor/test_gc.py
+++ b/tests/tensor/test_gc.py
@@ -6,7 +6,7 @@ import numpy as np
 import aesara
 from aesara.compile.mode import Mode
 from aesara.link.basic import PerformLinker
-from aesara.link.c.basic import OpWiseCLinker
+from aesara.link.numba import NumbaLinker
 from aesara.tensor.type import dvector, lvector
 
 
@@ -37,7 +37,7 @@ def test_gc_never_pickles_temporaries():
 
     for f_linker, g_linker in [
         (PerformLinker(allow_gc=True), PerformLinker(allow_gc=False)),
-        (OpWiseCLinker(allow_gc=True), OpWiseCLinker(allow_gc=False)),
+        (NumbaLinker(allow_gc=True), NumbaLinker(allow_gc=False)),
     ]:
         # f_linker has garbage collection
 


### PR DESCRIPTION
resolves #432 

A simple replacement of all `CLinker` instances with `NumbaLinker` from active tests to check what fails. 

Some test I've ignored `Clinker`s in are those from `test/gpuarray` and `tests/link` and also a `test/tensor/test_mpi.py`