### PR TITLE
Fix issue with version logic when tags are not available

### DIFF
--- a/aesara/version.py
+++ b/aesara/version.py
@@ -17,7 +17,7 @@ short_version = full_version.split("+")[0]
 try:
     int(short_version.split(".")[2])
     release = True
-except ValueError:
+except (ValueError, IndexError):
     release = False
 
 if release and info["error"] is None:


### PR DESCRIPTION
This PR fixes `IndexError` issues in `aesara.version` when the project is cloned at a fixed depth and there are no tags
present at the given depth (e.g. during the RTD builds).