### PR TITLE
Add Numba cache configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ __pycache__
 *.snm
 *.toc
 *.vrb
+*.nbc
+*.nbi
 .noseids
 *.DS_Store
 *.bak

--- a/aesara/configdefaults.py
+++ b/aesara/configdefaults.py
@@ -1452,6 +1452,27 @@ def add_scan_configvars():
     )
 
 
+def add_numba_configvars():
+    config.add(
+        "numba__vectorize_target",
+        ("Default target for numba.vectorize."),
+        EnumStr("cpu", ["parallel", "cuda"], mutable=True),
+        in_c_key=False,
+    )
+    config.add(
+        "numba__fastmath",
+        ("If True, use Numba's fastmath mode."),
+        BoolParam(True),
+        in_c_key=False,
+    )
+    config.add(
+        "numba__cache",
+        ("If True, use Numba's file based caching."),
+        BoolParam(True),
+        in_c_key=False,
+    )
+
+
 def _get_default_gpuarray__cache_path():
     return os.path.join(config.compiledir, "gpuarray_kernels")
 
@@ -1683,6 +1704,7 @@ add_optimizer_configvars()
 add_metaopt_configvars()
 add_vm_configvars()
 add_deprecated_configvars()
+add_numba_configvars()
 
 # TODO: `gcc_version_str` is used by other modules.. Should it become an immutable config var?
 try:

--- a/aesara/link/basic.py
+++ b/aesara/link/basic.py
@@ -676,6 +676,8 @@ class JITLinker(PerformLinker):
             A tuple containing the thunks.
         output_nodes: list and their
             A tuple containing the output nodes.
+        jit_fn: callable
+            The JITed function that performs the computations.
 
         """
         output_nodes = [o.owner for o in self.fgraph.outputs]
@@ -721,7 +723,7 @@ class JITLinker(PerformLinker):
         thunks.append(thunk)
 
         # This is a bit hackish, but we only return one of the output nodes
-        return thunks, output_nodes[:1]
+        return thunks, output_nodes[:1], fgraph_jit
 
     def make_all(self, input_storage=None, output_storage=None, storage_map=None):
         fgraph = self.fgraph
@@ -736,7 +738,7 @@ class JITLinker(PerformLinker):
         for k in storage_map:
             compute_map[k] = [k.owner is None]
 
-        thunks, nodes = self.create_jitable_thunk(
+        thunks, nodes, jit_fn = self.create_jitable_thunk(
             compute_map, nodes, input_storage, output_storage, storage_map
         )
 
@@ -770,6 +772,7 @@ class JITLinker(PerformLinker):
             fgraph, thunks, nodes, post_thunk_old_storage, no_recycling=no_recycling
         )
 
+        fn.jit_fn = jit_fn
         fn.allow_gc = self.allow_gc
         fn.storage_map = storage_map
 

--- a/aesara/link/numba/dispatch/nlinalg.py
+++ b/aesara/link/numba/dispatch/nlinalg.py
@@ -38,7 +38,7 @@ def numba_funcify_SVD(op, node, **kwargs):
 
         ret_sig = get_numba_type(node.outputs[0].type)
 
-        @numba.njit
+        @numba_basic.numba_njit
         def svd(x):
             with numba.objmode(ret=ret_sig):
                 ret = np.linalg.svd(x, full_matrices, compute_uv)
@@ -49,7 +49,7 @@ def numba_funcify_SVD(op, node, **kwargs):
         out_dtype = node.outputs[0].type.numpy_dtype
         inputs_cast = int_to_float_fn(node.inputs, out_dtype)
 
-        @numba.njit(inline="always")
+        @numba_basic.numba_njit(inline="always")
         def svd(x):
             return np.linalg.svd(inputs_cast(x), full_matrices)
 
@@ -62,7 +62,7 @@ def numba_funcify_Det(op, node, **kwargs):
     out_dtype = node.outputs[0].type.numpy_dtype
     inputs_cast = int_to_float_fn(node.inputs, out_dtype)
 
-    @numba.njit(inline="always")
+    @numba_basic.numba_njit(inline="always")
     def det(x):
         return numba_basic.direct_cast(np.linalg.det(inputs_cast(x)), out_dtype)
 
@@ -77,7 +77,7 @@ def numba_funcify_Eig(op, node, **kwargs):
 
     inputs_cast = int_to_float_fn(node.inputs, out_dtype_1)
 
-    @numba.njit
+    @numba_basic.numba_njit
     def eig(x):
         out = np.linalg.eig(inputs_cast(x))
         return (out[0].astype(out_dtype_1), out[1].astype(out_dtype_2))
@@ -104,7 +104,7 @@ def numba_funcify_Eigh(op, node, **kwargs):
             [get_numba_type(node.outputs[0].type), get_numba_type(node.outputs[1].type)]
         )
 
-        @numba.njit
+        @numba_basic.numba_njit
         def eigh(x):
             with numba.objmode(ret=ret_sig):
                 out = np.linalg.eigh(x, UPLO=uplo)
@@ -113,7 +113,7 @@ def numba_funcify_Eigh(op, node, **kwargs):
 
     else:
 
-        @numba.njit(inline="always")
+        @numba_basic.numba_njit(inline="always")
         def eigh(x):
             return np.linalg.eigh(x)
 
@@ -126,7 +126,7 @@ def numba_funcify_Inv(op, node, **kwargs):
     out_dtype = node.outputs[0].type.numpy_dtype
     inputs_cast = int_to_float_fn(node.inputs, out_dtype)
 
-    @numba.njit(inline="always")
+    @numba_basic.numba_njit(inline="always")
     def inv(x):
         return np.linalg.inv(inputs_cast(x)).astype(out_dtype)
 
@@ -139,7 +139,7 @@ def numba_funcify_MatrixInverse(op, node, **kwargs):
     out_dtype = node.outputs[0].type.numpy_dtype
     inputs_cast = int_to_float_fn(node.inputs, out_dtype)
 
-    @numba.njit(inline="always")
+    @numba_basic.numba_njit(inline="always")
     def matrix_inverse(x):
         return np.linalg.inv(inputs_cast(x)).astype(out_dtype)
 
@@ -152,7 +152,7 @@ def numba_funcify_MatrixPinv(op, node, **kwargs):
     out_dtype = node.outputs[0].type.numpy_dtype
     inputs_cast = int_to_float_fn(node.inputs, out_dtype)
 
-    @numba.njit(inline="always")
+    @numba_basic.numba_njit(inline="always")
     def matrixpinv(x):
         return np.linalg.pinv(inputs_cast(x)).astype(out_dtype)
 
@@ -177,7 +177,7 @@ def numba_funcify_QRFull(op, node, **kwargs):
         else:
             ret_sig = get_numba_type(node.outputs[0].type)
 
-        @numba.njit
+        @numba_basic.numba_njit
         def qr_full(x):
             with numba.objmode(ret=ret_sig):
                 ret = np.linalg.qr(x, mode=mode)
@@ -188,7 +188,7 @@ def numba_funcify_QRFull(op, node, **kwargs):
         out_dtype = node.outputs[0].type.numpy_dtype
         inputs_cast = int_to_float_fn(node.inputs, out_dtype)
 
-        @numba.njit(inline="always")
+        @numba_basic.numba_njit(inline="always")
         def qr_full(x):
             return np.linalg.qr(inputs_cast(x))
 

--- a/aesara/link/utils.py
+++ b/aesara/link/utils.py
@@ -14,8 +14,7 @@ from typing import Any, Callable, Dict, Iterable, List, NoReturn, Optional, Tupl
 
 import numpy as np
 
-from aesara import utils
-from aesara.configdefaults import config
+from aesara import config, utils
 from aesara.graph.basic import Apply, Constant, Variable
 from aesara.graph.fg import FunctionGraph
 
@@ -768,7 +767,7 @@ def {fgraph_name}({", ".join(fgraph_input_names)}):
         local_env = locals()
 
     fgraph_def = compile_function_src(
-        fgraph_def_src, fgraph_name, global_env, local_env
+        fgraph_def_src, fgraph_name, {**globals(), **global_env}, local_env
     )
 
     return fgraph_def


### PR DESCRIPTION
Built on top of rebased version of : https://github.com/aesara-devs/aesara/pull/475

Adds a `partial` function `numba_njit` as `numba.njit(cache=config.numba__cache)` and a `numba_vectorize` as `numba.vectorize(cache=config.numba__cache)`.

