### PR TITLE
Fix a `RandomVariable` `DimShuffle` lift case for empty sizes

### DIFF
--- a/tests/tensor/random/test_opt.py
+++ b/tests/tensor/random/test_opt.py
@@ -148,6 +148,17 @@ def test_local_rv_size_lift(dist_op, dist_params, size):
     "ds_order, lifted, dist_op, dist_params, size, rtol",
     [
         (
+            ("x", 0),
+            True,
+            normal,
+            (
+                np.array([0.0, -100.0], dtype=np.float64),
+                np.array(1e-6, dtype=np.float64),
+            ),
+            (),
+            1e-7,
+        ),
+        (
             ("x",),
             True,
             normal,


### PR DESCRIPTION
This PR fixes a case that `local_dimshuffle_rv_lift` currently doesn't handle: when broadcast dimensions are added to a `RandomVariable` with independent dimensions (i.e. non-scalar parameter(s)) and no `size`.