### PR TITLE
Introduce `aesara.as_symbolic`

### DIFF
--- a/aesara/graph/opt.py
+++ b/aesara/graph/opt.py
@@ -37,7 +37,6 @@ from aesara.graph.fg import FunctionGraph, InconsistencyError
 from aesara.graph.op import Op
 from aesara.graph.utils import AssocList
 from aesara.misc.ordered_set import OrderedSet
-from aesara.raise_op import CheckAndRaise
 from aesara.utils import flatten
 
 
@@ -789,6 +788,8 @@ class MergeOptimizer(GlobalOptimizer):
             fgraph.attach_feature(MergeFeature())
 
     def apply(self, fgraph):
+        from aesara.raise_op import CheckAndRaise
+
         # Constant and non-constant are now applied in the same phase.
         # I am not sure why, but it seems to be faster this way.
         sched = fgraph.merge_feature.scheduled

--- a/aesara/tensor/__init__.py
+++ b/aesara/tensor/__init__.py
@@ -9,32 +9,34 @@ from aesara.graph.op import Op
 
 def as_tensor_variable(
     x: Any, name: Optional[str] = None, ndim: Optional[int] = None, **kwargs
-) -> Callable:
-    """Convert `x` into the appropriate ``TensorType``.
+) -> Variable:
+    """Convert `x` into an equivalent `TensorVariable`.
 
-    This function is often used by ``make_node`` methods of ``Op`` subclasses
-    to turn ndarrays, numbers, ``Scalar`` instances, ``Apply`` instances and
-    ``TensorType`` instances into valid input list elements.
+    This function can be used to turn ndarrays, numbers, `Scalar` instances,
+    `Apply` instances and `TensorVariable` instances into valid input list
+    elements.
+
+    See `aesara.as_symbolic` for a more general conversion function.
 
     Parameters
     ----------
     x
-        The object to be converted into a ``Variable`` type. A
-        ``numpy.ndarray`` argument will not be copied, but a list of numbers
-        will be copied to make an ``numpy.ndarray``.
+        The object to be converted into a `Variable` type. A
+        `numpy.ndarray` argument will not be copied, but a list of numbers
+        will be copied to make an `numpy.ndarray`.
     name
-        If a new ``Variable`` instance is created, it will be named with this
+        If a new `Variable` instance is created, it will be named with this
         string.
     ndim
-        Return a ``Variable`` with this many dimensions.
+        Return a `Variable` with this many dimensions.
     dtype
-        The dtype to use for the resulting ``Variable``.  If `x` is already
-        a ``Variable`` type, then the dtype will not be changed.
+        The dtype to use for the resulting `Variable`.  If `x` is already
+        a `Variable` type, then the dtype will not be changed.
 
     Raises
     ------
     TypeError
-        If `x` cannot be converted to a ``TensorType`` Variable.
+        If `x` cannot be converted to a `TensorVariable`.
 
     """
     return _as_tensor_variable(x, name, ndim, **kwargs)

--- a/tests/tensor/test_type_other.py
+++ b/tests/tensor/test_type_other.py
@@ -1,10 +1,17 @@
 """ This file don't test everything. It only test one past crash error."""
 
 import aesara
+from aesara import as_symbolic
 from aesara.graph.basic import Constant
 from aesara.tensor.math import argmax
 from aesara.tensor.type import iscalar, vector
-from aesara.tensor.type_other import MakeSlice, NoneConst, NoneTypeT, make_slice
+from aesara.tensor.type_other import (
+    MakeSlice,
+    NoneConst,
+    NoneTypeT,
+    SliceConstant,
+    make_slice,
+)
 
 
 def test_make_slice_merge():
@@ -44,3 +51,15 @@ def test_none_Constant():
         kwargs = {"mode": "FAST_RUN"}
     f = aesara.function([x], [y], **kwargs)
     pickle.loads(pickle.dumps(f))
+
+
+def test_as_symbolic():
+
+    res = as_symbolic(None)
+    assert res is NoneConst
+
+    res = as_symbolic(slice(iscalar()))
+    assert res.owner.op == make_slice
+
+    res = as_symbolic(slice(1, 2))
+    assert isinstance(res, SliceConstant)


### PR DESCRIPTION
This PR introduces the `aesara.as_symbolic` dispatch function, which converts all eligible objects to `Variable`s.  Unlike `aesara.tensor.as_tensor_variable`, `as_symbolic` will convert `None`s, `slice`s, or any other types that have equivalent Aesara `Type`s.

- [ ] Add this new function to the documentation.