### PR TITLE
Make `TensorConstant`s print their names when specified

### DIFF
--- a/aesara/tensor/var.py
+++ b/aesara/tensor/var.py
@@ -986,13 +986,17 @@ class TensorConstant(TensorVariable, Constant):
     def __str__(self):
         unique_val = get_unique_value(self)
         if unique_val is not None:
-            name = f"{self.data.shape} of {unique_val}"
+            val = f"{self.data.shape} of {unique_val}"
         else:
-            name = f"{self.data}"
-        if len(name) > 20:
-            name = name[:10] + ".." + name[-10:]
+            val = f"{self.data}"
+        if len(val) > 20:
+            val = val[:10] + ".." + val[-10:]
 
-        return "TensorConstant{%s}" % name
+        if self.name is not None:
+            name = self.name
+        else:
+            name = "TensorConstant"
+        return "%s{%s}" % (name, val)
 
     def signature(self):
         return TensorConstantSignature((self.type, self.data))

--- a/tests/tensor/test_var.py
+++ b/tests/tensor/test_var.py
@@ -196,6 +196,13 @@ def test__getitem__AdvancedSubtensor():
     assert op_types[-1] == AdvancedSubtensor
 
 
+def test_print_constant():
+    c = aesara.tensor.constant(1, name="const")
+    assert str(c) == "const{1}"
+    d = aesara.tensor.constant(1)
+    assert str(d) == "TensorConstant{1}"
+
+
 @pytest.mark.parametrize(
     "x, indices, new_order",
     [


### PR DESCRIPTION
In addition, the value is printed (and sometimes the data type).

I modified it a bit to also print the value, but easy to change if the original proposal in #689 is deemed better. I imagined that it may be better to get more information, but on the other hand the name is there, so maybe no benefit.

Example:
```
In [9]: z = at.constant(1, name='z')
   ...: y = z + 1; 
   ...: y.name = 'y'

In [10]: dprint(y)
Elemwise{add,no_inplace} [id A] 'y'   
 |z{1} [id B]
 |TensorConstant{1} [id C]

In [11]: print(z)
z{1}
```

**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [x] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
