### PR TITLE
Add a `sum` method to `_sparse_py_operators`

### DIFF
--- a/aesara/sparse/basic.py
+++ b/aesara/sparse/basic.py
@@ -299,6 +299,9 @@ class _sparse_py_operators:
     def __rdot__(right, left):
         return structured_dot(left, right)
 
+    def sum(self, axis=None, sparse_grad=False):
+        return sp_sum(self, axis=axis, sparse_grad=sparse_grad)
+
     dot = __dot__
 
     # N.B. THIS IS COMMENTED OUT ON PURPOSE!!!

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -2039,12 +2039,17 @@ class TestSpSum(utt.InferShapeTester):
         self.op_class = sparse.SpSum
         self.op = sparse.sp_sum
 
-    def test_op(self):
+    @pytest.mark.parametrize("op_type", ["func", "method"])
+    def test_op(self, op_type):
         for format in sparse.sparse_formats:
             for axis in self.possible_axis:
                 variable, data = sparse_random_inputs(format, shape=(10, 10))
 
-                z = sparse.sp_sum(variable[0], axis=axis)
+                if op_type == "func":
+                    z = sparse.sp_sum(variable[0], axis=axis)
+                if op_type == "method":
+                    z = variable[0].sum(axis=axis)
+
                 if axis is None:
                     assert z.type.broadcastable == ()
                 else:

--- a/tests/tensor/test_sharedvar.py
+++ b/tests/tensor/test_sharedvar.py
@@ -427,16 +427,10 @@ def makeSharedTester(
                 topo_cst[0].op == aesara.compile.function.types.deep_copy_op
 
             # Test that we can take the grad.
-            if aesara.sparse.enable_sparse and isinstance(
-                x1_specify_shape.type, aesara.sparse.SparseType
-            ):
-                # SparseVariable don't support sum for now.
-                assert not hasattr(x1_specify_shape, "sum")
-            else:
-                shape_grad = aesara.gradient.grad(x1_specify_shape.sum(), x1_shared)
-                shape_constant_fct_grad = aesara.function([], shape_grad)
-                # aesara.printing.debugprint(shape_constant_fct_grad)
-                shape_constant_fct_grad()
+            shape_grad = aesara.gradient.grad(x1_specify_shape.sum(), x1_shared)
+            shape_constant_fct_grad = aesara.function([], shape_grad)
+            # aesara.printing.debugprint(shape_constant_fct_grad)
+            shape_constant_fct_grad()
 
             # Test that we can replace with values of the different shape
             # but that will raise an error in some case, but not all


### PR DESCRIPTION
This PR add ```sum``` method for sparse tensors according to #522. So one can call ```x.sum()``` instead of  ```aesara.sparse.sp_sum(x)```.

I think this change should also be reflected in the documentation, but I could not find a section with the methods of sparse tensors. We need to decide something about what to do with it.
