### PR TITLE
Split `solve_triangular` functionality from the `Solve` class into separate `SolveTriangular` class

### DIFF
--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -2174,6 +2174,31 @@ def test_Cholesky(x, lower, exc):
             "gen",
             None,
         ),
+    ],
+)
+def test_Solve(A, x, lower, exc):
+    g = slinalg.Solve(lower)(A, x)
+
+    if isinstance(g, list):
+        g_fg = FunctionGraph(outputs=g)
+    else:
+        g_fg = FunctionGraph(outputs=[g])
+
+    cm = contextlib.suppress() if exc is None else pytest.warns(exc)
+    with cm:
+        compare_numba_and_py(
+            g_fg,
+            [
+                i.tag.test_value
+                for i in g_fg.inputs
+                if not isinstance(i, (SharedVariable, Constant))
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    "A, x, lower, exc",
+    [
         (
             set_test_value(
                 aet.dmatrix(),
@@ -2185,8 +2210,8 @@ def test_Cholesky(x, lower, exc):
         ),
     ],
 )
-def test_Solve(A, x, lower, exc):
-    g = slinalg.Solve(lower)(A, x)
+def test_SolveTriangular(A, x, lower, exc):
+    g = slinalg.SolveTriangular(lower)(A, x)
 
     if isinstance(g, list):
         g_fg = FunctionGraph(outputs=g)

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -1,3 +1,4 @@
+import functools
 import itertools
 
 import numpy as np
@@ -14,12 +15,15 @@ from aesara.tensor.slinalg import (
     CholeskyGrad,
     CholeskySolve,
     Solve,
+    SolveBase,
+    SolveTriangular,
     cho_solve,
     cholesky,
     eigvalsh,
     expm,
     kron,
     solve,
+    solve_triangular,
 )
 from aesara.tensor.type import dmatrix, matrix, tensor, vector
 from tests import unittest_tools as utt
@@ -170,121 +174,106 @@ def test_eigvalsh_grad():
     )
 
 
+class TestSolveBase(utt.InferShapeTester):
+    @pytest.mark.parametrize(
+        "A_func, b_func, error_message",
+        [
+            (vector, matrix, "`A` must be a matrix.*"),
+            (
+                functools.partial(tensor, dtype="floatX", broadcastable=(False,) * 3),
+                matrix,
+                "`A` must be a matrix.*",
+            ),
+            (
+                matrix,
+                functools.partial(tensor, dtype="floatX", broadcastable=(False,) * 3),
+                "`b` must be a matrix or a vector.*",
+            ),
+        ],
+    )
+    def test_make_node(self, A_func, b_func, error_message):
+        np.random.default_rng(utt.fetch_seed())
+        with pytest.raises(ValueError, match=error_message):
+            A = A_func()
+            b = b_func()
+            SolveBase()(A, b)
+
+    def test__repr__(self):
+        np.random.default_rng(utt.fetch_seed())
+        A = matrix()
+        b = matrix()
+        y = SolveBase()(A, b)
+        assert y.__repr__() == "SolveBase{lower=False, check_finite=True}.0"
+
+
 class TestSolve(utt.InferShapeTester):
-    def setup_method(self):
-        self.op_class = Solve
-        self.op = Solve()
-        super().setup_method()
+    def test__init__(self):
+        with pytest.raises(ValueError) as excinfo:
+            Solve(assume_a="test")
+        assert "is not a recognized matrix structure" in str(excinfo.value)
 
-    def test_infer_shape(self):
+    @pytest.mark.parametrize("b_shape", [(5, 1), (5,)])
+    def test_infer_shape(self, b_shape):
         rng = np.random.default_rng(utt.fetch_seed())
         A = matrix()
-        b = matrix()
+        b_val = np.asarray(rng.random(b_shape), dtype=config.floatX)
+        b = aet.as_tensor_variable(b_val).type()
         self._compile_and_check(
-            [A, b],  # aesara.function inputs
-            [self.op(A, b)],  # aesara.function outputs
-            # A must be square
+            [A, b],
+            [solve(A, b)],
             [
                 np.asarray(rng.random((5, 5)), dtype=config.floatX),
-                np.asarray(rng.random((5, 1)), dtype=config.floatX),
+                b_val,
             ],
-            self.op_class,
-            warn=False,
-        )
-        rng = np.random.default_rng(utt.fetch_seed())
-        A = matrix()
-        b = vector()
-        self._compile_and_check(
-            [A, b],  # aesara.function inputs
-            [self.op(A, b)],  # aesara.function outputs
-            # A must be square
-            [
-                np.asarray(rng.random((5, 5)), dtype=config.floatX),
-                np.asarray(rng.random((5)), dtype=config.floatX),
-            ],
-            self.op_class,
+            Solve,
             warn=False,
         )
 
-    def test_solve_correctness(self):
+    def test_correctness(self):
         rng = np.random.default_rng(utt.fetch_seed())
         A = matrix()
         b = matrix()
-        y = self.op(A, b)
+        y = solve(A, b)
         gen_solve_func = aesara.function([A, b], y)
-
-        cholesky_lower = Cholesky(lower=True)
-        L = cholesky_lower(A)
-        y_lower = self.op(L, b)
-        lower_solve_func = aesara.function([L, b], y_lower)
-
-        cholesky_upper = Cholesky(lower=False)
-        U = cholesky_upper(A)
-        y_upper = self.op(U, b)
-        upper_solve_func = aesara.function([U, b], y_upper)
 
         b_val = np.asarray(rng.random((5, 1)), dtype=config.floatX)
 
-        # 1-test general case
         A_val = np.asarray(rng.random((5, 5)), dtype=config.floatX)
-        # positive definite matrix:
         A_val = np.dot(A_val.transpose(), A_val)
+
         assert np.allclose(
             scipy.linalg.solve(A_val, b_val), gen_solve_func(A_val, b_val)
         )
 
-        # 2-test lower traingular case
-        L_val = scipy.linalg.cholesky(A_val, lower=True)
+        A_undef = np.array(
+            [
+                [1, 0, 0, 0, 0],
+                [0, 1, 0, 0, 0],
+                [0, 0, 1, 0, 0],
+                [0, 0, 0, 1, 1],
+                [0, 0, 0, 1, 0],
+            ],
+            dtype=config.floatX,
+        )
         assert np.allclose(
-            scipy.linalg.solve_triangular(L_val, b_val, lower=True),
-            lower_solve_func(L_val, b_val),
+            scipy.linalg.solve(A_undef, b_val), gen_solve_func(A_undef, b_val)
         )
 
-        # 3-test upper traingular case
-        U_val = scipy.linalg.cholesky(A_val, lower=False)
-        assert np.allclose(
-            scipy.linalg.solve_triangular(U_val, b_val, lower=False),
-            upper_solve_func(U_val, b_val),
-        )
+    @pytest.mark.parametrize(
+        "m, n, assume_a, lower",
+        [
+            (5, None, "gen", False),
+            (5, None, "gen", True),
+            (4, 2, "gen", False),
+            (4, 2, "gen", True),
+        ],
+    )
+    def test_solve_grad(self, m, n, assume_a, lower):
+        rng = np.random.default_rng(utt.fetch_seed())
 
-    def test_solve_dtype(self):
-        dtypes = [
-            "uint8",
-            "uint16",
-            "uint32",
-            "uint64",
-            "int8",
-            "int16",
-            "int32",
-            "int64",
-            "float16",
-            "float32",
-            "float64",
-        ]
-
-        A_val = np.eye(2)
-        b_val = np.ones((2, 1))
-
-        # try all dtype combinations
-        for A_dtype, b_dtype in itertools.product(dtypes, dtypes):
-            A = matrix(dtype=A_dtype)
-            b = matrix(dtype=b_dtype)
-            x = solve(A, b)
-            fn = function([A, b], x)
-            x_result = fn(A_val.astype(A_dtype), b_val.astype(b_dtype))
-
-            assert x.dtype == x_result.dtype
-
-    def verify_solve_grad(self, m, n, assume_a, lower, rng):
-        # ensure diagonal elements of A relatively large to avoid numerical
-        # precision issues
+        # Ensure diagonal elements of `A` are relatively large to avoid
+        # numerical precision issues
         A_val = (rng.normal(size=(m, m)) * 0.5 + np.eye(m)).astype(config.floatX)
-
-        if assume_a != "gen":
-            if lower:
-                A_val = np.tril(A_val)
-            else:
-                A_val = np.triu(A_val)
 
         if n is None:
             b_val = rng.normal(size=m).astype(config.floatX)
@@ -298,22 +287,76 @@ class TestSolve(utt.InferShapeTester):
         solve_op = Solve(assume_a=assume_a, lower=lower)
         utt.verify_grad(solve_op, [A_val, b_val], 3, rng, eps=eps)
 
+
+class TestSolveTriangular(utt.InferShapeTester):
+    @pytest.mark.parametrize("b_shape", [(5, 1), (5,)])
+    def test_infer_shape(self, b_shape):
+        rng = np.random.default_rng(utt.fetch_seed())
+        A = matrix()
+        b_val = np.asarray(rng.random(b_shape), dtype=config.floatX)
+        b = aet.as_tensor_variable(b_val).type()
+        self._compile_and_check(
+            [A, b],
+            [solve_triangular(A, b)],
+            [
+                np.asarray(rng.random((5, 5)), dtype=config.floatX),
+                b_val,
+            ],
+            SolveTriangular,
+            warn=False,
+        )
+
+    @pytest.mark.parametrize("lower", [True, False])
+    def test_correctness(self, lower):
+        rng = np.random.default_rng(utt.fetch_seed())
+
+        b_val = np.asarray(rng.random((5, 1)), dtype=config.floatX)
+
+        A_val = np.asarray(rng.random((5, 5)), dtype=config.floatX)
+        A_val = np.dot(A_val.transpose(), A_val)
+
+        C_val = scipy.linalg.cholesky(A_val, lower=lower)
+
+        A = matrix()
+        b = matrix()
+
+        cholesky = Cholesky(lower=lower)
+        C = cholesky(A)
+        y_lower = solve_triangular(C, b, lower=lower)
+        lower_solve_func = aesara.function([C, b], y_lower)
+
+        assert np.allclose(
+            scipy.linalg.solve_triangular(C_val, b_val, lower=lower),
+            lower_solve_func(C_val, b_val),
+        )
+
     @pytest.mark.parametrize(
-        "m, n, assume_a, lower",
+        "m, n, lower",
         [
-            (5, None, "gen", False),
-            (5, None, "gen", True),
-            (4, 2, "gen", False),
-            (4, 2, "gen", True),
-            (5, None, "sym", False),
-            (5, None, "sym", True),
-            (4, 2, "sym", False),
-            (4, 2, "sym", True),
+            (5, None, False),
+            (5, None, True),
+            (4, 2, False),
+            (4, 2, True),
         ],
     )
-    def test_solve_grad(self, m, n, assume_a, lower):
+    def test_solve_grad(self, m, n, lower):
         rng = np.random.default_rng(utt.fetch_seed())
-        self.verify_solve_grad(m, n, assume_a, lower, rng)
+
+        # Ensure diagonal elements of `A` are relatively large to avoid
+        # numerical precision issues
+        A_val = (rng.normal(size=(m, m)) * 0.5 + np.eye(m)).astype(config.floatX)
+
+        if n is None:
+            b_val = rng.normal(size=m).astype(config.floatX)
+        else:
+            b_val = rng.normal(size=(m, n)).astype(config.floatX)
+
+        eps = None
+        if config.floatX == "float64":
+            eps = 2e-8
+
+        solve_op = SolveTriangular(lower=lower)
+        utt.verify_grad(solve_op, [A_val, b_val], 3, rng, eps=eps)
 
 
 class TestCholeskySolve(utt.InferShapeTester):


### PR DESCRIPTION
Split "solve_triangular" functionality from the Solve class into 
separate SolveTriangular class (in aesara.tensor.slinalg)

- Implementation of new class SolveTriangular
- Changing naming convention of Solve to match scipy
- Split of old tests to match the current classes
- new tests for Solve class to cover the case of the issue
- changed the deprecated "solve_lower_triangular" and 
"solve_upper_triangular" according to class split