### PR TITLE
Convert `get_vector_length` to a dispatch function

### DIFF
--- a/aesara/tensor/__init__.py
+++ b/aesara/tensor/__init__.py
@@ -1,8 +1,10 @@
 """Symbolic tensor types and constructor functions."""
 
-import warnings
 from functools import singledispatch
-from typing import Any, Callable, NoReturn, Optional
+from typing import Any, Callable, NoReturn, Optional, Union
+
+from aesara.graph.basic import Constant, Variable
+from aesara.graph.op import Op
 
 
 def as_tensor_variable(
@@ -45,10 +47,53 @@ def _as_tensor_variable(
     raise NotImplementedError(f"Cannot convert {x} to a tensor variable.")
 
 
-import aesara.tensor.exceptions
-from aesara.gradient import consider_constant, grad, hessian, jacobian
-from aesara.tensor import sharedvar  # adds shared-variable constructors
-from aesara.tensor import (
+def get_vector_length(v: Any):
+    """Return the run-time length of a symbolic vector, when possible.
+
+    Parameters
+    ----------
+    v
+        A rank-1 `TensorType` variable.
+
+    Raises
+    ------
+    TypeError
+        `v` hasn't the proper type.
+    ValueError
+        No special case applies, the length is not known.
+        In general this is not possible, but for a number of special cases
+        the length can be determined at compile / graph-construction time.
+        This function implements these special cases.
+
+    """
+    v = as_tensor_variable(v)
+
+    if v.type.ndim != 1:
+        raise TypeError(f"Argument must be a vector; got {v.type}")
+
+    if v.type.broadcastable[0]:
+        return 1
+
+    return _get_vector_length(getattr(v.owner, "op", v), v)
+
+
+@singledispatch
+def _get_vector_length(op: Union[Op, Variable], var: Variable) -> NoReturn:
+    """`Op`-based dispatch for `get_vector_length`."""
+    raise ValueError(f"Length of {var} cannot be determined")
+
+
+@_get_vector_length.register(Constant)
+def _get_vector_length_Constant(var_inst, var):
+    return len(var.data)
+
+
+import aesara.tensor.exceptions  # noqa
+from aesara.gradient import consider_constant, grad, hessian, jacobian  # noqa
+
+# adds shared-variable constructors
+from aesara.tensor import sharedvar  # noqa
+from aesara.tensor import (  # noqa
     basic_opt,
     blas,
     blas_c,
@@ -61,14 +106,16 @@ from aesara.tensor import (
 
 
 # isort: off
-from aesara.tensor import linalg
-from aesara.tensor import nlinalg  # For backward compatibility
-from aesara.tensor import slinalg  # For backward compatibility
+from aesara.tensor import linalg  # noqa
+
+# For backward compatibility
+from aesara.tensor import nlinalg  # noqa
+from aesara.tensor import slinalg  # noqa
 
 # isort: on
-from aesara.tensor.basic import *
-from aesara.tensor.blas import batched_dot, batched_tensordot
-from aesara.tensor.extra_ops import (
+from aesara.tensor.basic import *  # noqa
+from aesara.tensor.blas import batched_dot, batched_tensordot  # noqa
+from aesara.tensor.extra_ops import (  # noqa
     bartlett,
     bincount,
     broadcast_arrays,
@@ -86,9 +133,7 @@ from aesara.tensor.extra_ops import (
     unique,
     unravel_index,
 )
-from aesara.tensor.io import *
-from aesara.tensor.math import *
-from aesara.tensor.shape import (
+from aesara.tensor.shape import (  # noqa
     reshape,
     shape,
     shape_padaxis,
@@ -97,13 +142,17 @@ from aesara.tensor.shape import (
     specify_shape,
 )
 
+
+from aesara.tensor.io import *  # noqa
+from aesara.tensor.math import *  # noqa
+
 # We import as `_shared` instead of `shared` to avoid confusion between
 # `aesara.shared` and `tensor._shared`.
-from aesara.tensor.sort import argsort, argtopk, sort, topk, topk_and_argtopk
-from aesara.tensor.subtensor import *
-from aesara.tensor.type import *
-from aesara.tensor.type_other import *
-from aesara.tensor.var import TensorConstant, TensorVariable
+from aesara.tensor.sort import argsort, argtopk, sort, topk, topk_and_argtopk  # noqa
+from aesara.tensor.subtensor import *  # noqa
+from aesara.tensor.type import *  # noqa
+from aesara.tensor.type_other import *  # noqa
+from aesara.tensor.var import TensorConstant, TensorVariable  # noqa
 
 
 __all__ = ["random"]  # noqa: F405

--- a/aesara/tensor/elemwise.py
+++ b/aesara/tensor/elemwise.py
@@ -20,7 +20,9 @@ from aesara.scalar.basic import Scalar
 from aesara.scalar.basic import bool as scalar_bool
 from aesara.scalar.basic import identity as scalar_identity
 from aesara.scalar.basic import transfer_type, upcast
+from aesara.tensor import _get_vector_length
 from aesara.tensor import elemwise_cgen as cgen
+from aesara.tensor import get_vector_length
 from aesara.tensor.type import (
     TensorType,
     continuous_dtypes,
@@ -1842,3 +1844,11 @@ def scalar_elemwise(*symbol, nfunc=None, nin=None, nout=None, symbolname=None):
         return construct(symbol[0])
     else:
         return construct
+
+
+@_get_vector_length.register(Elemwise)
+def _get_vector_length_Elemwise(op, var):
+    if len(var.owner.inputs) == 1 and len(var.owner.outputs) == 1:
+        return get_vector_length(var.owner.inputs[0])
+
+    raise ValueError(f"Length of {var} cannot be determined")

--- a/aesara/tensor/shape.py
+++ b/aesara/tensor/shape.py
@@ -10,6 +10,7 @@ from aesara.graph.op import COp
 from aesara.graph.params_type import ParamsType
 from aesara.misc.safe_asarray import _asarray
 from aesara.scalar import int32
+from aesara.tensor import _get_vector_length
 from aesara.tensor import basic as aet
 from aesara.tensor.exceptions import NotScalarConstantError
 from aesara.tensor.type import TensorType, int_dtypes, tensor
@@ -127,6 +128,11 @@ class Shape(COp):
 
 shape = Shape()
 _shape = shape  # was used in the past, now use shape directly.
+
+
+@_get_vector_length.register(Shape)
+def _get_vector_length_Shape(op, var):
+    return var.owner.inputs[0].type.ndim
 
 
 def shape_tuple(x):

--- a/aesara/tensor/sharedvar.py
+++ b/aesara/tensor/sharedvar.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from aesara.compile import SharedVariable, shared_constructor
 from aesara.misc.safe_asarray import _asarray
+from aesara.tensor import _get_vector_length
 from aesara.tensor.type import TensorType
 from aesara.tensor.var import _tensor_py_operators
 
@@ -21,6 +22,11 @@ def load_shared_variable(val):
 # _tensor_py_operators is first to have its version of __{gt,ge,lt,le}__
 class TensorSharedVariable(_tensor_py_operators, SharedVariable):
     pass
+
+
+@_get_vector_length.register(TensorSharedVariable)
+def _get_vector_length_TensorSharedVariable(var_inst, var):
+    return len(var.get_value(borrow=True))
 
 
 @shared_constructor


### PR DESCRIPTION
This PR changes `get_vector_length` into a `singledispatch` function.  Under these changes, `Op`-specific length-discerning logic can now be located in the module that the `Op` is defined, which reduces dependencies between sub-packages/modules and simplifies the process of making extensions to the logic itself.

These changes also help pave the way for a solution to #608.  (Such changes may also be included in this PR.)