### PR TITLE
fixed typo on tutorial --extending aesara

### DIFF
--- a/doc/extending/extending_aesara.rst
+++ b/doc/extending/extending_aesara.rst
@@ -514,7 +514,7 @@ and ``b`` are equal.
             return i0_shapes
 
         def grad(self, inputs, output_grads):
-            return [a * output_grads[0] + b]
+            return [self.a * output_grads[0]]
 
 
 The use of :attr:`__props__` saves


### PR DESCRIPTION
Resolves #660

There was a mistake in the tutorials

```python
import aesara
from aesara.graph.op import Op
from aesara.graph.basic import Apply

class AXPBOp(Op):
    """
    This creates an Op that takes x to a*x+b.
    """
    __props__ = ("a", "b")

    def __init__(self, a, b):
        self.a = a
        self.b = b
        super().__init__()

    def make_node(self, x):
        x = aesara.tensor.as_tensor_variable(x)
        return Apply(self, [x], [x.type()])

    def perform(self, node, inputs, output_storage):
        x = inputs[0]
        z = output_storage[0]
        z[0] = self.a * x + self.b

    def infer_shape(self, fgraph, node, i0_shapes):
        return i0_shapes

    def grad(self, inputs, output_grads):
        return [a * output_grads[0] + b]
```
```python
    def grad(self, inputs, output_grads):
        return [a * output_grads[0] + b]
```
should be:
```python
    def grad(self, inputs, output_grads):
        return [self.a * output_grads[0]]
```
