### PR TITLE
Make input mismatch TypeError in make_node more readable

### DIFF
--- a/aesara/graph/op.py
+++ b/aesara/graph/op.py
@@ -225,7 +225,15 @@ class Op(MetaObject):
             )
         if not all(inp.type == it for inp, it in zip(inputs, self.itypes)):
             raise TypeError(
-                f"We expected inputs of types '{str(self.itypes)}' but got types '{str([inp.type for inp in inputs])}'"
+                f"Invalid input types for Op {self}:\n"
+                + "\n".join(
+                    f"Input {i}/{len(inputs)}: Expected {inp}, got {out}"
+                    for i, (inp, out) in enumerate(
+                        zip(self.itypes, (inp.type for inp in inputs)),
+                        start=1,
+                    )
+                    if inp != out
+                )
             )
         return Apply(self, inputs, [o() for o in self.otypes])
 

--- a/tests/graph/test_op.py
+++ b/tests/graph/test_op.py
@@ -12,7 +12,7 @@ from aesara.graph.op import COp, Op
 from aesara.graph.type import Generic, Type
 from aesara.graph.utils import MethodNotDefined, TestValueError
 from aesara.tensor.math import log
-from aesara.tensor.type import dmatrix, vector
+from aesara.tensor.type import dmatrix, dscalar, dvector, vector
 
 
 def as_variable(x):
@@ -340,3 +340,16 @@ def test_get_test_values_exc():
     with pytest.raises(TestValueError):
         x = vector()
         assert op.get_test_values(x) == []
+
+
+def test_op_invalid_input_types():
+    class TestOp(aesara.graph.op.Op):
+        itypes = [dvector, dvector, dvector]
+        otypes = [dvector]
+
+        def perform(self, node, inputs, outputs):
+            pass
+
+    msg = r"^Invalid input types for Op TestOp:\nInput 2/3: Expected TensorType\(float64, vector\)"
+    with pytest.raises(TypeError, match=msg):
+        TestOp()(dvector(), dscalar(), dvector())


### PR DESCRIPTION
```python
import aesara
import aesara.tensor as at

class MyOp(aesara.graph.op.Op):
    itypes = [at.dvector, at.dvector, at.dvector]
    otypes = [at.dscalar]
    def perform(self, node, inputs, outputs):
        pass
    
MyOp()(at.vector(), at.scalar(), at.vector())
```

Before:
```
Traceback (most recent call last):
  File "/home/ricardo/Documents/Projects/aesara/venv/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3441, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-2-c79d16f9907a>", line 10, in <module>
    MyOp()(at.vector(), at.scalar(), at.dvector())
  File "/home/ricardo/Documents/Projects/aesara/aesara/graph/op.py", line 275, in __call__
    node = self.make_node(*inputs, **kwargs)
  File "/home/ricardo/Documents/Projects/aesara/aesara/graph/op.py", line 227, in make_node
    raise TypeError(
TypeError: We expected inputs of types '[TensorType(float64, vector), TensorType(float64, vector), TensorType(float64, vector)]' but got types '[TensorType(float64, vector), TensorType(float64, scalar), TensorType(float64, vector)]'

```

After:
```
Traceback (most recent call last):
  File "/home/ricardo/Documents/Projects/aesara/venv/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3441, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-2-ddfd178ce0c4>", line 13, in <module>
    MyOp()(at.vector(), at.scalar(), at.vector())
  File "/home/ricardo/Documents/Projects/aesara/aesara/graph/op.py", line 284, in __call__
    node = self.make_node(*inputs, **kwargs)
  File "/home/ricardo/Documents/Projects/aesara/aesara/graph/op.py", line 228, in make_node
    raise TypeError(
TypeError: Invalid input types for Op MyOp:
Input 2/3: Expected TensorType(float64, vector), got TensorType(float64, scalar)
```
