### PR TITLE
Fix broadcastables inference for `Alloc` and an `as_tensor_variable` bug when all `ndim=0` and all dimensions are broadcastable

### DIFF
--- a/aesara/gpuarray/basic_ops.py
+++ b/aesara/gpuarray/basic_ops.py
@@ -19,7 +19,7 @@ from aesara.graph.utils import MethodNotDefined
 from aesara.link.c.interface import HideC
 from aesara.scalar import bool as bool_t
 from aesara.scalar import int32 as int32_t
-from aesara.tensor.basic import Alloc, AllocEmpty, Join, Split, alloc_validate_shape
+from aesara.tensor.basic import Alloc, AllocEmpty, Join, Split, infer_broadcastable
 from aesara.tensor.shape import Reshape
 from aesara.tensor.type import TensorType, values_eq_approx_always_true
 
@@ -909,7 +909,7 @@ class GpuAlloc(HideC, Alloc):
 
     def make_node(self, value, *shape):
         value = as_gpuarray_variable(value, context_name=self.context_name)
-        sh, bcast = alloc_validate_shape(shape)
+        sh, bcast = infer_broadcastable(shape)
         if value.ndim > len(sh):
             TypeError(
                 "The GpuAlloc value to use has more dimensions "
@@ -1071,7 +1071,7 @@ class GpuAllocEmpty(HideC, AllocEmpty):
         )
 
     def make_node(self, *shape):
-        sh, bcast = alloc_validate_shape(shape)
+        sh, bcast = infer_broadcastable(shape)
         output = GpuArrayType(
             dtype=self.dtype, broadcastable=bcast, context_name=self.context_name
         )()

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -127,11 +127,14 @@ def _as_tensor_Variable(x, name, ndim, **kwargs):
         return x
 
     if x.type.ndim > ndim:
-        # strip off leading broadcastable dimensions
-        first_non_broadcastable = [
-            idx for idx in range(x.ndim) if not x.broadcastable[idx]
-        ][0]
-        x = x.dimshuffle(list(range(x.ndim))[first_non_broadcastable:])
+        # Strip off leading broadcastable dimensions
+        non_broadcastables = [idx for idx in range(x.ndim) if not x.broadcastable[idx]]
+
+        if non_broadcastables:
+            x = x.dimshuffle(list(range(x.ndim))[non_broadcastables[0] :])
+        else:
+            x = x.dimshuffle()
+
         if x.ndim > ndim:
             raise ValueError(
                 f"Tensor of type {x.type} could not be cast to have {ndim} dimensions"

--- a/aesara/tensor/extra_ops.py
+++ b/aesara/tensor/extra_ops.py
@@ -1585,7 +1585,7 @@ class BroadcastTo(Op):
         a = aet.as_tensor_variable(a)
         shape = aet.as_tensor_variable(shape, ndim=1)
 
-        shape, bcast = aet.alloc_validate_shape(shape)
+        shape, bcast = aet.infer_broadcastable(shape)
 
         out = type(a.type)(dtype=a.type.dtype, broadcastable=bcast)()
 
@@ -1609,7 +1609,7 @@ class BroadcastTo(Op):
         d_wrt_a = broadcast_to(dout, shape).sum(axis=new_dims)
 
         # Determine the dimensions that were broadcast
-        _, shape_bcast = aet.alloc_validate_shape(shape)
+        _, shape_bcast = aet.infer_broadcastable(shape)
         bcast_sums = [
             i
             for i, (a_b, s_b) in enumerate(zip(a.broadcastable, shape_bcast[-a.ndim :]))

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -129,12 +129,12 @@ def test_RandomVariable_bcast():
     s3.tag.test_value = 3
     s3 = Assert("testing")(s3, eq(s1, 1))
 
-    res = rv.compute_bcast([mu, sd], (s1, s2, s3))
-    assert res == [False] * 3
+    res = rv(mu, sd, size=(s1, s2, s3))
+    assert res.broadcastable == (False,) * 3
 
     size = aet.as_tensor((1, 2, 3), dtype=np.int32).astype(np.int64)
-    res = rv.compute_bcast([mu, sd], size)
-    assert res == [True, False, False]
+    res = rv(mu, sd, size=size)
+    assert res.broadcastable == (True, False, False)
 
     res = rv(0, 1, size=aet.as_tensor(1, dtype=np.int64))
     assert res.broadcastable == (True,)

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -447,14 +447,20 @@ class TestAsTensorVariable:
         with pytest.raises(ValueError):
             as_tensor_variable(bad_apply_var)
 
-    def test_strip_leading_broadcastable(self):
+    def test_ndim_strip_leading_broadcastable(self):
         x = TensorType(config.floatX, (True, False))("x")
         x = as_tensor_variable(x, ndim=1)
         assert x.ndim == 1
 
-        x = matrix("x", dtype=config.floatX)
-        with pytest.raises(ValueError):
-            as_tensor_variable(x, ndim=1)
+    def test_ndim_all_broadcastable(self):
+        x = TensorType(config.floatX, (True, True))("x")
+        res = as_tensor_variable(x, ndim=0)
+        assert res.ndim == 0
+
+    def test_ndim_incompatible(self):
+        x = TensorType(config.floatX, (True, False))("x")
+        with pytest.raises(ValueError, match="^Tensor of type.*"):
+            as_tensor_variable(x, ndim=0)
 
     def test_bool(self):
         # We should not allow `as_tensor_variable` to accept `True` or `False`,


### PR DESCRIPTION
This PR closes #692.