### PR TITLE
Do not add `SpecifyShape` to constant sizes in `RandomVariable`

### DIFF
--- a/aesara/tensor/random/utils.py
+++ b/aesara/tensor/random/utils.py
@@ -5,7 +5,7 @@ from itertools import zip_longest
 import numpy as np
 
 from aesara.compile.sharedvalue import shared
-from aesara.graph.basic import Variable
+from aesara.graph.basic import Constant, Variable
 from aesara.tensor import get_vector_length
 from aesara.tensor.basic import as_tensor_variable, cast, constant
 from aesara.tensor.extra_ops import broadcast_to
@@ -123,9 +123,12 @@ def normalize_size_param(size):
         )
     else:
         size = cast(as_tensor_variable(size, ndim=1), "int64")
-        # This should help ensure that the length of `size` will be available
-        # after certain types of cloning (e.g. the kind `Scan` performs)
-        size = specify_shape(size, (get_vector_length(size),))
+
+        if not isinstance(size, Constant):
+            # This should help ensure that the length of non-constant `size`s
+            # will be available after certain types of cloning (e.g. the kind
+            # `Scan` performs)
+            size = specify_shape(size, (get_vector_length(size),))
 
     assert size.dtype in int_dtypes
 

--- a/tests/tensor/random/test_opt.py
+++ b/tests/tensor/random/test_opt.py
@@ -23,7 +23,6 @@ from aesara.tensor.random.opt import (
     local_rv_size_lift,
     local_subtensor_rv_lift,
 )
-from aesara.tensor.shape import SpecifyShape
 from aesara.tensor.subtensor import AdvancedSubtensor, AdvancedSubtensor1, Subtensor
 from aesara.tensor.type import iscalar, vector
 
@@ -84,9 +83,7 @@ def test_inplace_optimization():
         np.array_equal(a.data, b.data)
         for a, b in zip(new_out.owner.inputs[2:], out.owner.inputs[2:])
     )
-    # A `SpecifyShape` is added
-    assert isinstance(new_out.owner.inputs[1].owner.op, SpecifyShape)
-    assert new_out.owner.inputs[1].owner.inputs[0].equals(out.owner.inputs[1])
+    assert np.array_equal(new_out.owner.inputs[1].data, [])
 
 
 @config.change_flags(compute_test_value="raise")


### PR DESCRIPTION
This PR removes the superfluous use of `SpecifyShape` with constant size parameters given to `RandomVariable`.