### PR TITLE
Fixing nightly build metadata

### DIFF
--- a/.github/workflows/nightly.py
+++ b/.github/workflows/nightly.py
@@ -1,0 +1,13 @@
+from datetime import datetime, timezone
+
+
+suffix = datetime.now(timezone.utc).strftime(r".dev%Y%m%d")
+with open("setup.py", "r") as f:
+    data = f.read()
+
+data = data.replace(
+    "NIGHTLY_VERSION_SUFFIX = None", f'NIGHTLY_VERSION_SUFFIX = "{suffix}"'
+)
+
+with open("setup.py", "w") as f:
+    f.write(data)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,10 +18,10 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install build
+      - name: Inject 'nightly' into setup.py
+        run: python .github/workflows/nightly.py
       - name: Build the sdist
         run: python -m build --sdist .
-        env:
-          BUILD_AESARA_NIGHTLY: true
       - uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import os
 import sys
 
 from setuptools import find_packages, setup
@@ -61,18 +60,18 @@ if sys.version_info[0:2] < (3, 7):
     install_requires += ["dataclasses"]
 
 # Handle builds of nightly release
-if "BUILD_AESARA_NIGHTLY" in os.environ:
+NIGHTLY_VERSION_SUFFIX = None
+if NIGHTLY_VERSION_SUFFIX is not None:
     nightly = True
     NAME += "-nightly"
 
     from versioneer import get_versions as original_get_versions
 
     def get_versions():
-        from datetime import datetime, timezone
-
-        suffix = datetime.now(timezone.utc).strftime(r".dev%Y%m%d")
         versions = original_get_versions()
-        versions["version"] = versions["version"].split("+")[0] + suffix
+        if versions["version"].endswith(NIGHTLY_VERSION_SUFFIX):
+            return versions
+        versions["version"] = versions["version"].split("+")[0] + NIGHTLY_VERSION_SUFFIX
         return versions
 
     versioneer.get_versions = get_versions


### PR DESCRIPTION
This fixes an issue with the metadata generated for the nightly package as implemented in #656. I've reproduced the issue there and checked that this fixes my build locally. I believe this will do the trick with the published packages too.