### PR TITLE
Reintroduce deprecated `broadcastable` keyword arguments

### DIFF
--- a/aesara/tensor/sharedvar.py
+++ b/aesara/tensor/sharedvar.py
@@ -1,4 +1,5 @@
 import traceback
+import warnings
 
 import numpy as np
 
@@ -38,6 +39,7 @@ def tensor_constructor(
     borrow=False,
     shape=None,
     target="cpu",
+    broadcastable=None,
 ):
     """
     SharedVariable Constructor for TensorType.
@@ -49,6 +51,13 @@ def tensor_constructor(
     optional `shape` argument will override this default.
 
     """
+    if broadcastable is not None:
+        warnings.warn(
+            "The `broadcastable` keyword is deprecated; use `shape`.",
+            DeprecationWarning,
+        )
+        shape = broadcastable
+
     if target != "cpu":
         raise TypeError("not for cpu")
 

--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from typing import Iterable, Optional, Union
 
 import numpy as np
@@ -60,8 +61,9 @@ class TensorType(CType):
     def __init__(
         self,
         dtype: Union[str, np.dtype],
-        shape: Iterable[Optional[Union[bool, int]]],
+        shape: Optional[Iterable[Optional[Union[bool, int]]]] = None,
         name: Optional[str] = None,
+        broadcastable: Optional[Iterable[bool]] = None,
     ):
         r"""
 
@@ -79,6 +81,14 @@ class TensorType(CType):
             Optional name for this type.
 
         """
+
+        if broadcastable is not None:
+            warnings.warn(
+                "The `broadcastable` keyword is deprecated; use `shape`.",
+                DeprecationWarning,
+            )
+            shape = broadcastable
+
         if isinstance(dtype, str) and dtype == "floatX":
             self.dtype = config.floatX
         else:
@@ -95,7 +105,13 @@ class TensorType(CType):
         self.name = name
         self.numpy_dtype = np.dtype(self.dtype)
 
-    def clone(self, dtype=None, shape=None, **kwargs):
+    def clone(self, dtype=None, shape=None, broadcastable=None, **kwargs):
+        if broadcastable is not None:
+            warnings.warn(
+                "The `broadcastable` keyword is deprecated; use `shape`.",
+                DeprecationWarning,
+            )
+            shape = broadcastable
         if dtype is None:
             dtype = self.dtype
         if shape is None:

--- a/tests/tensor/test_sharedvar.py
+++ b/tests/tensor/test_sharedvar.py
@@ -685,3 +685,10 @@ def test_scalar_shared_options():
 def test_get_vector_length():
     x = aesara.shared(np.array((2, 3, 4, 5)))
     assert get_vector_length(x) == 4
+
+
+def test_deprecated_kwargs():
+    with pytest.warns(DeprecationWarning, match=".*broadcastable.*"):
+        res = aesara.shared(np.array([[1.0]]), broadcastable=(True, False))
+
+    assert res.type.shape == (1, None)

--- a/tests/tensor/test_type.py
+++ b/tests/tensor/test_type.py
@@ -286,3 +286,15 @@ def test_fixed_shape_convert_variable():
     res = t3.convert_variable(t4_var)
     assert res.type == t4
     assert res.type.shape == (3, 2)
+
+
+def test_deprecated_kwargs():
+    with pytest.warns(DeprecationWarning, match=".*broadcastable.*"):
+        res = TensorType("float64", broadcastable=(True, False))
+
+    assert res.shape == (1, None)
+
+    with pytest.warns(DeprecationWarning, match=".*broadcastable.*"):
+        new_res = res.clone(broadcastable=(False, True))
+
+    assert new_res.shape == (None, 1)


### PR DESCRIPTION
This PR reintroduces the `broadcastable` keyword argument&mdash;with a warning&mdash;to `TensorType.[__init__, clone]` and the shared variable constructor.  This keyword should account for most backward compatibility issues in external libraries.