### PR TITLE
Refactor `get_scalar_constant_value`

### DIFF
--- a/aesara/configdefaults.py
+++ b/aesara/configdefaults.py
@@ -1462,13 +1462,6 @@ def add_scan_configvars():
         in_c_key=False,
     )
 
-    config.add(
-        "scan__debug",
-        "If True, enable extra verbose output related to scan",
-        BoolParam(False),
-        in_c_key=False,
-    )
-
 
 def _get_default_gpuarray__cache_path():
     return os.path.join(config.compiledir, "gpuarray_kernels")

--- a/aesara/graph/features.py
+++ b/aesara/graph/features.py
@@ -596,7 +596,9 @@ class ReplaceValidate(History, Validator):
         except Exception as e:
             fgraph.revert(chk)
             if verbose:
-                print(f"validate failed on node {r}.\n Reason: {reason}, {e}")
+                print(
+                    f"optimizer: validate failed on node {r}.\n Reason: {reason}, {e}"
+                )
             raise
         if config.scan__debug:
             from aesara.scan.op import Scan
@@ -618,7 +620,7 @@ class ReplaceValidate(History, Validator):
                     "Scan removed", nb, nb2, getattr(reason, "name", reason), r, new_r
                 )
         if verbose:
-            print(reason, r, new_r)
+            print(f"optimizer: rewrite {reason} replaces {r} with {new_r}")
         # The return is needed by replace_all_validate_remove
         return chk
 

--- a/aesara/graph/features.py
+++ b/aesara/graph/features.py
@@ -553,12 +553,9 @@ class ReplaceValidate(History, Validator):
         self, fgraph, replacements, reason=None, verbose=None, **kwargs
     ):
         chk = fgraph.checkpoint()
+
         if verbose is None:
             verbose = config.optimizer_verbose
-        if config.scan__debug:
-            from aesara.scan.op import Scan
-
-            scans = [n for n in fgraph.apply_nodes if isinstance(n.op, Scan)]
 
         for r, new_r in replacements:
             try:
@@ -600,27 +597,10 @@ class ReplaceValidate(History, Validator):
                     f"optimizer: validate failed on node {r}.\n Reason: {reason}, {e}"
                 )
             raise
-        if config.scan__debug:
-            from aesara.scan.op import Scan
 
-            scans2 = [n for n in fgraph.apply_nodes if isinstance(n.op, Scan)]
-            nb = len(scans)
-            nb2 = len(scans2)
-            if nb2 > nb:
-                print(
-                    "Extra scan introduced",
-                    nb,
-                    nb2,
-                    getattr(reason, "name", reason),
-                    r,
-                    new_r,
-                )
-            elif nb2 < nb:
-                print(
-                    "Scan removed", nb, nb2, getattr(reason, "name", reason), r, new_r
-                )
         if verbose:
             print(f"optimizer: rewrite {reason} replaces {r} with {new_r}")
+
         # The return is needed by replace_all_validate_remove
         return chk
 

--- a/aesara/graph/fg.py
+++ b/aesara/graph/fg.py
@@ -510,7 +510,7 @@ class FunctionGraph(MetaObject):
         if verbose is None:
             verbose = config.optimizer_verbose
         if verbose:
-            print(reason, var, new_var)
+            print(f"optimizer: rewrite {reason} replaces {var} with {new_var}")
 
         new_var = var.type.filter_variable(new_var, allow_convert=True)
 

--- a/aesara/graph/opt.py
+++ b/aesara/graph/opt.py
@@ -1347,6 +1347,10 @@ class LocalOptGroup(LocalOptimizer):
                     new_vars = new_repl
                 else:  # It must be a dict
                     new_vars = list(new_repl.values())
+
+                if config.optimizer_verbose:
+                    print(f"optimizer: rewrite {opt} replaces {node} with {new_repl}")
+
                 if self.profile:
                     self.node_created[opt] += len(
                         list(applys_between(fgraph.variables, new_vars))

--- a/aesara/ifelse.py
+++ b/aesara/ifelse.py
@@ -634,7 +634,6 @@ class CondMerge(GlobalOptimizer):
                     gpu=False,
                     name=mn_name + "&" + pl_name,
                 )
-                print("here")
                 new_outs = new_ifelse(*new_ins, return_list=True)
                 new_outs = [clone_replace(x) for x in new_outs]
                 old_outs = []

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -579,11 +579,6 @@ def get_scalar_constant_value(
         raise NotScalarConstantError(v)
 
 
-#########################
-# Casting Operations
-#########################
-
-
 class TensorFromScalar(Op):
 
     __props__ = ()

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -26,7 +26,7 @@ from aesara.gradient import DisconnectedType, grad_not_implemented, grad_undefin
 from aesara.graph.basic import Apply, Constant, Variable
 from aesara.graph.op import COp, Op
 from aesara.graph.params_type import ParamsType
-from aesara.graph.type import CType
+from aesara.graph.type import Type
 from aesara.misc.safe_asarray import _asarray
 from aesara.printing import min_informative_str, pprint
 from aesara.scalar import int32
@@ -468,7 +468,7 @@ def get_scalar_constant_value(
                         var.ndim == 0 for var in v.owner.inputs[0].owner.inputs[1:]
                     ):
                         idx = v.owner.op.idx_list[0]
-                        if isinstance(idx, CType):
+                        if isinstance(idx, Type):
                             idx = get_scalar_constant_value(
                                 v.owner.inputs[1], max_recur=max_recur
                             )
@@ -482,7 +482,7 @@ def get_scalar_constant_value(
                         var.ndim == 1 for var in v.owner.inputs[0].owner.inputs[1:]
                     ):
                         idx = v.owner.op.idx_list[0]
-                        if isinstance(idx, CType):
+                        if isinstance(idx, Type):
                             idx = get_scalar_constant_value(
                                 v.owner.inputs[1], max_recur=max_recur
                             )
@@ -517,7 +517,7 @@ def get_scalar_constant_value(
                 ):
 
                     idx = v.owner.op.idx_list[0]
-                    if isinstance(idx, CType):
+                    if isinstance(idx, Type):
                         idx = get_scalar_constant_value(
                             v.owner.inputs[1], max_recur=max_recur
                         )
@@ -539,7 +539,7 @@ def get_scalar_constant_value(
                     op = owner.op
                     idx_list = op.idx_list
                     idx = idx_list[0]
-                    if isinstance(idx, CType):
+                    if isinstance(idx, Type):
                         idx = get_scalar_constant_value(
                             owner.inputs[1], max_recur=max_recur
                         )

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -8,7 +8,6 @@ manipulation of tensors.
 import builtins
 import logging
 import warnings
-from collections import OrderedDict
 from collections.abc import Sequence
 from functools import partial
 from numbers import Number
@@ -697,7 +696,7 @@ class Rebroadcast(COp):
     def __init__(self, *axis):
         # Sort them to make sure we merge all possible case.
         items = sorted(axis)
-        self.axis = OrderedDict(items)
+        self.axis = dict(items)
         for axis, broad in self.axis.items():
             if not isinstance(axis, (np.integer, int)):
                 raise TypeError(f"Rebroadcast needs integer axes. Got {axis}")
@@ -714,13 +713,7 @@ class Rebroadcast(COp):
         return hash((type(self), tuple(items)))
 
     def __str__(self):
-        if len(self.axis) == 0:
-            broadcast_pattern = []
-        else:
-            broadcast_pattern = ["?" for i in range(1 + max(self.axis.keys()))]
-        for k, v in self.axis.items():
-            broadcast_pattern[k] = str(int(v))
-        return f"{self.__class__.__name__}{{{','.join(broadcast_pattern)}}}"
+        return f"{self.__class__.__name__}{{{','.join(str(i) for i in self.axis.items())}}}"
 
     def make_node(self, x):
         if self.axis.keys() and (x.ndim <= max(self.axis.keys())):

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -441,23 +441,9 @@ def get_scalar_constant_value(
                     and isinstance(v.owner.inputs[0].owner.op, Join)
                     and len(v.owner.op.idx_list) == 1
                 ):
-                    # Ensure the Join is joining only scalar variables (so that
-                    # the constant value can be found at the same index as the
-                    # one used in the sub-tensor).
-                    if builtins.all(
-                        var.ndim == 0 for var in v.owner.inputs[0].owner.inputs[1:]
-                    ):
-                        idx = v.owner.op.idx_list[0]
-                        if isinstance(idx, Type):
-                            idx = get_scalar_constant_value(
-                                v.owner.inputs[1], max_recur=max_recur
-                            )
-                        # Note the '+ 1' is because the first argument to Join
-                        # is the axis.
-                        ret = v.owner.inputs[0].owner.inputs[idx + 1]
-                        ret = get_scalar_constant_value(ret, max_recur=max_recur)
-                        # join can cast implicitly its input in some case.
-                        return _asarray(ret, dtype=v.type.dtype)
+                    # Ensure the Join is joining only (effectively) scalar
+                    # variables (so that the constant value can be found at the
+                    # same index as the one used in the sub-tensor).
                     if builtins.all(
                         var.ndim == 1 for var in v.owner.inputs[0].owner.inputs[1:]
                     ):

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -120,7 +120,7 @@ def _as_tensor_Scalar(x, name, ndim, **kwargs):
 def _as_tensor_Variable(x, name, ndim, **kwargs):
     if not isinstance(x.type, TensorType):
         raise TypeError(
-            "Tensor type field must be a TensorType; found {}.".format(type(x.type))
+            f"Tensor type field must be a TensorType; found {type(x.type)}."
         )
 
     if ndim is None:
@@ -134,9 +134,7 @@ def _as_tensor_Variable(x, name, ndim, **kwargs):
         x = x.dimshuffle(list(range(x.ndim))[first_non_broadcastable:])
         if x.ndim > ndim:
             raise ValueError(
-                "Tensor of type {} could not be cast to have {} dimensions".format(
-                    x.type, ndim
-                )
+                f"Tensor of type {x.type} could not be cast to have {ndim} dimensions"
             )
         return x
     elif x.type.ndim < ndim:

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -2478,11 +2478,14 @@ def local_join_empty(fgraph, node):
 @register_useless
 @local_optimizer([Join])
 def local_join_make_vector(fgraph, node):
-    """Join(0, make_vector1, make_vector2, ...) => Join(0, make_vector12, ...)
+    r"""Merge `MakeVector` inputs within a `Join`.
 
-    Merge MakeVector inputs to Join. This can make the join completely
-    disappear with the local_join_1 opt.
+    For example:
 
+        Join(0, make_vector1, make_vector2, ...) => Join(0, make_vector12, ...)
+
+    This in combination with the `local_join_1` optimization can make `Join`\s
+    completely disappear.
     """
     if not isinstance(node.op, Join) or node.outputs[0].ndim != 1:
         return

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -76,7 +76,7 @@ from aesara.tensor.exceptions import NotScalarConstantError, ShapeError
 from aesara.tensor.extra_ops import broadcast_shape
 from aesara.tensor.math import all as at_all
 from aesara.tensor.math import eq
-from aesara.tensor.shape import Reshape, Shape, Shape_i, shape, shape_padleft
+from aesara.tensor.shape import Reshape, Shape, Shape_i, shape_padleft
 from aesara.tensor.sort import TopKOp
 from aesara.tensor.subtensor import Subtensor, get_idx_list
 from aesara.tensor.type import discrete_dtypes, integer_dtypes, lscalar
@@ -509,7 +509,7 @@ compile.optdb.register(
 
 
 def register_useless(lopt, *tags, **kwargs):
-    if type(lopt) == str:
+    if isinstance(lopt, str):
 
         def register(inner_lopt):
             return register_useless(inner_lopt, lopt, *tags, **kwargs)
@@ -525,7 +525,7 @@ def register_useless(lopt, *tags, **kwargs):
 
 
 def register_canonicalize(lopt, *tags, **kwargs):
-    if type(lopt) == str:
+    if isinstance(lopt, str):
 
         def register(inner_lopt):
             return register_canonicalize(inner_lopt, lopt, *tags, **kwargs)
@@ -538,7 +538,7 @@ def register_canonicalize(lopt, *tags, **kwargs):
 
 
 def register_stabilize(lopt, *tags, **kwargs):
-    if type(lopt) == str:
+    if isinstance(lopt, str):
 
         def register(inner_lopt):
             return register_stabilize(inner_lopt, lopt, *tags, **kwargs)
@@ -551,7 +551,7 @@ def register_stabilize(lopt, *tags, **kwargs):
 
 
 def register_specialize(lopt, *tags, **kwargs):
-    if type(lopt) == str:
+    if isinstance(lopt, str):
 
         def register(inner_lopt):
             return register_specialize(inner_lopt, lopt, *tags, **kwargs)
@@ -564,7 +564,7 @@ def register_specialize(lopt, *tags, **kwargs):
 
 
 def register_uncanonicalize(lopt, *tags, **kwargs):
-    if type(lopt) == str:
+    if isinstance(lopt, str):
 
         def register(inner_lopt):
             return register_uncanonicalize(inner_lopt, lopt, *tags, **kwargs)
@@ -579,7 +579,7 @@ def register_uncanonicalize(lopt, *tags, **kwargs):
 
 
 def register_specialize_device(lopt, *tags, **kwargs):
-    if type(lopt) == str:
+    if isinstance(lopt, str):
 
         def register(inner_lopt):
             return register_specialize_device(inner_lopt, lopt, *tags, **kwargs)
@@ -1893,7 +1893,7 @@ compile.optdb.register(
 @register_canonicalize
 @local_optimizer([Shape])
 def local_shape_to_shape_i(fgraph, node):
-    if node.op == shape:
+    if isinstance(node.op, Shape):
         # This optimization needs ShapeOpt and fgraph.shape_feature
         if not hasattr(fgraph, "shape_feature"):
             return

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -2281,10 +2281,7 @@ def local_upcast_elemwise_constant_inputs(fgraph, node):
 @register_specialize
 @local_optimizer([Rebroadcast])
 def local_useless_rebroadcast(fgraph, node):
-    """
-    Remove Rebroadcast if id does not actually change the broadcasting pattern.
-
-    """
+    """Remove `Rebroadcast` if it does not actually change the broadcasting pattern."""
     if isinstance(node.op, Rebroadcast):
         x = node.inputs[0]
         if np.all(x.broadcastable == node.outputs[0].broadcastable):

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -1887,19 +1887,24 @@ def local_shape_to_shape_i(fgraph, node):
 # TODO: Not sure what type of node we are expecting here
 @register_specialize
 @register_canonicalize
-@local_optimizer(None)
+@local_optimizer([Shape_i])
 def local_track_shape_i(fgraph, node):
+    if not isinstance(node.op, Shape_i):
+        return False
+
     try:
         shape_feature = fgraph.shape_feature
     except AttributeError:
-        return
-    if node in shape_feature.scheduled:
-        # Don't unschedule node as it could be reinserted in the
-        # fgraph as we don't change it in the shapefeature internal
-        # structure.
-        assert isinstance(node.op, Shape_i)
-        replacement = shape_feature.scheduled[node]
-        return [shape_feature.shape_of[replacement][node.op.i]]
+        return False
+
+    if node not in shape_feature.scheduled:
+        return False
+
+    # Don't unschedule node as it could be reinserted in the
+    # fgraph as we don't change it in the shapefeature internal
+    # structure.
+    replacement = shape_feature.scheduled[node]
+    return [shape_feature.shape_of[replacement][node.op.i]]
 
 
 # TODO: the other optimization for and, or, xor, le and ge see ticket #496.

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -71,7 +71,7 @@ from aesara.tensor.basic import (
 )
 from aesara.tensor.elemwise import DimShuffle, Elemwise
 from aesara.tensor.exceptions import NotScalarConstantError, ShapeError
-from aesara.tensor.extra_ops import broadcast_shape
+from aesara.tensor.extra_ops import BroadcastTo, Repeat, Unique, broadcast_shape
 from aesara.tensor.math import all as at_all
 from aesara.tensor.math import eq
 from aesara.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape, shape_padleft
@@ -3495,3 +3495,160 @@ def local_Shape_i_of_broadcastable(fgraph, node):
 
     if shape_arg.broadcastable[node.op.i]:
         return [as_tensor_variable(1, dtype=np.int64)]
+
+
+@register_useless
+@register_canonicalize
+@local_optimizer([Unique])
+def local_Unique_scalar(fgraph, node):
+    """Convert ``unique(x)`` to ``x`` when ``x`` is a scalar."""
+    if not isinstance(node.op, Unique):
+        return False
+
+    if node.op.return_index or node.op.return_inverse or node.op.return_counts:
+        return False
+
+    uniqued_var = node.inputs[0]
+
+    if uniqued_var.ndim != 0:
+        return False
+
+    old_out = node.outputs[0]
+    res = as_tensor_variable(uniqued_var, ndim=old_out.ndim, dtype=old_out.dtype)
+    return [res]
+
+
+@register_useless
+@register_canonicalize
+@local_optimizer([Unique])
+def local_Unique_Alloc_lift(fgraph, node):
+    """Convert ``unique(alloc(x, ...), axis=None)`` to ``unique(x, axis=None)``.
+
+    This isn't really so much a lift as a "reduction/consumption".
+    """
+    if not isinstance(node.op, Unique):
+        return False
+
+    if (
+        node.op.return_index
+        or node.op.return_inverse
+        or node.op.return_counts
+        or node.op.axis is not None
+    ):
+        return False
+
+    alloc_var = node.inputs[0]
+
+    if not (alloc_var.owner and isinstance(alloc_var.owner.op, Alloc)):
+        return False
+
+    alloced_var, *alloc_shape = alloc_var.owner.inputs
+
+    new_unique, *_ = node.op.make_node(alloced_var).outputs
+
+    old_out = node.outputs[0]
+    new_x = as_tensor_variable(new_unique, ndim=old_out.ndim, dtype=old_out.dtype)
+    return [new_x]
+
+
+@register_useless
+@register_canonicalize
+@local_optimizer([Unique])
+def local_Unique_BroadcastTo_lift(fgraph, node):
+    """Convert ``unique(broadcast_to(x, ...), axis=None)`` to ``unique(x, axis=None)``.
+
+    This isn't really so much a lift as a "reduction/consumption".
+    """
+    if not isinstance(node.op, Unique):
+        return False
+
+    if (
+        node.op.return_index
+        or node.op.return_inverse
+        or node.op.return_counts
+        or node.op.axis is not None
+    ):
+        return False
+
+    bcast_var = node.inputs[0]
+
+    if not (bcast_var.owner and isinstance(bcast_var.owner.op, BroadcastTo)):
+        return False
+
+    bcasted_var, *bcast_shape = bcast_var.owner.inputs
+
+    new_unique, *_ = node.op.make_node(bcasted_var).outputs
+
+    old_out = node.outputs[0]
+    new_x = as_tensor_variable(new_unique, ndim=old_out.ndim, dtype=old_out.dtype)
+    return [new_x]
+
+
+@register_useless
+@register_canonicalize
+@local_optimizer([Unique])
+def local_Unique_Repeat_lift(fgraph, node):
+    """Convert ``unique(repeat(x, ...), axis=None)`` to ``unique(x, axis=None)``.
+
+    This isn't really so much a lift as a "reduction/consumption".
+    """
+    if not isinstance(node.op, Unique):
+        return False
+
+    if (
+        node.op.return_index
+        or node.op.return_inverse
+        or node.op.return_counts
+        or node.op.axis is not None
+    ):
+        return False
+
+    repeat_var = node.inputs[0]
+
+    if not (repeat_var.owner and isinstance(repeat_var.owner.op, Repeat)):
+        return False
+
+    repeated_var, *repeat_shape = repeat_var.owner.inputs
+
+    new_unique, *_ = node.op.make_node(repeated_var).outputs
+
+    old_out = node.outputs[0]
+    new_x = as_tensor_variable(new_unique, ndim=old_out.ndim, dtype=old_out.dtype)
+    return [new_x]
+
+
+@register_useless
+@register_canonicalize
+@local_optimizer([Unique])
+def local_Unique_second(fgraph, node):
+    """Convert ``unique(second(x, ...), axis=None)`` to ``second(x, axis=None)``.
+
+    This isn't really so much a lift as a "reduction/consumption".
+    """
+    if not isinstance(node.op, Unique):
+        return False
+
+    if (
+        node.op.return_index
+        or node.op.return_inverse
+        or node.op.return_counts
+        or node.op.axis is not None
+    ):
+        return False
+
+    second_var = node.inputs[0]
+
+    if not (
+        second_var.owner
+        and isinstance(second_var.owner.op, Elemwise)
+        and isinstance(second_var.owner.op.scalar_op, aes.Second)
+    ):
+        return False
+
+    shape_var, seconded_var = second_var.owner.inputs
+
+    new_unique, *_ = node.op.make_node(seconded_var).outputs
+
+    old_out = node.outputs[0]
+    new_x = as_tensor_variable(new_unique, ndim=old_out.ndim, dtype=old_out.dtype)
+    return [new_x]

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -622,6 +622,8 @@ def is_dimshuffle_useless(new_order, input):
     return is_useless
 
 
+@register_canonicalize
+@register_specialize
 @local_optimizer([DimShuffle])
 def local_dimshuffle_lift(fgraph, node):
     """
@@ -704,9 +706,6 @@ def local_useless_dimshuffle_in_reshape(fgraph, node):
         copy_stack_trace(node.outputs[0], ret)
         return [ret]
 
-
-register_canonicalize(local_dimshuffle_lift)
-register_specialize(local_dimshuffle_lift)
 
 ######################
 # Casting operations #
@@ -1633,6 +1632,7 @@ def local_elemwise_alloc(fgraph, node):
     return ret
 
 
+@register_canonicalize
 @local_optimizer([Elemwise])
 def local_fill_sink(fgraph, node):
     """
@@ -1678,9 +1678,6 @@ def local_fill_sink(fgraph, node):
                 continue
             replacements.update(r)
     return replacements
-
-
-register_canonicalize(local_fill_sink)
 
 
 @register_specialize

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -113,24 +113,6 @@ def merge_broadcastables(broadcastables):
     return [all(bcast) for bcast in zip(*broadcastables)]
 
 
-def scalarconsts_rest(inputs, elemwise=True, only_process_constants=False):
-    """Partition a list of variables into two kinds:
-    scalar constants, and the rest."""
-    consts = []
-    origconsts = []
-    nonconsts = []
-    for i in inputs:
-        try:
-            v = get_scalar_constant_value(
-                i, elemwise=elemwise, only_process_constants=only_process_constants
-            )
-            consts.append(v)
-            origconsts.append(i)
-        except NotScalarConstantError:
-            nonconsts.append(i)
-    return consts, origconsts, nonconsts
-
-
 def broadcast_like(value, template, fgraph, dtype=None):
     """
     Return a Variable with the same shape and dtype as the template,

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -88,12 +88,6 @@ _logger = logging.getLogger("aesara.tensor.basic_opt")
 _logger.addFilter(NoDuplicateOptWarningFilter())
 
 
-def _fill_chain(new_out, orig_inputs):
-    for i in orig_inputs:
-        new_out = fill(i, new_out)
-    return [new_out]
-
-
 def encompasses_broadcastable(b1, b2):
     """
 

--- a/aesara/tensor/elemwise.py
+++ b/aesara/tensor/elemwise.py
@@ -20,7 +20,7 @@ from aesara.scalar.basic import Scalar
 from aesara.scalar.basic import bool as scalar_bool
 from aesara.scalar.basic import identity as scalar_identity
 from aesara.scalar.basic import transfer_type, upcast
-from aesara.tensor import _get_vector_length
+from aesara.tensor import _get_vector_length, as_tensor_variable
 from aesara.tensor import elemwise_cgen as cgen
 from aesara.tensor import get_vector_length
 from aesara.tensor.type import (
@@ -206,7 +206,7 @@ class DimShuffle(ExternalCOp):
             super().__init__([self.c_func_file], self.c_func_name)
 
     def make_node(self, _input):
-        input = aesara.tensor.basic.as_tensor_variable(_input)
+        input = as_tensor_variable(_input)
         ib = tuple(input.type.broadcastable)
         if not ib == self.input_broadcastable:
             if len(ib) != len(self.input_broadcastable):
@@ -279,7 +279,6 @@ class DimShuffle(ExternalCOp):
         return self(*eval_points, return_list=True)
 
     def grad(self, inp, grads):
-        from aesara.tensor.basic import as_tensor_variable
 
         (x,) = inp
         (gz,) = grads
@@ -484,7 +483,7 @@ second dimension
         is left-completed to the greatest number of dimensions with 1s
         using DimShuffle.
         """
-        inputs = list(map(aesara.tensor.basic.as_tensor_variable, inputs))
+        inputs = [as_tensor_variable(i) for i in inputs]
         out_dtypes, out_broadcastables, inputs = self.get_output_info(
             DimShuffle, *inputs
         )
@@ -1315,8 +1314,6 @@ class CAReduce(COp):
         return input_dtype
 
     def make_node(self, input):
-        from aesara.tensor.basic import as_tensor_variable
-
         input = as_tensor_variable(input)
         inp_dims = input.type.ndim
         inp_bdcast = input.type.broadcastable
@@ -1760,7 +1757,7 @@ class CAReduceDtype(CAReduce):
         # We need to redefine make_node so that, if self.dtype is None,
         # we can infer what dtype should be, and create a node from an Op
         # of the appropriate dtype.
-        input = aesara.tensor.basic.as_tensor_variable(input)
+        input = as_tensor_variable(input)
         dtype = self._output_dtype(input.dtype)
         acc_dtype = self._acc_dtype(input.dtype)
 

--- a/aesara/tensor/exceptions.py
+++ b/aesara/tensor/exceptions.py
@@ -9,13 +9,6 @@ class NotScalarConstantError(Exception):
     """
 
 
-class EmptyConstantError(NotScalarConstantError):
-    """
-    Raised by get_scalar_const_value if called on something that is a
-    zero dimensional constant.
-    """
-
-
 class AdvancedIndexingError(TypeError):
     """
     Raised when Subtensor is asked to perform advanced indexing.

--- a/aesara/tensor/extra_ops.py
+++ b/aesara/tensor/extra_ops.py
@@ -794,7 +794,7 @@ def repeat(x, repeats, axis=None):
     .. versionadded:: 0.6
 
     """
-    repeats = aet.as_tensor_variable(repeats)
+    repeats = aet.as_tensor_variable(repeats, dtype=np.int64)
 
     if repeats.ndim > 1:
         raise ValueError("The dimension of repeats should not exceed 1.")

--- a/aesara/tensor/math_opt.py
+++ b/aesara/tensor/math_opt.py
@@ -1,6 +1,4 @@
 """ Tensor optimizations addressing the ops in math.py."""
-# TODO: intelligent merge for mul/add
-# TODO: 0*x -> 0
 
 import itertools
 import logging
@@ -2225,12 +2223,15 @@ def local_log1p(fgraph, node):
             return [log1p(neg(other))]
 
 
-# TODO: in canonicalize, change log10 and log2 -> log
 @register_stabilize
 @register_specialize
 @local_optimizer([log])
 def local_log_add_exp(fgraph, node):
-    # log(exp(x)+exp(y)+exp(z)) = max + log(x-max, y-max, z-max)
+    """
+    ``log(exp(x)+exp(y)+exp(z)) = max + log(x-max, y-max, z-max)``
+
+    TODO: in canonicalize, change log10 and log2 -> log
+    """
 
     if node.op == log:
         z = node.inputs[0]

--- a/aesara/tensor/math_opt.py
+++ b/aesara/tensor/math_opt.py
@@ -48,7 +48,6 @@ from aesara.tensor.basic_opt import (
     register_stabilize,
     register_uncanonicalize,
     register_useless,
-    scalarconsts_rest,
 )
 from aesara.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from aesara.tensor.exceptions import NotScalarConstantError
@@ -99,6 +98,24 @@ from aesara.utils import NoDuplicateOptWarningFilter
 
 _logger = logging.getLogger("aesara.tensor.math_opt")
 _logger.addFilter(NoDuplicateOptWarningFilter())
+
+
+def scalarconsts_rest(inputs, elemwise=True, only_process_constants=False):
+    """Partition a list of variables into two kinds:
+    scalar constants, and the rest."""
+    consts = []
+    origconsts = []
+    nonconsts = []
+    for i in inputs:
+        try:
+            v = get_scalar_constant_value(
+                i, elemwise=elemwise, only_process_constants=only_process_constants
+            )
+            consts.append(v)
+            origconsts.append(i)
+        except NotScalarConstantError:
+            nonconsts.append(i)
+    return consts, origconsts, nonconsts
 
 
 def get_constant(v):

--- a/aesara/tensor/subtensor.py
+++ b/aesara/tensor/subtensor.py
@@ -111,7 +111,9 @@ def indices_from_subtensor(
     )
 
 
-def as_index_constant(a):
+def as_index_constant(
+    a: Optional[Union[slice, int, np.integer, Variable]]
+) -> Optional[Union[Variable, slice]]:
     r"""Convert Python literals to Aesara constants--when possible--in `Subtensor` arguments.
 
     This will leave `Variable`\s untouched.

--- a/aesara/tensor/subtensor_opt.py
+++ b/aesara/tensor/subtensor_opt.py
@@ -11,6 +11,7 @@ from aesara.graph.opt import TopoOptimizer, copy_stack_trace, in2out, local_opti
 from aesara.tensor.basic import (
     Alloc,
     ARange,
+    MakeVector,
     Rebroadcast,
     ScalarFromTensor,
     TensorFromScalar,
@@ -67,7 +68,7 @@ from aesara.tensor.var import TensorConstant, TensorVariable
 
 
 def register_useless(lopt, *tags, **kwargs):
-    if type(lopt) == str:
+    if isinstance(lopt, str):
 
         def register(inner_lopt):
             return register_useless(inner_lopt, lopt, *tags, **kwargs)
@@ -556,7 +557,7 @@ def local_subtensor_remove_broadcastable_index(fgraph, node):
             # The idx is a Scalar, ie a Type. This means the actual index
             # is contained in node.inputs[1]
             dim_index = node.inputs[node_inputs_idx]
-            if type(dim_index) == aes.ScalarConstant:
+            if isinstance(dim_index, aes.ScalarConstant):
                 dim_index = dim_index.value
             if dim_index in [0, -1] and node.inputs[0].broadcastable[dim]:
                 remove_dim.append(dim)
@@ -707,8 +708,8 @@ def local_subtensor_make_vector(fgraph, node):
 
     """
     x = node.inputs[0]
-    if not x.owner or x.owner.op != make_vector:
-        return
+    if not x.owner or not isinstance(x.owner.op, MakeVector):
+        return False
 
     if isinstance(node.op, Subtensor):
         # This optimization needs ShapeOpt and fgraph.shape_feature

--- a/aesara/tensor/subtensor_opt.py
+++ b/aesara/tensor/subtensor_opt.py
@@ -1031,13 +1031,8 @@ def merge_two_slices(fgraph, slice1, len1, slice2, len2):
     """
 
     if not isinstance(slice1, slice):
-        raise ValueError(
-            (
-                "First provided slice should actually be of type"
-                "slice and not an index !"
-            ),
-            slice1,
-        )
+        raise ValueError("slice1 should be of type `slice`")
+
     sl1, reverse1 = get_canonical_form_slice(slice1, len1)
     sl2, reverse2 = get_canonical_form_slice(slice2, len2)
 

--- a/doc/library/config.rst
+++ b/doc/library/config.rst
@@ -232,14 +232,6 @@ import ``aesara`` and print the config variable, as in:
     ``False``, then Aesara will perform garbage collection during the inner
     operations of a :class:`Scan` after each iterations.
 
-.. attribute:: config.scan__debug
-
-    Bool value, either ``True`` or ``False``
-
-    Default: ``False``
-
-    If ``True``, Aesara will print extra :class:`Scan` debug information.
-
 .. attribute:: cycle_detection
 
     String value, either ``regular`` or ``fast```

--- a/tests/graph/test_fg.py
+++ b/tests/graph/test_fg.py
@@ -256,6 +256,19 @@ class TestFunctionGraph:
         assert fg.apply_nodes == {var4.owner, var5.owner}
         assert var4.owner.inputs == [var1, var2]
 
+    def test_replace_verbose(self, capsys):
+
+        var1 = MyVariable("var1")
+        var2 = MyVariable("var2")
+        var3 = op1(var2, var1)
+        fg = FunctionGraph([var1, var2], [var3], clone=False)
+
+        fg.replace(var3, var1, reason="test-reason", verbose=True)
+
+        capres = capsys.readouterr()
+        assert capres.err == ""
+        assert "optimizer: rewrite test-reason replaces Op1.0 with var1" in capres.out
+
     def test_replace_circular(self):
         """`FunctionGraph` allows cycles--for better or worse."""
 

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -33,7 +33,7 @@ def test_scan_debugprint1():
      | | | | | |k [id D]
      | | | | | |Subtensor{int64} [id H] ''
      | | | | |   |Shape [id I] ''
-     | | | | |   | |Rebroadcast{0} [id J] ''
+     | | | | |   | |Rebroadcast{(0, False)} [id J] ''
      | | | | |   |   |InplaceDimShuffle{x,0} [id K] ''
      | | | | |   |     |Elemwise{second,no_inplace} [id L] ''
      | | | | |   |       |A [id M]
@@ -42,9 +42,9 @@ def test_scan_debugprint1():
      | | | | |   |ScalarConstant{0} [id P]
      | | | | |Subtensor{int64} [id Q] ''
      | | | |   |Shape [id R] ''
-     | | | |   | |Rebroadcast{0} [id J] ''
+     | | | |   | |Rebroadcast{(0, False)} [id J] ''
      | | | |   |ScalarConstant{1} [id S]
-     | | | |Rebroadcast{0} [id J] ''
+     | | | |Rebroadcast{(0, False)} [id J] ''
      | | | |ScalarFromTensor [id T] ''
      | | |   |Subtensor{int64} [id H] ''
      | | |A [id M]
@@ -208,7 +208,7 @@ def test_scan_debugprint3():
      >   | | | | | | |k_copy [id BF] -> [id X]
      >   | | | | | | |Subtensor{int64} [id BJ] ''
      >   | | | | | |   |Shape [id BK] ''
-     >   | | | | | |   | |Rebroadcast{0} [id BL] ''
+     >   | | | | | |   | |Rebroadcast{(0, False)} [id BL] ''
      >   | | | | | |   |   |InplaceDimShuffle{x,0} [id BM] ''
      >   | | | | | |   |     |Elemwise{second,no_inplace} [id BN] ''
      >   | | | | | |   |       |A_copy [id BO] -> [id W]
@@ -217,9 +217,9 @@ def test_scan_debugprint3():
      >   | | | | | |   |ScalarConstant{0} [id BR]
      >   | | | | | |Subtensor{int64} [id BS] ''
      >   | | | | |   |Shape [id BT] ''
-     >   | | | | |   | |Rebroadcast{0} [id BL] ''
+     >   | | | | |   | |Rebroadcast{(0, False)} [id BL] ''
      >   | | | | |   |ScalarConstant{1} [id BU]
-     >   | | | | |Rebroadcast{0} [id BL] ''
+     >   | | | | |Rebroadcast{(0, False)} [id BL] ''
      >   | | | | |ScalarFromTensor [id BV] ''
      >   | | | |   |Subtensor{int64} [id BJ] ''
      >   | | | |A_copy [id BO] -> [id W]
@@ -341,7 +341,7 @@ def test_scan_debugprint5():
     | | | |   | | | |k [id G]
     | | | |   | | | |Subtensor{int64} [id K] ''
     | | | |   | | |   |Shape [id L] ''
-    | | | |   | | |   | |Rebroadcast{0} [id M] ''
+    | | | |   | | |   | |Rebroadcast{(0, False)} [id M] ''
     | | | |   | | |   |   |InplaceDimShuffle{x,0} [id N] ''
     | | | |   | | |   |     |Elemwise{second,no_inplace} [id O] ''
     | | | |   | | |   |       |A [id P]
@@ -350,9 +350,9 @@ def test_scan_debugprint5():
     | | | |   | | |   |ScalarConstant{0} [id S]
     | | | |   | | |Subtensor{int64} [id T] ''
     | | | |   | |   |Shape [id U] ''
-    | | | |   | |   | |Rebroadcast{0} [id M] ''
+    | | | |   | |   | |Rebroadcast{(0, False)} [id M] ''
     | | | |   | |   |ScalarConstant{1} [id V]
-    | | | |   | |Rebroadcast{0} [id M] ''
+    | | | |   | |Rebroadcast{(0, False)} [id M] ''
     | | | |   | |ScalarFromTensor [id W] ''
     | | | |   |   |Subtensor{int64} [id K] ''
     | | | |   |A [id P]

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -87,7 +87,7 @@ from aesara.tensor.basic import (
     zeros_like,
 )
 from aesara.tensor.elemwise import DimShuffle
-from aesara.tensor.exceptions import EmptyConstantError, NotScalarConstantError
+from aesara.tensor.exceptions import NotScalarConstantError
 from aesara.tensor.math import dense_dot, eq
 from aesara.tensor.math import sum as aet_sum
 from aesara.tensor.shape import Reshape, Shape, Shape_i, shape_padright
@@ -3140,6 +3140,15 @@ def test_dimshuffle_duplicate():
 
 class TestGetScalarConstantValue:
     def test_basic(self):
+
+        res = get_scalar_constant_value(aet.as_tensor(10))
+        assert res == 10
+        assert isinstance(res, np.ndarray)
+
+        res = get_scalar_constant_value(np.array(10))
+        assert res == 10
+        assert isinstance(res, np.ndarray)
+
         a = aet.stack([1, 2, 3])
         assert get_scalar_constant_value(a[0]) == 1
         assert get_scalar_constant_value(a[1]) == 2
@@ -3195,7 +3204,7 @@ class TestGetScalarConstantValue:
         assert get_scalar_constant_value(np.array(3)) == 3
         with pytest.raises(NotScalarConstantError):
             get_scalar_constant_value(np.array([0, 1]))
-        with pytest.raises(EmptyConstantError):
+        with pytest.raises(NotScalarConstantError):
             get_scalar_constant_value(np.array([]))
 
     def test_make_vector(self):

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -1019,7 +1019,7 @@ def test_get_vector_length():
     mode = aesara.compile.get_default_mode().excluding("constant_folding")
     f = function([x, y], [b, c, a], mode=mode)
     topo = f.maker.fgraph.toposort()
-    assert [True for node in topo if isinstance(node.op, MakeVector)]
+    assert any([True for node in topo if isinstance(node.op, MakeVector)])
 
     assert np.allclose(f(4, 5), [5, 9, 4])
 

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -3141,6 +3141,9 @@ def test_dimshuffle_duplicate():
 class TestGetScalarConstantValue:
     def test_basic(self):
 
+        with pytest.raises(NotScalarConstantError):
+            get_scalar_constant_value(aes.int64())
+
         res = get_scalar_constant_value(aet.as_tensor(10))
         assert res == 10
         assert isinstance(res, np.ndarray)
@@ -3189,6 +3192,11 @@ class TestGetScalarConstantValue:
         )
         assert isinstance(res, np.ndarray)
         assert 10 == res
+
+    @pytest.mark.xfail(reason="Incomplete implementation")
+    def test_DimShufle(self):
+        a = as_tensor_variable(1.0)[None][0]
+        assert get_scalar_constant_value(a) == 1
 
     def test_subtensor_of_constant(self):
         c = constant(random(5))

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -1810,7 +1810,6 @@ def test_join_inplace():
     f = aesara.function([In(x, borrow=True), s], Out(c, borrow=True))
 
     data = np.array([3, 4, 5], dtype=config.floatX)
-    print(f(data, 0))
 
     if config.mode not in ["DebugMode", "DEBUG_MODE"]:
         assert f(data, 0) is data
@@ -3441,7 +3440,7 @@ class TestAllocDiag:
                 # Test infer_shape
                 f_shape = aesara.function([x], adiag_op(x).shape, mode="FAST_RUN")
 
-                aesara.printing.debugprint(f_shape.maker.fgraph.outputs[0])
+                # aesara.printing.debugprint(f_shape.maker.fgraph.outputs[0])
                 output_shape = f_shape(test_val)
                 assert not any(
                     isinstance(node.op, self.alloc_diag)

--- a/tests/tensor/test_basic_opt.py
+++ b/tests/tensor/test_basic_opt.py
@@ -19,6 +19,7 @@ from aesara.graph.basic import Apply, Constant
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.op import Op
 from aesara.graph.opt import check_stack_trace, local_optimizer, out2in
+from aesara.graph.opt_utils import optimize_graph
 from aesara.graph.optdb import OptimizationQuery
 from aesara.misc.safe_asarray import _asarray
 from aesara.tensor.basic import (
@@ -82,7 +83,7 @@ from aesara.tensor.math import sin, sinh, softplus, sqr, sqrt, sub
 from aesara.tensor.math import sum as aet_sum
 from aesara.tensor.math import tan, tanh, true_div, xor
 from aesara.tensor.math_opt import local_lift_transpose_through_dot
-from aesara.tensor.shape import Reshape, Shape_i, reshape
+from aesara.tensor.shape import Reshape, Shape_i, reshape, specify_shape
 from aesara.tensor.subtensor import (
     AdvancedIncSubtensor1,
     Subtensor,
@@ -3190,6 +3191,21 @@ class TestShapeFeature:
             shape_feature.same_shape(x, o, 1, 0)
         with pytest.raises(IndexError):
             shape_feature.same_shape(x, o, 0, 1)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [lscalar(), iscalar()],
+)
+def test_local_Shape_of_SpecifyShape(shape):
+    x = vector()
+    s = specify_shape(x, shape).shape
+
+    fgraph = FunctionGraph(outputs=[s], clone=False)
+    _ = optimize_graph(fgraph, clone=False)
+
+    assert x not in fgraph.variables
+    assert shape in fgraph.variables
 
 
 def test_assert_op_gradient():

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -2557,6 +2557,8 @@ def test_norm():
 
 
 def test_cov():
+    rng = np.random.default_rng(utt.fetch_seed())
+
     x = matrix("x")
     y = matrix("y")
 
@@ -2564,14 +2566,14 @@ def test_cov():
         c = cov(x, rowvar=rowvar, bias=bias, ddof=ddof)
         f = function([x], c)
 
-        data = np.asarray(np.random.random((3, 5)), dtype=config.floatX)
+        data = np.asarray(rng.random((3, 5)), dtype=config.floatX)
         assert np.allclose(f(data), np.cov(data, rowvar=rowvar, bias=bias, ddof=ddof))
 
         c = cov(x, y=y, rowvar=rowvar, bias=bias, ddof=ddof)
         f = function([x, y], c)
 
-        data = np.asarray(np.random.random((3, 5)), dtype=config.floatX)
-        y_val = np.asarray(np.random.random((3, 5)), dtype=config.floatX)
+        data = np.asarray(rng.random((3, 5)), dtype=config.floatX)
+        y_val = np.asarray(rng.random((3, 5)), dtype=config.floatX)
         assert np.allclose(
             f(data, y_val), np.cov(data, rowvar=rowvar, y=y_val, bias=bias, ddof=ddof)
         )

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -537,10 +537,9 @@ class TestSubtensor(utt.OptimizationTestMixin):
         ret = f()
         assert ret.shape == (1, 1, 4)
 
-    def test_ellipsis(self):
-        numpy_n = np.arange(24, dtype=self.dtype).reshape((2, 3, 4))
-        n = self.shared(numpy_n)
-        test_cases = [
+    @pytest.mark.parametrize(
+        "length, op_type_opt, slice_",
+        [
             (0, Subtensor, np.index_exp[...]),
             (1, Subtensor, np.index_exp[..., 1]),
             (1, Subtensor, np.index_exp[1, ...]),
@@ -554,14 +553,16 @@ class TestSubtensor(utt.OptimizationTestMixin):
                 AdvancedSubtensor,
                 np.index_exp[..., np.newaxis, [1, 2]],
             ),
-        ]
-
-        for length, op_type_opt, slice_ in test_cases:
-            numpy_tval = numpy_n[slice_]
-            t = n[slice_]
-            tval = self.eval_output_and_check(t, op_type=op_type_opt, length=length)
-            assert tval.shape == numpy_tval.shape
-            assert_array_equal(tval, numpy_tval)
+        ],
+    )
+    def test_ellipsis(self, length, op_type_opt, slice_):
+        numpy_n = np.arange(24, dtype=self.dtype).reshape((2, 3, 4))
+        n = self.shared(numpy_n)
+        numpy_tval = numpy_n[slice_]
+        t = n[slice_]
+        tval = self.eval_output_and_check(t, op_type=op_type_opt, length=length)
+        assert tval.shape == numpy_tval.shape
+        assert_array_equal(tval, numpy_tval)
 
     def test_boolean(self):
         def numpy_inc_subtensor(x, idx, a):

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -28,6 +28,7 @@ from aesara.tensor.subtensor import (
     advanced_inc_subtensor1,
     advanced_set_subtensor,
     advanced_set_subtensor1,
+    as_index_literal,
     basic_shape,
     get_canonical_form_slice,
     inc_subtensor,
@@ -59,7 +60,7 @@ from aesara.tensor.type import (
     tensor4,
     vector,
 )
-from aesara.tensor.type_other import make_slice, slicetype
+from aesara.tensor.type_other import NoneConst, SliceConstant, make_slice, slicetype
 from tests import unittest_tools as utt
 from tests.tensor.utils import inplace_func, integers_ranged, random
 
@@ -70,6 +71,29 @@ subtensor_ops = (
     AdvancedSubtensor1,
     AdvancedIncSubtensor1,
 )
+
+
+def test_as_index_literal():
+    res = as_index_literal(slice(None, aet.as_tensor(1)))
+    assert res == slice(None, 1)
+    res = as_index_literal(slice(aet.as_tensor(1), None))
+    assert res == slice(1, None)
+    res = as_index_literal(slice(None, None, aet.as_tensor(2)))
+    assert res == slice(None, None, 2)
+    res = as_index_literal(SliceConstant(slicetype, slice(None)))
+    assert res == slice(None)
+    res = as_index_literal(make_slice(None, aet.as_tensor(1)))
+    assert res == slice(None, 1)
+
+    res = as_index_literal(aet.as_tensor(2))
+    assert res == 2
+
+    res = as_index_literal(np.newaxis)
+    assert res is np.newaxis
+    res = as_index_literal(NoneConst)
+    assert res is np.newaxis
+    res = as_index_literal(NoneConst.clone())
+    assert res is np.newaxis
 
 
 class TestSubtensor(utt.OptimizationTestMixin):


### PR DESCRIPTION
This PR adds missing canonicalizations and misc. updates that relate to `get_scalar_constant_value`.

`get_scalar_constant_value` uses a confusing and poorly defined abstraction: it attempts to return the non-symbolic value of a symbolic scalar graph **and/or** the "underlying" scalar value of a graph.  The latter concept of an "underlying" scalar value is ambiguous and very limited, since it only applies in a few cases&mdash;like the outputs of `Alloc` `Op`s, because they use a scalar input (i.e. the "underlying" scalar value) to construct an array/tensor.

- [x] Replace uses of `get_scalar_constant_value` for `Alloc` and `Second`

Its implementation is a hard to follow (and maintain) set of conditions, iterations, and recursions&mdash;all of which are a mix of existing/missing constants-based canonicalizations and re-implemented constant folding steps.

The goal of this PR is to further the replacement/removal of `get_scalar_constant_value` with a more complete set of optimizations, and, when/if necessary, explicit use of constant folding.

This PR also implements some of the missing `Shape`-related canonicalizations mentioned in #642.