### PR TITLE
Set `default_updates` on RNGs passed to `RandomVariable.make_node`

### DIFF
--- a/aesara/tensor/random/op.py
+++ b/aesara/tensor/random/op.py
@@ -331,9 +331,7 @@ class RandomVariable(Op):
         if rng is None:
             rng = aesara.shared(np.random.default_rng())
         elif not isinstance(rng.type, RandomType):
-            raise TypeError(
-                "The type of rng should be an instance of either RandomGeneratorType or RandomStateType"
-            )
+            raise TypeError("The type of `rng` must be a subclass of RandomType")
 
         shape = self._infer_shape(size, dist_params)
         _, bcast = infer_broadcastable(shape)
@@ -342,7 +340,7 @@ class RandomVariable(Op):
         if dtype == "floatX":
             dtype = config.floatX
         elif dtype is None or (isinstance(dtype, str) and dtype not in all_dtypes):
-            raise TypeError("dtype is unspecified")
+            raise TypeError("`dtype` is unspecified")
 
         if isinstance(dtype, str):
             dtype_idx = constant(all_dtypes.index(dtype), dtype="int64")

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -79,6 +79,15 @@ def test_RandomVariable_basics():
             inplace=True,
         )(0, 1)
 
+    with raises(TypeError, match="^The type of `rng`*"):
+        RandomVariable(
+            "normal",
+            0,
+            [0, 0],
+            "normal",
+            inplace=True,
+        )(rng=at.as_tensor(1))
+
     # Confirm that `inplace` works
     rv = RandomVariable(
         "normal",

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -71,7 +71,7 @@ def test_RandomVariable_basics():
         )(0, 1, size={1, 2})
 
     # No dtype
-    with raises(TypeError, match="^dtype*"):
+    with raises(TypeError, match="^`dtype`.*"):
         RandomVariable(
             "normal",
             0,

--- a/tests/tensor/random/test_opt.py
+++ b/tests/tensor/random/test_opt.py
@@ -55,9 +55,10 @@ def apply_local_opt_to_rv(opt, op_fn, dist_op, dist_params, size, rng, name=None
         f_inputs,
         dist_st,
         mode=mode,
+        no_default_updates=True,
     )
 
-    (new_out,) = f_opt.maker.fgraph.outputs
+    (new_out, *_) = f_opt.maker.fgraph.outputs
 
     return new_out, f_inputs, dist_st, f_opt
 
@@ -322,6 +323,7 @@ def test_DimShuffle_lift(ds_order, lifted, dist_op, dist_params, size, rtol):
         f_inputs,
         dist_st,
         mode=no_mode,
+        no_default_updates=True,
     )
 
     arg_values = [p.get_test_value() for p in f_inputs]
@@ -447,6 +449,7 @@ def test_Subtensor_lift(indices, lifted, dist_op, dist_params, size):
         f_inputs,
         dist_st,
         mode=no_mode,
+        no_default_updates=True,
     )
 
     arg_values = [p.get_test_value() for p in f_inputs]


### PR DESCRIPTION
This PR makes the behavior of `RandomVariable` in `Scan`s a little more intuitive by adding `default_updates` to the RNG objects used and generated by `RandomVariable`s.

Under these changes, the following result is produced by default:
``` python
import aesara
import aesara.tensor as at


def inner_fn():
    return at.random.normal()


out, updates = aesara.scan(inner_fn, n_steps=10)

fn = aesara.function([], out)
fn()
# array([-0.89055728,  0.60126195,  0.85510428,  0.22562239, -0.59557647,
#   )
fn()
# array([ 2.09033971, -0.48043732, -2.66384694, -0.49392544,  0.90139483,
#         1.51081408, -1.15271538,  1.98298267, -0.38496484, -0.13587198])
```

In order to avoid updating shared RNG states implicitly produced by calls like `at.random.normal()`, the option `no_default_updates` can be set to `True` when calling `aesara.function`:
``` python
fn = aesara.function([], out, no_default_updates=True)
fn()
# array([-0.48043732, -2.66384694, -0.49392544,  0.90139483,  1.51081408,
#        -1.15271538,  1.98298267, -0.38496484, -0.13587198,  1.2234377 ])
fn()
# array([-0.48043732, -2.66384694, -0.49392544,  0.90139483,  1.51081408,
#        -1.15271538,  1.98298267, -0.38496484, -0.13587198,  1.2234377 ])
```