### PR TITLE
Adding support for nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,28 @@
+name: Nightly
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  build_and_publish:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install build
+      - name: Build the sdist
+        run: python -m build --sdist .
+        env:
+          BUILD_AESARA_NIGHTLY: true
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.nightly_pypi_secret }}

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 import sys
 
 from setuptools import find_packages, setup
@@ -59,6 +60,24 @@ install_requires = [
 if sys.version_info[0:2] < (3, 7):
     install_requires += ["dataclasses"]
 
+# Handle builds of nightly release
+if "BUILD_AESARA_NIGHTLY" in os.environ:
+    nightly = True
+    NAME += "-nightly"
+
+    from versioneer import get_versions as original_get_versions
+
+    def get_versions():
+        from datetime import datetime, timezone
+
+        suffix = datetime.now(timezone.utc).strftime(r".dev%Y%m%d")
+        versions = original_get_versions()
+        versions["version"] = versions["version"].split("+")[0] + suffix
+        return versions
+
+    versioneer.get_versions = get_versions
+
+
 if __name__ == "__main__":
     setup(
         name=NAME,
@@ -66,6 +85,7 @@ if __name__ == "__main__":
         cmdclass=versioneer.get_cmdclass(),
         description=DESCRIPTION,
         long_description=LONG_DESCRIPTION,
+        long_description_content_type="text/x-rst",
         classifiers=CLASSIFIERS,
         author=AUTHOR,
         author_email=AUTHOR_EMAIL,


### PR DESCRIPTION
This PR closes #511 by adding support for building a "nightly" release on a GitHub Actions cronjob and pushing it to the `aesara-nightly` PyPI package.

_How it works_: It's not terribly elegant, but if the environment variable `BUILD_AESARA_NIGHTLY` is present, the name of the package in `setup.py` gets renamed and versioneer's `get_versions` function gets monkey patched to return the current base version with the date appended.

_Open questions_:

1. Right now we're following versioneer's convention of using the last release version as the base version. This is the simplest to implement, but it might be more sensible to use the `setuptools_scm` convention of using the current release + one minor increment as the base version.
2. We'll need to add a correctly scoped and permissioned PyPI API token to this repo (called `nightly_pypi_secret`) so that we can push to the `aesara-nightly` project. I'll message @brandonwillard offline to get this set up.

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] ~~There are tests covering the changes introduced in the PR.~~