### PR TITLE
Add a `CheckAndRaise` `COp`

### DIFF
--- a/aesara/assert_op.py
+++ b/aesara/assert_op.py
@@ -1,99 +1,11 @@
-import numpy as np
-
-from aesara.gradient import DisconnectedType
-from aesara.graph.basic import Apply, Variable
-from aesara.graph.op import COp
+import warnings
 
 
-class Assert(COp):
-    """
-    Implements assertion in a computational graph.
+warnings.warn(
+    "The module `aesara.assert_op` is deprecated "
+    "and its `Op`s have been moved to `aesara.raise_op`",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-    Returns the first parameter if the condition is true, otherwise, triggers
-    AssertionError.
-
-    Notes
-    -----
-    This Op is a debugging feature. It can be removed from the graph
-    because of optimizations, and can hide some possible optimizations to
-    the optimizer. Specifically, removing happens if it can be determined
-    that condition will always be true. Also, the output of the Op must be
-    used in the function computing the graph, but it doesn't have to be
-    returned.
-
-    Examples
-    --------
-    >>> import aesara
-    >>> import aesara.tensor as aet
-    >>> from aesara.assert_op import Assert
-    >>> x = aet.vector("x")
-    >>> assert_op = Assert("This assert failed")
-    >>> func = aesara.function([x], assert_op(x, x.size < 2))
-
-    """
-
-    _f16_ok = True
-    __props__ = ("msg",)
-    view_map = {0: [0]}
-
-    check_input = False
-
-    def __init__(self, msg="Aesara Assert failed!"):
-        self.msg = msg
-
-    def __setstate__(self, attrs):
-        self.__dict__.update(attrs)
-        if not hasattr(self, "msg"):
-            self.msg = "Aesara Assert failed!"
-
-    def make_node(self, value, *conds):
-        from aesara.tensor import as_tensor_variable
-
-        if not isinstance(value, Variable):
-            value = as_tensor_variable(value)
-        cond = [as_tensor_variable(c) for c in conds]
-        assert np.all([c.type.ndim == 0 for c in cond])
-        return Apply(self, [value] + cond, [value.type()])
-
-    def perform(self, node, inputs, out_):
-        (out,) = out_
-        v = inputs[0]
-        out[0] = v
-        assert np.all(inputs[1:]), self.msg
-
-    def grad(self, input, output_gradients):
-        return output_gradients + [DisconnectedType()()] * (len(input) - 1)
-
-    def connection_pattern(self, node):
-        return [[1]] + [[0]] * (len(node.inputs) - 1)
-
-    def c_code(self, node, name, inames, onames, props):
-        value = inames[0]
-        out = onames[0]
-        check = []
-        fail = props["fail"]
-        msg = self.msg.replace('"', '\\"').replace("\n", "\\n")
-        for idx in range(len(inames) - 1):
-            i = inames[idx + 1]
-            dtype = node.inputs[idx + 1].dtype
-            check.append(
-                "if(!((npy_%(dtype)s*)PyArray_DATA(%(i)s))[0])"
-                '{PyErr_SetString(PyExc_AssertionError,"%(msg)s");'
-                "%(fail)s}" % locals()
-            )
-        check = "\n".join(check)
-        return f"""
-        {check}
-        Py_XDECREF({out});
-        {out} = {value};
-        Py_INCREF({value});
-        """
-
-    def c_code_cache_version(self):
-        return (3, 0)
-
-    def infer_shape(self, fgraph, node, input_shapes):
-        return [input_shapes[0]]
-
-
-assert_op = Assert()
+from aesara.raise_op import Assert, assert_op  # noqa: F401 E402

--- a/aesara/gpuarray/dnn.py
+++ b/aesara/gpuarray/dnn.py
@@ -11,7 +11,6 @@ import aesara
 import aesara.gpuarray.pathparse
 import aesara.tensor.basic as aet
 import aesara.tensor.math as tm
-from aesara.assert_op import Assert
 from aesara.compile.io import Out
 from aesara.compile.mode import Mode
 from aesara.configdefaults import SUPPORTED_DNN_CONV_ALGO_RUNTIME, config
@@ -33,6 +32,7 @@ from aesara.graph.op import ExternalCOp, _NoPythonCOp, _NoPythonExternalCOp
 from aesara.graph.params_type import ParamsType
 from aesara.graph.type import CDataType, EnumList, Generic
 from aesara.link.c.cmodule import GCC_compiler
+from aesara.raise_op import Assert
 from aesara.scalar import as_scalar
 from aesara.scalar import bool as bool_t
 from aesara.scalar import constant, get_scalar_type

--- a/aesara/gpuarray/opt.py
+++ b/aesara/gpuarray/opt.py
@@ -13,7 +13,6 @@ import aesara.tensor.signal.pool as pool
 import aesara.tensor.slinalg as slinalg
 from aesara import scalar as aes
 from aesara import tensor as aet
-from aesara.assert_op import Assert
 from aesara.breakpoint import PdbBreakpoint
 from aesara.compile import optdb
 from aesara.configdefaults import config
@@ -162,6 +161,7 @@ from aesara.graph.opt import (
 from aesara.ifelse import IfElse
 from aesara.link.c.basic import CLinker
 from aesara.misc.ordered_set import OrderedSet
+from aesara.raise_op import Assert
 from aesara.scalar.basic import Cast, Pow, Scalar, log, neg, true_div
 from aesara.scalar.math import Erfcinv, Erfinv
 from aesara.scan.op import Scan

--- a/aesara/graph/opt.py
+++ b/aesara/graph/opt.py
@@ -21,7 +21,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import numpy as np
 
 import aesara
-from aesara.assert_op import Assert, assert_op
+from aesara.assert_op import Assert
 from aesara.configdefaults import config
 from aesara.graph import destroyhandler as dh
 from aesara.graph.basic import (
@@ -563,24 +563,25 @@ class MergeFeature(Feature):
 
             merge_candidates = [c for c, i in clients if c in self.nodes_seen]
 
-            # Put all clients of Assert inputs (if exist) into merge_candidates
-            # TODO: Deactivated for now as this cause cycle in the graph.
-            # (There is a second deactivation part below.)
-            for i in []:  # node.inputs:
-                if i.owner and isinstance(i.owner.op, Assert):
-                    node_has_assert = True
-                    i_clients = fgraph.clients[i.owner.inputs[0]]
-                    assert_clients = [c for (c, _) in i_clients if c in self.nodes_seen]
-
-                    for idx in range(len(assert_clients)):
-                        client = assert_clients[idx]
-                        if isinstance(i.owner.op, Assert):
-                            o_clients = fgraph.clients[client.outputs[0]]
-                            for c in o_clients:
-                                if c[0] in self.nodes_seen:
-                                    assert_clients.append(c[0])
-
-                    merge_candidates.extend(assert_clients)
+            # Put all clients of `CheckAndRaise` inputs (if exist) into
+            # `merge_candidates`
+            # TODO: Deactivated for now, because it can create cycles in a
+            # graph.  (There is a second deactivation part below.)
+            # for i in node.inputs:
+            #     if i.owner and isinstance(i.owner.op, CheckAndRaise):
+            #         node_has_assert = True
+            #         i_clients = fgraph.clients[i.owner.inputs[0]]
+            #         assert_clients = [c for (c, _) in i_clients if c in self.nodes_seen]
+            #
+            #         for idx in range(len(assert_clients)):
+            #             client = assert_clients[idx]
+            #             if isinstance(i.owner.op, CheckAndRaise):
+            #                 o_clients = fgraph.clients[client.outputs[0]]
+            #                 for c in o_clients:
+            #                     if c[0] in self.nodes_seen:
+            #                         assert_clients.append(c[0])
+            #
+            #         merge_candidates.extend(assert_clients)
         else:
             # If two nodes have no input, but perform the same operation,
             # they are not always constant-folded, so we want to merge them.
@@ -598,29 +599,31 @@ class MergeFeature(Feature):
 
             # Get input list of the candidate with assert removed
             cand_inputs_assert_removed = []
-            # TODO: Deactivated while Assert merging is disabled. (See above and below.)
-            for i in []:  # candidate.inputs:
-                if i.owner and isinstance(i.owner.op, Assert):
-                    cand_has_assert = True
-                    cand_inputs_assert_removed.append(i.owner.inputs[0])
-                else:
-                    cand_inputs_assert_removed.append(i)
+            # TODO: Deactivated while `CheckAndRaise` merging is disabled. (See
+            # above and below.)
+            # for i in candidate.inputs:
+            #     if i.owner and isinstance(i.owner.op, CheckAndRaise):
+            #         cand_has_assert = True
+            #         cand_inputs_assert_removed.append(i.owner.inputs[0])
+            #     else:
+            #         cand_inputs_assert_removed.append(i)
 
-            # TODO: Remove this when Assert merging is re-enabled. (See above.)
-            # Without Assert merging we can still look for identical Asserts,
-            # so we should not treat Asserts separately for now.
+            # TODO: Remove this when `CheckAndRaise` merging is
+            # re-enabled. (See above.)  Without `CheckAndRaise` merging we can
+            # still look for identical `CheckAndRaise`, so we should not treat
+            # `CheckAndRaise`s separately for now.
             cand_inputs_assert_removed = candidate.inputs
 
             # Get input list of the node with assert removed
-            if node_has_assert:
-                node_inputs_assert_removed = []
-                for i in node.inputs:
-                    if i.owner and isinstance(i.owner.op, Assert):
-                        node_inputs_assert_removed.append(i.owner.inputs[0])
-                    else:
-                        node_inputs_assert_removed.append(i)
-            else:
-                node_inputs_assert_removed = node.inputs
+            # if node_has_assert:
+            #     node_inputs_assert_removed = []
+            #     for i in node.inputs:
+            #         if i.owner and isinstance(i.owner.op, CheckAndRaise):
+            #             node_inputs_assert_removed.append(i.owner.inputs[0])
+            #         else:
+            #             node_inputs_assert_removed.append(i)
+            # else:
+            node_inputs_assert_removed = node.inputs
 
             inputs_match = all(
                 node_in is cand_in
@@ -635,7 +638,7 @@ class MergeFeature(Feature):
                     continue
 
                 # replace node with candidate
-                if not (node_has_assert or cand_has_assert):
+                if not node_has_assert and not cand_has_assert:
                     # Schedule transfer of clients from node to candidate
                     pairs = list(
                         zip(
@@ -645,32 +648,32 @@ class MergeFeature(Feature):
                         )
                     )
 
-                # if the current node has assert input, it should not be
-                # replaced with a candidate node which has no assert input
-                elif node_has_assert and not cand_has_assert:
-                    pairs = list(
-                        zip(
-                            candidate.outputs,
-                            node.outputs,
-                            ["merge"] * len(node.outputs),
-                        )
-                    )
-                else:
-                    new_inputs = self.get_merged_assert_input(node, candidate)
-                    new_node = node.op(*new_inputs)
-                    pairs = list(
-                        zip(
-                            node.outputs,
-                            new_node.owner.outputs,
-                            ["new_node"] * len(node.outputs),
-                        )
-                    ) + list(
-                        zip(
-                            candidate.outputs,
-                            new_node.owner.outputs,
-                            ["new_node"] * len(node.outputs),
-                        )
-                    )
+                # # if the current node has assert input, it should not be
+                # # replaced with a candidate node which has no assert input
+                # elif node_has_assert and not cand_has_assert:
+                #     pairs = list(
+                #         zip(
+                #             candidate.outputs,
+                #             node.outputs,
+                #             ["merge"] * len(node.outputs),
+                #         )
+                #     )
+                # else:
+                #     new_inputs = self.get_merged_assert_input(node, candidate)
+                #     new_node = node.op(*new_inputs)
+                #     pairs = list(
+                #         zip(
+                #             node.outputs,
+                #             new_node.owner.outputs,
+                #             ["new_node"] * len(node.outputs),
+                #         )
+                #     ) + list(
+                #         zip(
+                #             candidate.outputs,
+                #             new_node.owner.outputs,
+                #             ["new_node"] * len(node.outputs),
+                #         )
+                #     )
 
                 # transfer names
                 for pair in pairs:
@@ -689,29 +692,35 @@ class MergeFeature(Feature):
             if not node.inputs:
                 self.noinput_nodes.add(node)
 
-    def get_merged_assert_input(self, node, candidate):
-        new_inputs = []
-        for node_i, cand_i in zip(node.inputs, candidate.inputs):
-            # if node_i is assert
-            if node_i.owner and isinstance(node_i.owner.op, Assert):
-                # node_i is assert, cand_i is assert
-                if cand_i.owner and isinstance(cand_i.owner.op, Assert):
-                    # Here two assert nodes are merged.
-                    # Step 1. Merge conditions of both assert nodes.
-                    # Step 2. Make the new assert node
-                    node_cond = node_i.owner.inputs[1:]
-                    cand_cond = cand_i.owner.inputs[1:]
-                    new_cond = list(set(node_cond + cand_cond))
-                    new_inputs.append(assert_op(node_i.owner.inputs[0], *new_cond))
-
-                # node_i is assert, cand_i is not assert
-                else:
-                    new_inputs.append(node_i)
-            else:
-                # if node_i is not an assert node, append cand_i
-                new_inputs.append(cand_i)
-
-        return new_inputs
+    # def get_merged_assert_input(self, node, candidate):
+    #     new_inputs = []
+    #     for node_i, cand_i in zip(node.inputs, candidate.inputs):
+    #         if node_i.owner and isinstance(node_i.owner.op, CheckAndRaise):
+    #             if (
+    #                 cand_i.owner
+    #                 and isinstance(cand_i.owner.op, CheckAndRaise)
+    #                 and node_i.owner.op.exc_type == cand_i.owner.op.exc_type
+    #             ):
+    #                 # Here two assert nodes are merged.
+    #                 # Step 1. Merge conditions of both assert nodes.
+    #                 # Step 2. Make the new assert node
+    #                 node_cond = node_i.owner.inputs[1:]
+    #                 cand_cond = cand_i.owner.inputs[1:]
+    #                 new_cond = list(set(node_cond + cand_cond))
+    #                 new_raise_op = CheckAndRaise(
+    #                     node_i.owner.op.exc_type,
+    #                     "; ".join([node_i.owner.op.msg, cand_i.owner.op.msg]),
+    #                 )
+    #                 new_inputs.append(new_raise_op(*(node_i.owner.inputs[:1] + new_cond)))
+    #
+    #             # node_i is assert, cand_i is not assert
+    #             else:
+    #                 new_inputs.append(node_i)
+    #         else:
+    #             # if node_i is not an assert node, append cand_i
+    #             new_inputs.append(cand_i)
+    #
+    #     return new_inputs
 
 
 class MergeOptimizer(GlobalOptimizer):

--- a/aesara/graph/opt.py
+++ b/aesara/graph/opt.py
@@ -21,7 +21,6 @@ from typing import Dict, List, Optional, Tuple, Union
 import numpy as np
 
 import aesara
-from aesara.assert_op import Assert
 from aesara.configdefaults import config
 from aesara.graph import destroyhandler as dh
 from aesara.graph.basic import (
@@ -37,6 +36,7 @@ from aesara.graph.fg import FunctionGraph, InconsistencyError
 from aesara.graph.op import Op
 from aesara.graph.utils import AssocList
 from aesara.misc.ordered_set import OrderedSet
+from aesara.raise_op import CheckAndRaise
 from aesara.utils import flatten
 
 
@@ -783,7 +783,7 @@ class MergeOptimizer(GlobalOptimizer):
                     # nodes removed
                     cand_inputs_assert_removed = []
                     for i in candidate.inputs:
-                        if i.owner and isinstance(i.owner.op, Assert):
+                        if i.owner and isinstance(i.owner.op, CheckAndRaise):
                             cand_inputs_assert_removed.append(i.owner.inputs[0])
                         else:
                             cand_inputs_assert_removed.append(i)
@@ -791,7 +791,7 @@ class MergeOptimizer(GlobalOptimizer):
                     # Get input list of the node with assert nodes removed
                     node_inputs_assert_removed = []
                     for i in node.inputs:
-                        if i.owner and isinstance(i.owner.op, Assert):
+                        if i.owner and isinstance(i.owner.op, CheckAndRaise):
                             node_inputs_assert_removed.append(i.owner.inputs[0])
                         else:
                             node_inputs_assert_removed.append(i)

--- a/aesara/graph/type.py
+++ b/aesara/graph/type.py
@@ -274,15 +274,16 @@ class CType(Type, CLinkerType):
 
 
 class Generic(CType, Singleton):
-    """
-    Represents a generic Python object.
+    r"""A type for a generic Python object exposed directly in C.
 
     This class implements the `CType` and `CLinkerType` interfaces
-    for generic PyObject instances.
+    for generic ``PyObject`` instances.
 
-    EXAMPLE of what this means, or when you would use this type.
+    It can be used to easily expose Python objects to `COp`\s.
 
-    WRITEME
+    For example, ``obj_const = Constant(Generic(), my_obj)`` will construct
+    an Aesara constant that can be used to access the Python object ``my_obj``
+    directly in a `COp` (e.g. as a ``PyObject *``).
 
     """
 

--- a/aesara/raise_op.py
+++ b/aesara/raise_op.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from aesara.gradient import DisconnectedType
 from aesara.graph.basic import Apply, Variable
-from aesara.graph.op import COp, Op
+from aesara.graph.op import COp
 from aesara.graph.params_type import ParamsType
 from aesara.graph.type import Generic
 
@@ -21,29 +21,6 @@ class ExceptionType(Generic):
 
 
 exception_type = ExceptionType()
-
-
-class Raise(Op):
-    """Op whose perform() raises an exception."""
-
-    __props__ = ("msg", "exc")
-
-    def __init__(self, msg="", exc=NotImplementedError):
-        """
-        msg - the argument to the exception
-        exc - an exception class to raise in self.perform
-        """
-        self.msg = msg
-        self.exc = exc
-
-    def __str__(self):
-        return f"Raise{{{self.exc}({self.msg})}}"
-
-    def make_node(self, x):
-        return Apply(self, [x], [x.type()])
-
-    def perform(self, node, inputs, out_storage):
-        raise self.exc(self.msg)
 
 
 class CheckAndRaise(COp):

--- a/aesara/raise_op.py
+++ b/aesara/raise_op.py
@@ -1,14 +1,26 @@
 """Symbolic Op for raising an exception."""
 
-from aesara.graph.basic import Apply
-from aesara.graph.op import Op
+from textwrap import indent
+from typing import Tuple
+
+import numpy as np
+
+from aesara.gradient import DisconnectedType
+from aesara.graph.basic import Apply, Variable
+from aesara.graph.op import COp, Op
+from aesara.graph.params_type import ParamsType
+from aesara.graph.type import Generic
 
 
-__authors__ = "James Bergstra " "PyMC Dev Team " "Aesara Developers"
-__copyright__ = "(c) 2011, Universite de Montreal"
-__license__ = "3-clause BSD License"
+class ExceptionType(Generic):
+    def __eq__(self, other):
+        return type(self) == type(other)
 
-__docformat__ = "restructuredtext en"
+    def __hash__(self):
+        return hash(type(self))
+
+
+exception_type = ExceptionType()
 
 
 class Raise(Op):
@@ -32,3 +44,151 @@ class Raise(Op):
 
     def perform(self, node, inputs, out_storage):
         raise self.exc(self.msg)
+
+
+class CheckAndRaise(COp):
+    """An `Op` that checks conditions and raises an exception if they fail.
+
+    This `Op` returns its "value" argument if its condition arguments are all
+    ``True``; otherwise, it raises a user-specified exception.
+
+    """
+
+    _f16_ok = True
+    __props__ = ("msg", "exc_type")
+    view_map = {0: [0]}
+
+    check_input = False
+    params_type = ParamsType(exc_type=exception_type)
+
+    def __init__(self, exc_type, msg=""):
+
+        if not issubclass(exc_type, Exception):
+            raise ValueError("`exc_type` must be an Exception subclass")
+
+        self.exc_type = exc_type
+        self.msg = msg
+
+    def __str__(self):
+        return f"CheckAndRaise{{{self.exc_type}({self.msg})}}"
+
+    def __eq__(self, other):
+        if type(self) != type(other):
+            return False
+
+        if self.msg == other.msg and self.exc_type == other.exc_type:
+            return True
+
+        return False
+
+    def __hash__(self):
+        return hash((self.msg, self.exc_type))
+
+    def make_node(self, value: Variable, *conds: Tuple[Variable]):
+        """
+
+        Parameters
+        ==========
+        value
+            The value to return if `conds` all evaluate to ``True``; otherwise,
+            `self.exc_type` is raised.
+        conds
+            The conditions to evaluate.
+        """
+        import aesara.tensor as at
+
+        if not isinstance(value, Variable):
+            value = at.as_tensor_variable(value)
+
+        conds = [at.as_tensor_variable(c) for c in conds]
+
+        assert all(c.type.ndim == 0 for c in conds)
+
+        return Apply(
+            self,
+            [value] + conds,
+            [value.type()],
+        )
+
+    def perform(self, node, inputs, outputs, params):
+        (out,) = outputs
+        val, *conds = inputs
+        out[0] = val
+        if not np.all(conds):
+            raise self.exc_type(self.msg)
+
+    def grad(self, input, output_gradients):
+        return output_gradients + [DisconnectedType()()] * (len(input) - 1)
+
+    def connection_pattern(self, node):
+        return [[1]] + [[0]] * (len(node.inputs) - 1)
+
+    def c_code(self, node, name, inames, onames, props):
+        value_name, *cond_names = inames
+        out_name = onames[0]
+        check = []
+        fail_code = props["fail"]
+        param_struct_name = props["params"]
+        msg = self.msg.replace('"', '\\"').replace("\n", "\\n")
+        for idx, cond_name in enumerate(cond_names):
+            check.append(
+                f"""
+        if(PyObject_IsTrue((PyObject *){cond_name}) == 0) {{
+            PyObject * exc_type = {param_struct_name}->exc_type;
+            Py_INCREF(exc_type);
+            PyErr_SetString(exc_type, "{msg}");
+            Py_XDECREF(exc_type);
+            {indent(fail_code, " " * 4)}
+        }}
+                """
+            )
+        check = "\n".join(check)
+        res = f"""
+        {check}
+        Py_XDECREF({out_name});
+        {out_name} = {value_name};
+        Py_INCREF({value_name});
+        """
+        return res
+
+    def c_code_cache_version(self):
+        return (1, 0)
+
+    def infer_shape(self, fgraph, node, input_shapes):
+        return [input_shapes[0]]
+
+
+class Assert(CheckAndRaise):
+    """Implements assertion in a computational graph.
+
+    Returns the first parameter if the condition is ``True``; otherwise,
+    triggers `AssertionError`.
+
+    Notes
+    -----
+    This `Op` is a debugging feature. It can be removed from the graph
+    because of optimizations, and can hide some possible optimizations to
+    the optimizer. Specifically, removing happens if it can be determined
+    that condition will always be true. Also, the output of the Op must be
+    used in the function computing the graph, but it doesn't have to be
+    returned.
+
+    Examples
+    --------
+    >>> import aesara
+    >>> import aesara.tensor as aet
+    >>> from aesara.raise_op import Assert
+    >>> x = aet.vector("x")
+    >>> assert_op = Assert("This assert failed")
+    >>> func = aesara.function([x], assert_op(x, x.size < 2))
+
+    """
+
+    def __init__(self, msg="Aesara Assert failed!"):
+        super().__init__(AssertionError, msg)
+
+    def __str__(self):
+        return f"Assert{{msg={self.msg}}}"
+
+
+assert_op = Assert()

--- a/aesara/tensor/extra_ops.py
+++ b/aesara/tensor/extra_ops.py
@@ -4,7 +4,6 @@ from typing import Iterable, Tuple, Union
 import numpy as np
 
 import aesara
-from aesara.assert_op import Assert
 from aesara.gradient import (
     DisconnectedType,
     _float_zeros_like,
@@ -16,6 +15,7 @@ from aesara.graph.op import COp, Op
 from aesara.graph.params_type import ParamsType
 from aesara.graph.type import EnumList, Generic
 from aesara.misc.safe_asarray import _asarray
+from aesara.raise_op import Assert
 from aesara.scalar import int32 as int_t
 from aesara.scalar import upcast
 from aesara.tensor import basic as aet

--- a/aesara/tensor/math_opt.py
+++ b/aesara/tensor/math_opt.py
@@ -9,7 +9,6 @@ import numpy as np
 
 import aesara.scalar.basic as aes
 import aesara.scalar.math as aes_math
-from aesara.assert_op import assert_op
 from aesara.graph.basic import Constant, Variable
 from aesara.graph.opt import (
     LocalOptGroup,
@@ -21,6 +20,7 @@ from aesara.graph.opt import (
 )
 from aesara.graph.opt_utils import get_clients_at_depth
 from aesara.misc.safe_asarray import _asarray
+from aesara.raise_op import assert_op
 from aesara.tensor.basic import (
     Alloc,
     Join,

--- a/aesara/tensor/nnet/abstract_conv.py
+++ b/aesara/tensor/nnet/abstract_conv.py
@@ -20,10 +20,10 @@ from scipy.signal.sigtools import _convolve2d
 
 import aesara
 from aesara import tensor as aet
-from aesara.assert_op import Assert
 from aesara.configdefaults import config
 from aesara.graph.basic import Apply, Variable
 from aesara.graph.op import Op
+from aesara.raise_op import Assert
 from aesara.tensor.basic import (
     as_tensor_variable,
     get_scalar_constant_value,

--- a/aesara/tensor/nnet/basic.py
+++ b/aesara/tensor/nnet/basic.py
@@ -19,12 +19,12 @@ import numpy as np
 
 import aesara
 from aesara import scalar as aes
-from aesara.assert_op import Assert
 from aesara.compile import optdb
 from aesara.gradient import DisconnectedType, grad_not_implemented
 from aesara.graph.basic import Apply
 from aesara.graph.op import COp, Op
 from aesara.graph.opt import copy_stack_trace, local_optimizer, optimizer
+from aesara.raise_op import Assert
 from aesara.scalar import UnaryScalarOp
 
 # Work-around for Python 3.6 issue that prevents `import aesara.tensor as aet`

--- a/aesara/tensor/subtensor_opt.py
+++ b/aesara/tensor/subtensor_opt.py
@@ -6,9 +6,9 @@ import numpy as np
 import aesara
 import aesara.scalar.basic as aes
 from aesara import compile
-from aesara.assert_op import Assert
 from aesara.graph.basic import Constant, Variable
 from aesara.graph.opt import TopoOptimizer, copy_stack_trace, in2out, local_optimizer
+from aesara.raise_op import Assert
 from aesara.tensor.basic import (
     Alloc,
     ARange,

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,11 @@ omit =
     aesara/_version.py
     aesara/gpuarray/*
     tests/*
+    aesara/assert_op.py
+    aesara/link/jax/jax_linker.py
+    aesara/link/jax/jax_dispatch.py
+    aesara/graph/toolbox.py
+    aesara/scalar/basic_scipy.py
 branch = True
 relative_files = true
 

--- a/tests/gpuarray/test_opt.py
+++ b/tests/gpuarray/test_opt.py
@@ -5,7 +5,6 @@ import aesara
 import aesara.gpuarray
 import aesara.tensor.slinalg as slinalg
 from aesara import tensor as aet
-from aesara.assert_op import Assert, assert_op
 from aesara.breakpoint import PdbBreakpoint
 from aesara.configdefaults import config
 from aesara.gpuarray import basic_ops, blas, dnn, opt
@@ -30,6 +29,7 @@ from aesara.gpuarray.linalg import GpuCholesky, GpuCusolverSolve, cusolver_avail
 from aesara.gpuarray.subtensor import GpuSubtensor
 from aesara.gpuarray.type import GpuArrayType, get_context, gpuarray_shared_constructor
 from aesara.graph.opt import check_stack_trace
+from aesara.raise_op import Assert, assert_op
 from aesara.tensor.basic import Alloc, AllocEmpty, MakeVector, Rebroadcast
 from aesara.tensor.blas import batched_dot
 from aesara.tensor.math import dot, eq, exp, gt, tanh

--- a/tests/graph/test_opt.py
+++ b/tests/graph/test_opt.py
@@ -1,6 +1,5 @@
 import pytest
 
-from aesara.assert_op import assert_op
 from aesara.configdefaults import config
 from aesara.graph.basic import Apply, Constant, equal_computations
 from aesara.graph.features import Feature
@@ -19,6 +18,7 @@ from aesara.graph.opt import (
     pre_constant_merge,
     pre_greedy_local_optimizer,
 )
+from aesara.raise_op import assert_op
 from aesara.tensor.basic_opt import constant_folding
 from aesara.tensor.math import Dot, add, dot
 from aesara.tensor.subtensor import AdvancedSubtensor

--- a/tests/graph/utils.py
+++ b/tests/graph/utils.py
@@ -62,7 +62,7 @@ class MyOp(Op):
         return Apply(self, inputs, outputs)
 
     def perform(self, node, inputs, outputs):
-        outputs[0] = np.array(inputs, dtype=np.object)
+        outputs[0] = np.array(inputs, dtype=object)
 
     def __str__(self):
         return self.name

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -20,7 +20,6 @@ from tempfile import mkdtemp
 import numpy as np
 import pytest
 
-from aesara.assert_op import assert_op
 from aesara.compile.debugmode import DebugMode
 from aesara.compile.function import function
 from aesara.compile.function.pfunc import rebuild_collect_shared
@@ -41,6 +40,7 @@ from aesara.graph.basic import Apply, clone_replace, graph_inputs
 from aesara.graph.fg import MissingInputError
 from aesara.graph.op import Op
 from aesara.misc.safe_asarray import _asarray
+from aesara.raise_op import assert_op
 from aesara.scan.basic import scan
 from aesara.scan.op import Scan
 from aesara.scan.opt import ScanMerge

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -3,8 +3,8 @@ from pytest import fixture, raises
 
 import aesara.tensor as aet
 from aesara import config
-from aesara.assert_op import Assert
 from aesara.gradient import NullTypeGradError, grad
+from aesara.raise_op import Assert
 from aesara.tensor.math import eq
 from aesara.tensor.random.op import RandomVariable, default_shape_from_params
 from aesara.tensor.shape import specify_shape

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -13,7 +13,6 @@ import aesara.scalar as aes
 import aesara.tensor.basic as aet
 import aesara.tensor.math as tm
 from aesara import compile, config, function, shared
-from aesara.assert_op import Assert
 from aesara.compile.io import In, Out
 from aesara.compile.mode import get_default_mode
 from aesara.compile.ops import DeepCopyOp
@@ -21,6 +20,7 @@ from aesara.gradient import grad, hessian
 from aesara.graph.basic import Apply
 from aesara.graph.op import Op
 from aesara.misc.safe_asarray import _asarray
+from aesara.raise_op import Assert
 from aesara.scalar import autocast_float, autocast_float_as
 from aesara.tensor.basic import (
     Alloc,

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -4,12 +4,12 @@ import pytest
 import aesara
 from aesara import function
 from aesara import tensor as aet
-from aesara.assert_op import Assert
 from aesara.compile.mode import Mode
 from aesara.configdefaults import config
 from aesara.gradient import grad
 from aesara.graph.basic import applys_between
 from aesara.graph.optdb import OptimizationQuery
+from aesara.raise_op import Assert
 from aesara.tensor.elemwise import DimShuffle
 from aesara.tensor.extra_ops import (
     Bartlett,

--- a/tests/tensor/test_subtensor_opt.py
+++ b/tests/tensor/test_subtensor_opt.py
@@ -5,7 +5,6 @@ import aesara
 import aesara.scalar as aes
 import aesara.tensor as aet
 from aesara import shared
-from aesara.assert_op import Assert
 from aesara.compile.function import function
 from aesara.compile.mode import Mode, get_default_mode, get_mode
 from aesara.compile.ops import DeepCopyOp
@@ -15,6 +14,7 @@ from aesara.graph.opt import check_stack_trace
 from aesara.graph.opt_utils import optimize_graph
 from aesara.graph.optdb import OptimizationQuery
 from aesara.graph.type import Type
+from aesara.raise_op import Assert
 from aesara.tensor import inplace
 from aesara.tensor.basic import (
     Alloc,

--- a/tests/test_raise_op.py
+++ b/tests/test_raise_op.py
@@ -1,0 +1,90 @@
+import numpy as np
+import pytest
+
+import aesara
+import aesara.tensor as at
+from aesara.compile.mode import OPT_FAST_RUN, Mode
+from aesara.graph.basic import Constant, equal_computations
+from aesara.raise_op import CheckAndRaise, assert_op
+
+
+class CustomException(ValueError):
+    """A custom user-created exception to throw."""
+
+
+def test_CheckAndRaise_str():
+    exc_msg = "this is the exception"
+    check_and_raise = CheckAndRaise(CustomException, exc_msg)
+    assert (
+        str(check_and_raise)
+        == f"CheckAndRaise{{{CustomException}(this is the exception)}}"
+    )
+
+
+def test_CheckAndRaise_pickle():
+    import pickle
+
+    exc_msg = "this is the exception"
+    check_and_raise = CheckAndRaise(CustomException, exc_msg)
+
+    y = check_and_raise(at.as_tensor(1), at.as_tensor(0))
+    y_str = pickle.dumps(y)
+    new_y = pickle.loads(y_str)
+
+    assert y.owner.op == new_y.owner.op
+    assert y.owner.op.msg == new_y.owner.op.msg
+    assert y.owner.op.exc_type == new_y.owner.op.exc_type
+
+
+def test_CheckAndRaise_equal():
+    x, y = at.vectors("xy")
+    g1 = assert_op(x, (x > y).all())
+    g2 = assert_op(x, (x > y).all())
+
+    assert equal_computations([g1], [g2])
+
+
+def test_CheckAndRaise_validation():
+
+    with pytest.raises(ValueError):
+        CheckAndRaise(str)
+
+    g1 = assert_op(np.array(1.0))
+    assert isinstance(g1.owner.inputs[0], Constant)
+
+
+@pytest.mark.parametrize(
+    "linker",
+    [
+        pytest.param(
+            "cvm",
+            marks=pytest.mark.skipif(
+                not aesara.config.cxx,
+                reason="G++ not available, so we need to skip this test.",
+            ),
+        ),
+        "py",
+    ],
+)
+def test_CheckAndRaise_basic_c(linker):
+    exc_msg = "this is the exception"
+    check_and_raise = CheckAndRaise(CustomException, exc_msg)
+
+    x = at.scalar()
+    conds = at.scalar()
+    y = check_and_raise(at.as_tensor(1), conds)
+    y_fn = aesara.function([conds], y, mode=Mode(linker))
+
+    with pytest.raises(CustomException, match=exc_msg):
+        y_fn(0)
+
+    y = check_and_raise(at.as_tensor(1), conds)
+    y_fn = aesara.function([conds], y.shape, mode=Mode(linker, OPT_FAST_RUN))
+
+    assert np.array_equal(y_fn(0), [])
+
+    y = check_and_raise(x, at.as_tensor(0))
+    y_grad = aesara.grad(y, [x])
+    y_fn = aesara.function([x], y_grad, mode=Mode(linker, OPT_FAST_RUN))
+
+    assert np.array_equal(y_fn(1.0), [1.0])


### PR DESCRIPTION
This PR introduces a `CheckAndRaise` `Op` that behaves like a more configurable version of `Assert` by allowing one to specify an `Exception` type for each instance.