### PR TITLE
Fixed float typecasting for Dot implementation in Numba module

### DIFF
--- a/aesara/link/numba/dispatch/basic.py
+++ b/aesara/link/numba/dispatch/basic.py
@@ -539,10 +539,12 @@ def int_to_float_fn(inputs, out_dtype):
             return x.astype(args_dtype)
 
     else:
+        args_dtype_sz = max([_arg.type.numpy_dtype.itemsize for _arg in inputs])
+        args_dtype = np.dtype(f"f{args_dtype_sz}")
 
         @numba.njit(inline="always")
         def inputs_cast(x):
-            return x
+            return x.astype(args_dtype)
 
     return inputs_cast
 

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -176,11 +176,7 @@ def eval_python_only(fn_inputs, fgraph, inputs):
         _ = aesara_numba_fn(*inputs)
 
 
-def compare_numba_and_py(
-    fgraph,
-    inputs,
-    assert_fn=None,
-):
+def compare_numba_and_py(fgraph, inputs, assert_fn=None):
     """Function to compare python graph output and Numba compiled output for testing equality
 
     In the tests below computational graphs are defined in Aesara. These graphs are then passed to
@@ -1829,6 +1825,15 @@ def test_BroadcastTo(x, shape, exc):
         (
             set_test_value(aet.matrix(), rng.random(size=(3, 2)).astype(config.floatX)),
             set_test_value(aet.vector(), rng.random(size=(2,)).astype(config.floatX)),
+            None,
+        ),
+        (
+            set_test_value(
+                aet.matrix(dtype="float64"), rng.random(size=(3, 2)).astype("float64")
+            ),
+            set_test_value(
+                aet.vector(dtype="float32"), rng.random(size=(2,)).astype("float32")
+            ),
             None,
         ),
         (


### PR DESCRIPTION
Fixes #620 

A simple fix that typecasts the inputs to `Dot` (and other few implementation of Numba Ops) to the maximum sized input float so that every input is of same `dtype` (as expected by Numba)