### PR TITLE
Make `local_optimizer` automatically validate nodes using its `tracks` argument

### DIFF
--- a/aesara/gpuarray/optdb.py
+++ b/aesara/gpuarray/optdb.py
@@ -29,8 +29,8 @@ class GraphToGPULocalOptGroup(LocalOptGroup):
     def transform(self, fgraph, op, context_name, inputs, outputs):
         if len(self.opts) == 0:
             return
-        opts = self.track_map[type(op)] + self.track_map[op] + self.track_map[None]
-        for opt in opts:
+
+        for opt in self.tracker.get_trackers(op):
             opt_start = time.time()
             new_repl = opt.transform(fgraph, op, context_name, inputs, outputs)
             opt_finish = time.time()

--- a/aesara/gpuarray/optdb.py
+++ b/aesara/gpuarray/optdb.py
@@ -1,11 +1,51 @@
+import time
+
 from aesara.compile import optdb
-from aesara.graph.opt import GraphToGPULocalOptGroup, TopoOptimizer, local_optimizer
+from aesara.graph.basic import applys_between
+from aesara.graph.opt import LocalOptGroup, TopoOptimizer, local_optimizer
 from aesara.graph.optdb import (
     EquilibriumDB,
     LocalGroupDB,
     OptimizationDatabase,
     SequenceDB,
 )
+
+
+class GraphToGPULocalOptGroup(LocalOptGroup):
+    """This is the equivalent of `LocalOptGroup` for `GraphToGPU`.
+
+    The main different is the function signature of the local
+    optimizer that use the `GraphToGPU` signature and not the normal
+    `LocalOptimizer` signature.
+
+    ``apply_all_opts=True`` is not supported
+
+    """
+
+    def __init__(self, *optimizers, **kwargs):
+        super().__init__(*optimizers, **kwargs)
+        assert self.apply_all_opts is False
+
+    def transform(self, fgraph, op, context_name, inputs, outputs):
+        if len(self.opts) == 0:
+            return
+        opts = self.track_map[type(op)] + self.track_map[op] + self.track_map[None]
+        for opt in opts:
+            opt_start = time.time()
+            new_repl = opt.transform(fgraph, op, context_name, inputs, outputs)
+            opt_finish = time.time()
+            if self.profile:
+                self.time_opts[opt] += opt_start - opt_finish
+                self.process_count[opt] += 1
+            if not new_repl:
+                continue
+            if self.profile:
+                self.node_created[opt] += len(
+                    list(applys_between(fgraph.variables, new_repl))
+                )
+                self.applied_true[opt] += 1
+
+            return new_repl
 
 
 gpu_optimizer = EquilibriumDB()

--- a/aesara/graph/opt.py
+++ b/aesara/graph/opt.py
@@ -1444,43 +1444,6 @@ class LocalOptGroup(LocalOptimizer):
             opt.add_requirements(fgraph)
 
 
-class GraphToGPULocalOptGroup(LocalOptGroup):
-    """This is the equivalent of `LocalOptGroup` for `GraphToGPU`.
-
-    The main different is the function signature of the local
-    optimizer that use the `GraphToGPU` signature and not the normal
-    `LocalOptimizer` signature.
-
-    ``apply_all_opts=True`` is not supported
-
-    """
-
-    def __init__(self, *optimizers, **kwargs):
-        super().__init__(*optimizers, **kwargs)
-        assert self.apply_all_opts is False
-
-    def transform(self, fgraph, op, context_name, inputs, outputs):
-        if len(self.opts) == 0:
-            return
-        opts = self.track_map[type(op)] + self.track_map[op] + self.track_map[None]
-        for opt in opts:
-            opt_start = time.time()
-            new_repl = opt.transform(fgraph, op, context_name, inputs, outputs)
-            opt_finish = time.time()
-            if self.profile:
-                self.time_opts[opt] += opt_start - opt_finish
-                self.process_count[opt] += 1
-            if not new_repl:
-                continue
-            if self.profile:
-                self.node_created[opt] += len(
-                    list(applys_between(fgraph.variables, new_repl))
-                )
-                self.applied_true[opt] += 1
-
-            return new_repl
-
-
 class OpSub(LocalOptimizer):
     """
 

--- a/aesara/graph/opt.py
+++ b/aesara/graph/opt.py
@@ -1200,7 +1200,10 @@ class FromFunctionLocalOptimizer(LocalOptimizer):
         return self._tracks
 
     def __str__(self):
-        return getattr(self, "__name__", "<FromFunctionLocalOptimizer instance>")
+        return getattr(self, "__name__", repr(self))
+
+    def __repr__(self):
+        return f"FromFunctionLocalOptimizer({repr(self.fn)}, {repr(self._tracks)}, {repr(self.requirements)})"
 
     def print_summary(self, stream=sys.stdout, level=0, depth=-1):
         print(f"{' ' * level}{self.transform} id={id(self)}", file=stream)

--- a/aesara/graph/optdb.py
+++ b/aesara/graph/optdb.py
@@ -170,12 +170,6 @@ class OptimizationDatabase:
         print("  names", self._names, file=stream)
         print("  db", self.__db__, file=stream)
 
-    def __hash__(self):
-        if not hasattr(self, "_optimizer_idx"):
-            self._optimizer_idx = opt._optimizer_idx[0]
-            opt._optimizer_idx[0] += 1
-        return self._optimizer_idx
-
 
 # This is deprecated and will be removed.
 DB = OptimizationDatabase

--- a/tests/graph/test_opt.py
+++ b/tests/graph/test_opt.py
@@ -25,6 +25,7 @@ from aesara.tensor.subtensor import AdvancedSubtensor
 from aesara.tensor.type import matrix, values_eq_approx_always_true
 from aesara.tensor.type_other import MakeSlice, SliceConstant, slicetype
 from tests.graph.utils import (
+    MyOp,
     MyType,
     MyVariable,
     op1,
@@ -691,3 +692,15 @@ class TestLocalOptGroup:
             "optimizer: rewrite local_opt_2 replaces Op2(y, y) with [Op2.0]"
             in capres.out
         )
+
+
+def test_local_optimizer_str():
+    @local_optimizer([op1, MyOp])
+    def local_opt_1(fgraph, node):
+        pass
+
+    assert str(local_opt_1) == "local_opt_1"
+    res = repr(local_opt_1)
+    assert res.startswith("FromFunctionLocalOptimizer(")
+    assert "Op1" in res
+    assert "local_opt_1" in res


### PR DESCRIPTION
This PR makes it so that `local_optimizer` implementations no longer need to manually check that their `node` argument matches the instances/types specified by their `tracks` arguments.  It also adds a long needed `__repr__` implementation for `FromFunctionLocalOptimizer`.