### PR TITLE
Use NumPy C API to perform `DimShuffle` steps in its C implementation

### DIFF
--- a/aesara/gpuarray/elemwise.py
+++ b/aesara/gpuarray/elemwise.py
@@ -468,7 +468,7 @@ class GpuDimShuffle(DimShuffle):
 
         res = input
 
-        res = res.transpose(self.shuffle + self.drop)
+        res = res.transpose(self.transposition)
 
         shape = list(res.shape[: len(self.shuffle)])
         for augm in self.augment:

--- a/aesara/link/jax/dispatch.py
+++ b/aesara/link/jax/dispatch.py
@@ -710,7 +710,7 @@ def jax_funcify_Reshape(op, **kwargs):
 def jax_funcify_DimShuffle(op, **kwargs):
     def dimshuffle(x):
 
-        res = jnp.transpose(x, op.shuffle + op.drop)
+        res = jnp.transpose(x, op.transposition)
 
         shape = list(res.shape[: len(op.shuffle)])
 

--- a/aesara/link/numba/dispatch/elemwise.py
+++ b/aesara/link/numba/dispatch/elemwise.py
@@ -319,7 +319,7 @@ def numba_funcify_CAReduce(op, node, **kwargs):
 @numba_funcify.register(DimShuffle)
 def numba_funcify_DimShuffle(op, **kwargs):
     shuffle = tuple(op.shuffle)
-    drop = tuple(op.drop)
+    transposition = tuple(op.transposition)
     augment = tuple(op.augment)
     inplace = op.inplace
 
@@ -352,7 +352,7 @@ def numba_funcify_DimShuffle(op, **kwargs):
 
         @numba.njit
         def dimshuffle_inner(x, shuffle):
-            res = np.transpose(x, shuffle + drop)
+            res = np.transpose(x, transposition)
             shuffle_shape = res.shape[: len(shuffle)]
 
             new_shape = create_zeros_tuple()

--- a/aesara/tensor/inplace.py
+++ b/aesara/tensor/inplace.py
@@ -399,4 +399,4 @@ pprint.assign(pow_inplace, printing.OperatorPrinter("**=", 1, "right"))
 def transpose_inplace(x, **kwargs):
     "Perform a transpose on a tensor without copying the underlying storage"
     dims = list(range(x.ndim - 1, -1, -1))
-    return DimShuffle(x.broadcastable, dims, inplace=True)(x)
+    return DimShuffle(x.broadcastable, dims)(x)

--- a/tests/link/test_jax.py
+++ b/tests/link/test_jax.py
@@ -856,7 +856,7 @@ def test_jax_Dimshuffle():
     compare_jax_and_py(x_fg, [np.c_[[1.0, 2.0, 3.0, 4.0]].astype(config.floatX)])
 
     a_aet = tensor(dtype=config.floatX, broadcastable=[False, True])
-    x = aet_elemwise.DimShuffle([False, True], (0,), inplace=True)(a_aet)
+    x = aet_elemwise.DimShuffle([False, True], (0,))(a_aet)
     x_fg = FunctionGraph([a_aet], [x])
     compare_jax_and_py(x_fg, [np.c_[[1.0, 2.0, 3.0, 4.0]].astype(config.floatX)])
 

--- a/tests/link/test_jax.py
+++ b/tests/link/test_jax.py
@@ -1207,6 +1207,10 @@ def test_extra_ops_omni():
     compare_jax_and_py(fgraph, [])
 
 
+@pytest.mark.xfail(
+    version_parse(jax.__version__) >= version_parse("0.2.26"),
+    reason="JAX samplers require concrete/static shape values?",
+)
 @pytest.mark.parametrize(
     "at_dist, dist_params, rng, size",
     [

--- a/tests/link/test_jax.py
+++ b/tests/link/test_jax.py
@@ -601,7 +601,7 @@ def test_jax_scan_tap_output():
 
 def test_jax_Subtensors():
     # Basic indices
-    x_aet = aet.arange(3 * 4 * 5).reshape((3, 4, 5))
+    x_aet = aet.as_tensor(np.arange(3 * 4 * 5).reshape((3, 4, 5)))
     out_aet = x_aet[1, 2, 0]
     assert isinstance(out_aet.owner.op, aet_subtensor.Subtensor)
     out_fg = FunctionGraph([], [out_aet])

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -653,7 +653,7 @@ def test_AllocDiag(v, offset):
 
 
 @pytest.mark.parametrize(
-    "v, new_order, inplace",
+    "v, new_order",
     [
         # `{'drop': [], 'shuffle': [], 'augment': [0, 1]}`
         (
@@ -662,7 +662,6 @@ def test_AllocDiag(v, offset):
                 np.array(1, dtype=np.int64),
             ),
             ("x", "x"),
-            True,
         ),
         # I.e. `a_aet.T`
         # `{'drop': [], 'shuffle': [1, 0], 'augment': []}`
@@ -671,7 +670,6 @@ def test_AllocDiag(v, offset):
                 aet.matrix("a"), np.array([[1.0, 2.0], [3.0, 4.0]], dtype=config.floatX)
             ),
             (1, 0),
-            True,
         ),
         # `{'drop': [], 'shuffle': [0, 1], 'augment': [2]}`
         (
@@ -679,7 +677,6 @@ def test_AllocDiag(v, offset):
                 aet.matrix("a"), np.array([[1.0, 2.0], [3.0, 4.0]], dtype=config.floatX)
             ),
             (1, 0, "x"),
-            True,
         ),
         # `{'drop': [1], 'shuffle': [2, 0], 'augment': [0, 2, 4]}`
         (
@@ -688,7 +685,6 @@ def test_AllocDiag(v, offset):
                 np.array([[[1.0, 2.0]], [[3.0, 4.0]]], dtype=config.floatX),
             ),
             ("x", 2, "x", 0, "x"),
-            True,
         ),
         # I.e. `a_aet.dimshuffle((0,))`
         # `{'drop': [1], 'shuffle': [0], 'augment': []}`
@@ -698,7 +694,6 @@ def test_AllocDiag(v, offset):
                 np.array([[1.0], [2.0], [3.0], [4.0]], dtype=config.floatX),
             ),
             (0,),
-            True,
         ),
         (
             set_test_value(
@@ -706,7 +701,6 @@ def test_AllocDiag(v, offset):
                 np.array([[1.0], [2.0], [3.0], [4.0]], dtype=config.floatX),
             ),
             (0,),
-            True,
         ),
         (
             set_test_value(
@@ -714,12 +708,11 @@ def test_AllocDiag(v, offset):
                 np.array([[[1.0]]], dtype=config.floatX),
             ),
             (),
-            True,
         ),
     ],
 )
-def test_Dimshuffle(v, new_order, inplace):
-    g = aet_elemwise.DimShuffle(v.broadcastable, new_order, inplace=inplace)(v)
+def test_Dimshuffle(v, new_order):
+    g = aet_elemwise.DimShuffle(v.broadcastable, new_order)(v)
     g_fg = FunctionGraph(outputs=[g])
     compare_numba_and_py(
         g_fg,

--- a/tests/tensor/test_shape.py
+++ b/tests/tensor/test_shape.py
@@ -222,6 +222,10 @@ class TestReshape(utt.InferShapeTester, utt.OptimizationTestMixin):
             f(a_val, [7, 5])
         with pytest.raises(ValueError):
             f(a_val, [-1, -1])
+        with pytest.raises(
+            ValueError, match=".*Shape argument to Reshape has incorrect length.*"
+        ):
+            f(a_val, [3, 4, 1])
 
     def test_0(self):
         x = fvector("x")
@@ -267,14 +271,14 @@ class TestReshape(utt.InferShapeTester, utt.OptimizationTestMixin):
             [admat], [Reshape(ndim)(admat, [-1, 4])], [admat_val], Reshape
         )
 
-        # enable when infer_shape is generalized:
-        # self._compile_and_check([admat, aivec],
-        #                        [Reshape(ndim)(admat, aivec)],
-        #                        [admat_val, [4, 3]], Reshape)
-        #
-        # self._compile_and_check([admat, aivec],
-        #                        [Reshape(ndim)(admat, aivec)],
-        #                        [admat_val, [4, -1]], Reshape)
+        aivec = ivector()
+        self._compile_and_check(
+            [admat, aivec], [Reshape(ndim)(admat, aivec)], [admat_val, [4, 3]], Reshape
+        )
+
+        self._compile_and_check(
+            [admat, aivec], [Reshape(ndim)(admat, aivec)], [admat_val, [4, -1]], Reshape
+        )
 
         adtens4 = dtensor4()
         ndim = 4
@@ -287,14 +291,19 @@ class TestReshape(utt.InferShapeTester, utt.OptimizationTestMixin):
             [adtens4], [Reshape(ndim)(adtens4, [1, 3, 10, 4])], [adtens4_val], Reshape
         )
 
-        # enable when infer_shape is generalized:
-        # self._compile_and_check([adtens4, aivec],
-        #                        [Reshape(ndim)(adtens4, aivec)],
-        #                        [adtens4_val, [1, -1, 10, 4]], Reshape)
-        #
-        # self._compile_and_check([adtens4, aivec],
-        #                        [Reshape(ndim)(adtens4, aivec)],
-        #                        [adtens4_val, [1, 3, 10, 4]], Reshape)
+        self._compile_and_check(
+            [adtens4, aivec],
+            [Reshape(ndim)(adtens4, aivec)],
+            [adtens4_val, [1, -1, 10, 4]],
+            Reshape,
+        )
+
+        self._compile_and_check(
+            [adtens4, aivec],
+            [Reshape(ndim)(adtens4, aivec)],
+            [adtens4_val, [1, 3, 10, 4]],
+            Reshape,
+        )
 
 
 def test_shape_i_hash():


### PR DESCRIPTION
This PR replaces the custom view array creation in `DimShuffle`'s C implementation with calls to NumPy's C API that match the Python implementation.  It also replaces the manual shape creation steps in `Reshape`'s C implementation with a call to a NumPy helper function.

Closes #699