### PR TITLE
Fixed: Inv Numba implementation now correctly returns non-integral in…

### DIFF
--- a/aesara/link/numba/dispatch/scalar.py
+++ b/aesara/link/numba/dispatch/scalar.py
@@ -21,6 +21,7 @@ from aesara.scalar.basic import (
     Clip,
     Composite,
     Identity,
+    Inv,
     Mul,
     ScalarOp,
     Second,
@@ -170,3 +171,12 @@ def numba_funcify_Second(op, node, **kwargs):
         return y
 
     return second
+
+
+@numba_funcify.register(Inv)
+def numba_funcify_Inv(op, node, **kwargs):
+    @numba.njit(inline="always")
+    def inv(x):
+        return 1 / x
+
+    return inv

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -797,6 +797,25 @@ def test_Cast(v, dtype):
 
 
 @pytest.mark.parametrize(
+    "v, dtype",
+    [
+        (set_test_value(aet.iscalar(), np.array(10, dtype="int32")), aesb.float64),
+    ],
+)
+def test_Inv(v, dtype):
+    g = aesb.inv(v)
+    g_fg = FunctionGraph(outputs=[g])
+    compare_numba_and_py(
+        g_fg,
+        [
+            i.tag.test_value
+            for i in g_fg.inputs
+            if not isinstance(i, (SharedVariable, Constant))
+        ],
+    )
+
+
+@pytest.mark.parametrize(
     "v, shape, ndim",
     [
         (set_test_value(aet.vector(), np.array([4], dtype=config.floatX)), (), 0),


### PR DESCRIPTION
A simple fix which replaces Numpy's reciprocal function for Numba implementation of `Inv` Ops with a direct inverse signature. 

Fixes #624 