### PR TITLE
Make `ScalarConstant` a subclass of `ScalarVariable`

### DIFF
--- a/aesara/scalar/basic.py
+++ b/aesara/scalar/basic.py
@@ -865,8 +865,9 @@ class ScalarVariable(_scalar_py_operators, Variable):
     pass
 
 
-class ScalarConstant(_scalar_py_operators, Constant):
-    pass
+class ScalarConstant(ScalarVariable, Constant):
+    def __init__(self, *args, **kwargs):
+        Constant.__init__(self, *args, **kwargs)
 
 
 # Register ScalarConstant as the type of Constant corresponding to Scalar


### PR DESCRIPTION
This PR makes the `Scalar` `Constant` and `Variable` types more consistent with the analogous `TensorType`s.