### PR TITLE
Implement `aesara.tensor.matmul`

### DIFF
--- a/aesara/tensor/nlinalg.py
+++ b/aesara/tensor/nlinalg.py
@@ -1,4 +1,3 @@
-import logging
 from functools import partial
 from typing import Tuple, Union
 
@@ -12,9 +11,6 @@ from aesara.tensor import basic as at
 from aesara.tensor import math as tm
 from aesara.tensor.basic import as_tensor_variable, extract_diag
 from aesara.tensor.type import dvector, lscalar, matrix, scalar, vector
-
-
-logger = logging.getLogger(__name__)
 
 
 class MatrixPinv(Op):


### PR DESCRIPTION
closes #488

This implements an aesara equivalent of `np.matmul`.

The behavior depends on the arguments in the following way.

If both arguments are 2-D they are multiplied like conventional matrices.

If either argument is N-D, N > 2, it is treated as a stack of matrices residing in the last two indexes and broadcast accordingly.

If the first argument is 1-D, it is promoted to a matrix by prepending a 1 to its dimensions. After matrix multiplication the prepended 1 is removed.

If the second argument is 1-D, it is promoted to a matrix by appending a 1 to its dimensions. After matrix multiplication the appended 1 is removed.

`matmul` differs from `dot` in two important ways:

Multiplication by scalars is not allowed.

Stacks of matrices are broadcast together as if the matrices were elements, respecting the signature `(n,k),(k,m)->(n,m)`

References
---------------
https://numpy.org/doc/stable/reference/generated/numpy.matmul.html
