### PR TITLE
Make `Sparse` tensor `Type`s extend `TensorType`

### DIFF
--- a/aesara/__init__.py
+++ b/aesara/__init__.py
@@ -167,7 +167,7 @@ def get_scalar_constant_value(v):
     """
     # Is it necessary to test for presence of aesara.sparse at runtime?
     sparse = globals().get("sparse")
-    if sparse and isinstance(v.type, sparse.SparseType):
+    if sparse and isinstance(v.type, sparse.SparseTensorType):
         if v.owner is not None and isinstance(v.owner.op, sparse.CSM):
             data = v.owner.inputs[0]
             return tensor.get_scalar_constant_value(data)

--- a/aesara/link/c/type.py
+++ b/aesara/link/c/type.py
@@ -17,7 +17,7 @@ class CType(Type, CLinkerType):
 
     - `TensorType`: for numpy.ndarray
 
-    - `SparseType`: for scipy.sparse
+    - `SparseTensorType`: for scipy.sparse
 
     But you are encouraged to write your own, as described in WRITEME.
 

--- a/aesara/misc/may_share_memory.py
+++ b/aesara/misc/may_share_memory.py
@@ -12,7 +12,7 @@ from aesara.tensor.type import TensorType
 try:
     import scipy.sparse
 
-    from aesara.sparse.basic import SparseType
+    from aesara.sparse.basic import SparseTensorType
 
     def _is_sparse(a):
         return scipy.sparse.issparse(a)
@@ -64,4 +64,4 @@ def may_share_memory(a, b, raise_other_type=True):
 
     if a_gpua or b_gpua:
         return False
-    return SparseType.may_share_memory(a, b)
+    return SparseTensorType.may_share_memory(a, b)

--- a/aesara/sparse/__init__.py
+++ b/aesara/sparse/__init__.py
@@ -9,7 +9,7 @@ except ImportError:
     enable_sparse = False
     warn("SciPy can't be imported.  Sparse matrix support is disabled.")
 
-from aesara.sparse.type import SparseType, _is_sparse
+from aesara.sparse.type import SparseTensorType, _is_sparse
 
 
 if enable_sparse:

--- a/aesara/sparse/sandbox/sp2.py
+++ b/aesara/sparse/sandbox/sp2.py
@@ -7,7 +7,7 @@ from aesara.graph.basic import Apply
 from aesara.graph.op import Op
 from aesara.sparse.basic import (
     Remove0,
-    SparseType,
+    SparseTensorType,
     _is_sparse,
     as_sparse_variable,
     remove0,
@@ -108,7 +108,9 @@ class Binomial(Op):
         assert shape.dtype in discrete_dtypes
 
         return Apply(
-            self, [n, p, shape], [SparseType(dtype=self.dtype, format=self.format)()]
+            self,
+            [n, p, shape],
+            [SparseTensorType(dtype=self.dtype, format=self.format)()],
         )
 
     def perform(self, node, inputs, outputs):

--- a/aesara/sparse/sharedvar.py
+++ b/aesara/sparse/sharedvar.py
@@ -3,7 +3,7 @@ import copy
 import scipy.sparse
 
 from aesara.compile import SharedVariable, shared_constructor
-from aesara.sparse.basic import SparseType, _sparse_py_operators
+from aesara.sparse.basic import SparseTensorType, _sparse_py_operators
 
 
 class SparseTensorSharedVariable(_sparse_py_operators, SharedVariable):
@@ -16,7 +16,7 @@ def sparse_constructor(
     value, name=None, strict=False, allow_downcast=None, borrow=False, format=None
 ):
     """
-    SharedVariable Constructor for SparseType.
+    SharedVariable Constructor for SparseTensorType.
 
     writeme
 
@@ -29,7 +29,7 @@ def sparse_constructor(
 
     if format is None:
         format = value.format
-    type = SparseType(format=format, dtype=value.dtype)
+    type = SparseTensorType(format=format, dtype=value.dtype)
     if not borrow:
         value = copy.deepcopy(value)
     return SparseTensorSharedVariable(

--- a/aesara/sparse/type.py
+++ b/aesara/sparse/type.py
@@ -148,8 +148,16 @@ class SparseType(TensorType, HasDataType):
                 return True
         return False
 
-    def make_variable(self, name=None):
-        return self.variable_type(self, name=name)
+    def convert_variable(self, var):
+        res = super().convert_variable(var)
+
+        if res and not isinstance(res.type, SparseType):
+            # TODO: Convert to this sparse format
+            raise NotImplementedError()
+
+        # TODO: Convert sparse `var`s with different formats to this format?
+
+        return res
 
     def __hash__(self):
         return super().__hash__() ^ hash(self.format)

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -313,8 +313,13 @@ def get_scalar_constant_value(
                     return np.array(data.item(), dtype=v.dtype)
                 except ValueError:
                     raise NotScalarConstantError()
-            else:
-                return data
+
+            from aesara.sparse.type import SparseType
+
+            if isinstance(v.type, SparseType):
+                raise NotScalarConstantError()
+
+            return data
 
         if not only_process_constants and getattr(v, "owner", None) and max_recur > 0:
             max_recur -= 1

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -314,9 +314,9 @@ def get_scalar_constant_value(
                 except ValueError:
                     raise NotScalarConstantError()
 
-            from aesara.sparse.type import SparseType
+            from aesara.sparse.type import SparseTensorType
 
-            if isinstance(v.type, SparseType):
+            if isinstance(v.type, SparseTensorType):
                 raise NotScalarConstantError()
 
             return data

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -78,7 +78,12 @@ from aesara.tensor.math import eq
 from aesara.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape, shape_padleft
 from aesara.tensor.sort import TopKOp
 from aesara.tensor.subtensor import Subtensor, get_idx_list
-from aesara.tensor.type import TensorType, discrete_dtypes, integer_dtypes
+from aesara.tensor.type import (
+    DenseTensorType,
+    TensorType,
+    discrete_dtypes,
+    integer_dtypes,
+)
 from aesara.tensor.var import TensorConstant
 from aesara.utils import NoDuplicateOptWarningFilter
 
@@ -2954,7 +2959,8 @@ def constant_folding(fgraph, node):
 
         # TODO: `Type` itself should provide an interface for constructing
         # instances appropriate for a given constant.
-        if isinstance(output.type, TensorType):
+        # TODO: Add handling for sparse types.
+        if isinstance(output.type, DenseTensorType):
             output_type = TensorType(
                 output.type.dtype,
                 tuple(s == 1 for s in data.shape),

--- a/aesara/tensor/math.py
+++ b/aesara/tensor/math.py
@@ -34,6 +34,7 @@ from aesara.tensor.elemwise import (
 )
 from aesara.tensor.shape import shape
 from aesara.tensor.type import (
+    DenseTensorType,
     complex_dtypes,
     continuous_dtypes,
     discrete_dtypes,
@@ -2075,6 +2076,11 @@ def dense_dot(a, b):
 
     """
     a, b = as_tensor_variable(a), as_tensor_variable(b)
+
+    if not isinstance(a.type, DenseTensorType) or not isinstance(
+        b.type, DenseTensorType
+    ):
+        raise TypeError("The dense dot product is only supported for dense types")
 
     if a.ndim == 0 or b.ndim == 0:
         return a * b

--- a/aesara/tensor/shape.py
+++ b/aesara/tensor/shape.py
@@ -431,7 +431,7 @@ class SpecifyShape(COp):
             )
 
         if isinstance(x.type, TensorType) and all(isinstance(s, Number) for s in shape):
-            out_var = TensorType(x.type.dtype, shape)()
+            out_var = x.type.clone(shape=shape)()
         else:
             out_var = x.type()
 

--- a/aesara/tensor/var.py
+++ b/aesara/tensor/var.py
@@ -10,6 +10,7 @@ import numpy as np
 from aesara import tensor as at
 from aesara.configdefaults import config
 from aesara.graph.basic import Constant, Variable
+from aesara.graph.utils import MetaType
 from aesara.scalar import ComplexError, IntegerDivisionError
 from aesara.tensor import _get_vector_length, as_tensor_variable
 from aesara.tensor.exceptions import AdvancedIndexingError
@@ -1040,3 +1041,33 @@ class TensorConstant(TensorVariable, Constant):
 
 
 TensorType.constant_type = TensorConstant
+
+
+class DenseVariableMeta(MetaType):
+    def __instancecheck__(self, o):
+        if type(o) == TensorVariable or isinstance(o, DenseVariableMeta):
+            return True
+        return False
+
+
+class DenseTensorVariable(TensorType, metaclass=DenseVariableMeta):
+    r"""A `Variable` for dense tensors.
+
+    Instances of this class and `TensorVariable`\s are considered dense
+    `Variable`\s.
+    """
+
+
+class DenseConstantMeta(MetaType):
+    def __instancecheck__(self, o):
+        if type(o) == TensorConstant or isinstance(o, DenseConstantMeta):
+            return True
+        return False
+
+
+class DenseTensorConstant(TensorType, metaclass=DenseConstantMeta):
+    r"""A `Constant` for dense tensors.
+
+    Instances of this class and `TensorConstant`\s are considered dense
+    `Constant`\s.
+    """

--- a/doc/extending/other_ops.rst
+++ b/doc/extending/other_ops.rst
@@ -44,7 +44,7 @@ usual dense tensors. In particular, in the
 instead of ``as_tensor_variable(x)``.
 
 Another difference is that you need to use ``SparseVariable`` and
-``SparseType`` instead of ``TensorVariable`` and ``TensorType``.
+``SparseTensorType`` instead of ``TensorVariable`` and ``TensorType``.
 
 Do not forget that we support only sparse matrices (so only 2 dimensions)
 and (like in SciPy) they do not support broadcasting operations by default
@@ -55,7 +55,7 @@ you can create output variables like this:
 .. code-block:: python
 
     out_format = inputs[0].format  # or 'csr' or 'csc' if the output format is fixed
-    SparseType(dtype=inputs[0].dtype, format=out_format).make_variable()
+    SparseTensorType(dtype=inputs[0].dtype, format=out_format).make_variable()
 
 See the sparse :class:`Aesara.sparse.basic.Cast` `Op` code for a good example of
 a sparse `Op` with Python code.
@@ -226,7 +226,7 @@ along with pointers to the relevant documentation.
         primitive type. The C type associated with this Aesara type is the
         represented C primitive itself.
 
-*       :ref:`SparseType <sparse_ops>` : Aesara `Type` used to represent sparse
+*       :ref:`SparseTensorType <sparse_ops>` : Aesara `Type` used to represent sparse
         tensors. There is no equivalent C type for this Aesara `Type` but you
         can split a sparse variable into its parts as TensorVariables. Those
         can then be used as inputs to an op with C code.

--- a/tests/compile/function/test_pfunc.py
+++ b/tests/compile/function/test_pfunc.py
@@ -751,8 +751,8 @@ class TestAliasingRules:
         #        operations are used) and to break the elemwise composition
         #        with some non-elemwise op (here dot)
 
-        x = sparse.SparseType("csc", dtype="float64")()
-        y = sparse.SparseType("csc", dtype="float64")()
+        x = sparse.SparseTensorType("csc", dtype="float64")()
+        y = sparse.SparseTensorType("csc", dtype="float64")()
         f = function([In(x, mutable=True), In(y, mutable=True)], (x + y) + (x + y))
         # Test 1. If the same variable is given twice
 

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -12,7 +12,7 @@ from aesara.compile.function import function
 from aesara.compile.io import In, Out
 from aesara.configdefaults import config
 from aesara.gradient import GradientError
-from aesara.graph.basic import Apply, Constant
+from aesara.graph.basic import Apply, Constant, applys_between
 from aesara.graph.op import Op
 from aesara.misc.safe_asarray import _asarray
 from aesara.sparse import (
@@ -78,6 +78,7 @@ from aesara.sparse import (
     true_dot,
 )
 from aesara.sparse.basic import (
+    SparseConstant,
     _is_dense_variable,
     _is_sparse,
     _is_sparse_variable,
@@ -1017,21 +1018,44 @@ class TestComparison:
 
 
 class TestConversion:
-    @pytest.mark.skip
     def test_basic(self):
-        a = at.as_tensor_variable(np.random.random((5)))
+        test_val = np.random.rand(5).astype(config.floatX)
+        a = at.as_tensor_variable(test_val)
         s = csc_from_dense(a)
         val = eval_outputs([s])
-        assert str(val.dtype) == "float64"
+        assert str(val.dtype) == config.floatX
         assert val.format == "csc"
 
-    @pytest.mark.skip
-    def test_basic_1(self):
-        a = at.as_tensor_variable(np.random.random((5)))
+        a = at.as_tensor_variable(test_val)
         s = csr_from_dense(a)
         val = eval_outputs([s])
-        assert str(val.dtype) == "float64"
+        assert str(val.dtype) == config.floatX
         assert val.format == "csr"
+
+        test_val = np.eye(3).astype(config.floatX)
+        a = sp.sparse.csr_matrix(test_val)
+        s = as_sparse_or_tensor_variable(a)
+        res = at.as_tensor_variable(s)
+        assert isinstance(res, SparseConstant)
+
+        a = sp.sparse.csr_matrix(test_val)
+        s = as_sparse_or_tensor_variable(a)
+        from aesara.tensor.exceptions import NotScalarConstantError
+
+        with pytest.raises(NotScalarConstantError):
+            at.get_scalar_constant_value(s, only_process_constants=True)
+
+    # TODO:
+    # def test_sparse_as_tensor_variable(self):
+    #     csr = sp.sparse.csr_matrix(np.eye(3))
+    #     val = aet.as_tensor_variable(csr)
+    #     assert str(val.dtype) == config.floatX
+    #     assert val.format == "csr"
+    #
+    #     csr = sp.sparse.csc_matrix(np.eye(3))
+    #     val = aet.as_tensor_variable(csr)
+    #     assert str(val.dtype) == config.floatX
+    #     assert val.format == "csc"
 
     def test_dense_from_sparse(self):
         # call dense_from_sparse
@@ -1590,6 +1614,32 @@ class TestDots(utt.InferShapeTester):
             np.random.default_rng().integers(0, 100, (size, size)), dtype=intX
         )
         f(i, a)
+
+    def test_tensor_dot_types(self):
+
+        x = sparse.csc_matrix("x")
+        x_d = at.matrix("x_d")
+        y = sparse.csc_matrix("y")
+
+        res = at.dot(x, y)
+        op_types = set(type(n.op) for n in applys_between([x, y], [res]))
+        assert sparse.basic.StructuredDot in op_types
+        assert at.math.Dot not in op_types
+
+        res = at.dot(x_d, y)
+        op_types = set(type(n.op) for n in applys_between([x, y], [res]))
+        assert sparse.basic.StructuredDot in op_types
+        assert at.math.Dot not in op_types
+
+        res = at.dot(x, x_d)
+        op_types = set(type(n.op) for n in applys_between([x, y], [res]))
+        assert sparse.basic.StructuredDot in op_types
+        assert at.math.Dot not in op_types
+
+        res = at.dot(at.second(1, x), y)
+        op_types = set(type(n.op) for n in applys_between([x, y], [res]))
+        assert sparse.basic.StructuredDot in op_types
+        assert at.math.Dot not in op_types
 
     def test_csr_dense_grad(self):
 

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -38,7 +38,7 @@ from aesara.sparse import (
     Remove0,
     SamplingDot,
     SparseFromDense,
-    SparseType,
+    SparseTensorType,
     SquareDiagonal,
     StructuredDot,
     StructuredDotGradCSC,
@@ -413,7 +413,7 @@ class TestSparseInferShape(utt.InferShapeTester):
         pass
 
     def test_getitem_scalar(self):
-        x = SparseType("csr", dtype=config.floatX)()
+        x = SparseTensorType("csr", dtype=config.floatX)()
         self._compile_and_check(
             [x],
             [x[2, 2]],
@@ -451,7 +451,7 @@ class TestSparseInferShape(utt.InferShapeTester):
             )
 
     def test_transpose(self):
-        x = SparseType("csr", dtype=config.floatX)()
+        x = SparseTensorType("csr", dtype=config.floatX)()
         self._compile_and_check(
             [x],
             [x.T],
@@ -460,7 +460,7 @@ class TestSparseInferShape(utt.InferShapeTester):
         )
 
     def test_neg(self):
-        x = SparseType("csr", dtype=config.floatX)()
+        x = SparseTensorType("csr", dtype=config.floatX)()
         self._compile_and_check(
             [x],
             [-x],
@@ -469,8 +469,8 @@ class TestSparseInferShape(utt.InferShapeTester):
         )
 
     def test_add_ss(self):
-        x = SparseType("csr", dtype=config.floatX)()
-        y = SparseType("csr", dtype=config.floatX)()
+        x = SparseTensorType("csr", dtype=config.floatX)()
+        y = SparseTensorType("csr", dtype=config.floatX)()
         self._compile_and_check(
             [x, y],
             [x + y],
@@ -482,7 +482,7 @@ class TestSparseInferShape(utt.InferShapeTester):
         )
 
     def test_add_sd(self):
-        x = SparseType("csr", dtype=config.floatX)()
+        x = SparseTensorType("csr", dtype=config.floatX)()
         y = matrix()
         self._compile_and_check(
             [x, y],
@@ -495,8 +495,8 @@ class TestSparseInferShape(utt.InferShapeTester):
         )
 
     def test_mul_ss(self):
-        x = SparseType("csr", dtype=config.floatX)()
-        y = SparseType("csr", dtype=config.floatX)()
+        x = SparseTensorType("csr", dtype=config.floatX)()
+        y = SparseTensorType("csr", dtype=config.floatX)()
         self._compile_and_check(
             [x, y],
             [x * y],
@@ -508,7 +508,7 @@ class TestSparseInferShape(utt.InferShapeTester):
         )
 
     def test_mul_sd(self):
-        x = SparseType("csr", dtype=config.floatX)()
+        x = SparseTensorType("csr", dtype=config.floatX)()
         y = matrix()
         self._compile_and_check(
             [x, y],
@@ -522,7 +522,7 @@ class TestSparseInferShape(utt.InferShapeTester):
         )
 
     def test_remove0(self):
-        x = SparseType("csr", dtype=config.floatX)()
+        x = SparseTensorType("csr", dtype=config.floatX)()
         self._compile_and_check(
             [x],
             [Remove0()(x)],
@@ -531,8 +531,8 @@ class TestSparseInferShape(utt.InferShapeTester):
         )
 
     def test_dot(self):
-        x = SparseType("csc", dtype=config.floatX)()
-        y = SparseType("csc", dtype=config.floatX)()
+        x = SparseTensorType("csc", dtype=config.floatX)()
+        y = SparseTensorType("csc", dtype=config.floatX)()
         self._compile_and_check(
             [x, y],
             [Dot()(x, y)],
@@ -545,12 +545,12 @@ class TestSparseInferShape(utt.InferShapeTester):
 
     def test_dot_broadcast(self):
         for x, y in [
-            (SparseType("csr", "float32")(), vector()[:, None]),
-            (SparseType("csr", "float32")(), vector()[None, :]),
-            (SparseType("csr", "float32")(), matrix()),
-            (vector()[:, None], SparseType("csr", "float32")()),
-            (vector()[None, :], SparseType("csr", "float32")()),
-            (matrix(), SparseType("csr", "float32")()),
+            (SparseTensorType("csr", "float32")(), vector()[:, None]),
+            (SparseTensorType("csr", "float32")(), vector()[None, :]),
+            (SparseTensorType("csr", "float32")(), matrix()),
+            (vector()[:, None], SparseTensorType("csr", "float32")()),
+            (vector()[None, :], SparseTensorType("csr", "float32")()),
+            (matrix(), SparseTensorType("csr", "float32")()),
         ]:
 
             sparse_out = at.dot(x, y)
@@ -562,8 +562,8 @@ class TestSparseInferShape(utt.InferShapeTester):
             assert dense_out.broadcastable == sparse_out.broadcastable
 
     def test_structured_dot(self):
-        x = SparseType("csc", dtype=config.floatX)()
-        y = SparseType("csc", dtype=config.floatX)()
+        x = SparseTensorType("csc", dtype=config.floatX)()
+        y = SparseTensorType("csc", dtype=config.floatX)()
         self._compile_and_check(
             [x, y],
             [structured_dot(x, y)],
@@ -583,8 +583,8 @@ class TestSparseInferShape(utt.InferShapeTester):
             ("csc", StructuredDotGradCSC),
             ("csr", StructuredDotGradCSR),
         ]:
-            x = SparseType(format, dtype=config.floatX)()
-            y = SparseType(format, dtype=config.floatX)()
+            x = SparseTensorType(format, dtype=config.floatX)()
+            y = SparseTensorType(format, dtype=config.floatX)()
             grads = aesara.grad(dense_from_sparse(structured_dot(x, y)).sum(), [x, y])
             self._compile_and_check(
                 [x, y],
@@ -606,7 +606,7 @@ class TestSparseInferShape(utt.InferShapeTester):
             )
 
     def test_dense_from_sparse(self):
-        x = SparseType("csr", dtype=config.floatX)()
+        x = SparseTensorType("csr", dtype=config.floatX)()
         self._compile_and_check(
             [x],
             [dense_from_sparse(x)],
@@ -1130,7 +1130,7 @@ class TestCsmProperties:
 
         for format in ("csc", "csr"):
             for dtype in ("float32", "float64"):
-                x = SparseType(format, dtype=dtype)()
+                x = SparseTensorType(format, dtype=dtype)()
                 f = aesara.function([x], csm_properties(x))
 
                 spmat = sp_types[format](random_lil((4, 3), dtype, 3))
@@ -1288,7 +1288,7 @@ class TestStructuredDot:
         for dense_dtype in typenames:
             for sparse_dtype in typenames:
                 correct_dtype = aesara.scalar.upcast(sparse_dtype, dense_dtype)
-                a = SparseType("csc", dtype=sparse_dtype)()
+                a = SparseTensorType("csc", dtype=sparse_dtype)()
                 b = matrix(dtype=dense_dtype)
                 d = structured_dot(a, b)
                 assert d.type.dtype == correct_dtype
@@ -1375,8 +1375,8 @@ class TestStructuredDot:
 
         for sparse_format_a in ["csc", "csr", "bsr"]:
             for sparse_format_b in ["csc", "csr", "bsr"]:
-                a = SparseType(sparse_format_a, dtype=sparse_dtype)()
-                b = SparseType(sparse_format_b, dtype=sparse_dtype)()
+                a = SparseTensorType(sparse_format_a, dtype=sparse_dtype)()
+                b = SparseTensorType(sparse_format_b, dtype=sparse_dtype)()
                 d = at.dot(a, b)
                 f = aesara.function([a, b], Out(d, borrow=True))
                 for M, N, K, nnz in [
@@ -1397,7 +1397,7 @@ class TestStructuredDot:
         sparse_dtype = "float64"
         dense_dtype = "float64"
 
-        a = SparseType("csc", dtype=sparse_dtype)()
+        a = SparseTensorType("csc", dtype=sparse_dtype)()
         b = matrix(dtype=dense_dtype)
         d = at.dot(a, b)
         f = aesara.function([a, b], Out(d, borrow=True))
@@ -1445,7 +1445,7 @@ class TestStructuredDot:
         sparse_dtype = "float32"
         dense_dtype = "float32"
 
-        a = SparseType("csr", dtype=sparse_dtype)()
+        a = SparseTensorType("csr", dtype=sparse_dtype)()
         b = matrix(dtype=dense_dtype)
         d = at.dot(a, b)
         f = aesara.function([a, b], d)
@@ -1567,8 +1567,8 @@ class TestDots(utt.InferShapeTester):
                 ("csr", "csc"),
                 ("csr", "csr"),
             ]:
-                x = sparse.SparseType(format=x_f, dtype=d1)("x")
-                y = sparse.SparseType(format=x_f, dtype=d2)("x")
+                x = sparse.SparseTensorType(format=x_f, dtype=d1)("x")
+                y = sparse.SparseTensorType(format=x_f, dtype=d2)("x")
 
                 def f_a(x, y):
                     return x * y
@@ -1886,7 +1886,7 @@ class TestZerosLike:
 def test_shape_i():
     sparse_dtype = "float32"
 
-    a = SparseType("csr", dtype=sparse_dtype)()
+    a = SparseTensorType("csr", dtype=sparse_dtype)()
     f = aesara.function([a], a.shape[1])
     assert f(sp.sparse.csr_matrix(random_lil((100, 10), sparse_dtype, 3))) == 10
 
@@ -1896,7 +1896,7 @@ def test_shape():
     # does not actually create a dense tensor in the process.
     sparse_dtype = "float32"
 
-    a = SparseType("csr", dtype=sparse_dtype)()
+    a = SparseTensorType("csr", dtype=sparse_dtype)()
     f = aesara.function([a], a.shape)
     assert np.all(
         f(sp.sparse.csr_matrix(random_lil((100, 10), sparse_dtype, 3))) == (100, 10)
@@ -1946,7 +1946,7 @@ def test_may_share_memory():
         (b.transpose(), a, False),
     ]:
 
-        assert SparseType.may_share_memory(a_, b_) == rep
+        assert SparseTensorType.may_share_memory(a_, b_) == rep
 
 
 def test_sparse_shared_memory():
@@ -1955,8 +1955,8 @@ def test_sparse_shared_memory():
     a = random_lil((3, 4), "float32", 3).tocsr()
     m1 = random_lil((4, 4), "float32", 3).tocsr()
     m2 = random_lil((4, 4), "float32", 3).tocsr()
-    x = SparseType("csr", dtype="float32")()
-    y = SparseType("csr", dtype="float32")()
+    x = SparseTensorType("csr", dtype="float32")()
+    y = SparseTensorType("csr", dtype="float32")()
 
     sdot = sparse.structured_dot
     z = sdot(x * 3, m1) + sdot(y * 2, m2)
@@ -1966,7 +1966,7 @@ def test_sparse_shared_memory():
     def f_(x, y, m1=m1, m2=m2):
         return ((x * 3) * m1) + ((y * 2) * m2)
 
-    assert SparseType.may_share_memory(a, a)  # This is trivial
+    assert SparseTensorType.may_share_memory(a, a)  # This is trivial
     result = f(a, a)
     result_ = f_(a, a)
     assert (result_.todense() == result.todense()).all()
@@ -3192,7 +3192,7 @@ class TestMulSV:
 
         for format in ("csr", "csc"):
             for dtype in ("float32", "float64"):
-                x = sparse.SparseType(format, dtype=dtype)()
+                x = sparse.SparseTensorType(format, dtype=dtype)()
                 y = vector(dtype=dtype)
                 f = aesara.function([x, y], mul_s_v(x, y))
 
@@ -3220,7 +3220,7 @@ class TestStructuredAddSV:
 
         for format in ("csr", "csc"):
             for dtype in ("float32", "float64"):
-                x = sparse.SparseType(format, dtype=dtype)()
+                x = sparse.SparseTensorType(format, dtype=dtype)()
                 y = vector(dtype=dtype)
                 f = aesara.function([x, y], structured_add_s_v(x, y))
 

--- a/tests/sparse/test_type.py
+++ b/tests/sparse/test_type.py
@@ -1,6 +1,28 @@
+import pytest
+
+from aesara.sparse import matrix as sp_matrix
 from aesara.sparse.type import SparseType
+from aesara.tensor import dmatrix
 
 
 def test_clone():
     st = SparseType("csr", "float64")
     assert st == st.clone()
+
+
+def test_Sparse_convert_variable():
+    x = dmatrix(name="x")
+    y = sp_matrix("csc", dtype="float64", name="y")
+    z = sp_matrix("csr", dtype="float64", name="z")
+
+    assert y.type.convert_variable(z) is None
+
+    # TODO FIXME: This is a questionable result, because `x.type` is associated
+    # with a dense `Type`, but, since `TensorType` is a base class of `Sparse`,
+    # we would need to added sparse/dense logic to `TensorType`, and we don't
+    # want to do that.
+    assert x.type.convert_variable(y) is y
+
+    # TODO FIXME: We should be able to do this.
+    with pytest.raises(NotImplementedError):
+        y.type.convert_variable(x)

--- a/tests/sparse/test_type.py
+++ b/tests/sparse/test_type.py
@@ -1,12 +1,12 @@
 import pytest
 
 from aesara.sparse import matrix as sp_matrix
-from aesara.sparse.type import SparseType
+from aesara.sparse.type import SparseTensorType
 from aesara.tensor import dmatrix
 
 
 def test_clone():
-    st = SparseType("csr", "float64")
+    st = SparseTensorType("csr", "float64")
     assert st == st.clone()
 
 

--- a/tests/sparse/test_var.py
+++ b/tests/sparse/test_var.py
@@ -1,0 +1,234 @@
+from contextlib import ExitStack
+
+import numpy as np
+import pytest
+from scipy.sparse.csr import csr_matrix
+
+import aesara
+import aesara.sparse as sparse
+import aesara.tensor as at
+from aesara.sparse.type import SparseType
+from aesara.tensor.type import DenseTensorType
+
+
+class TestSparseVariable:
+    @pytest.mark.parametrize(
+        "method, exp_type, cm",
+        [
+            ("__abs__", DenseTensorType, None),
+            ("__neg__", SparseType, ExitStack()),
+            ("__ceil__", DenseTensorType, None),
+            ("__floor__", DenseTensorType, None),
+            ("__trunc__", DenseTensorType, None),
+            ("transpose", DenseTensorType, None),
+            ("any", DenseTensorType, None),
+            ("all", DenseTensorType, None),
+            ("flatten", DenseTensorType, None),
+            ("ravel", DenseTensorType, None),
+            ("arccos", DenseTensorType, None),
+            ("arcsin", DenseTensorType, None),
+            ("arctan", DenseTensorType, None),
+            ("arccosh", DenseTensorType, None),
+            ("arcsinh", DenseTensorType, None),
+            ("arctanh", DenseTensorType, None),
+            ("ceil", DenseTensorType, None),
+            ("cos", DenseTensorType, None),
+            ("cosh", DenseTensorType, None),
+            ("deg2rad", DenseTensorType, None),
+            ("exp", DenseTensorType, None),
+            ("exp2", DenseTensorType, None),
+            ("expm1", DenseTensorType, None),
+            ("floor", DenseTensorType, None),
+            ("log", DenseTensorType, None),
+            ("log10", DenseTensorType, None),
+            ("log1p", DenseTensorType, None),
+            ("log2", DenseTensorType, None),
+            ("rad2deg", DenseTensorType, None),
+            ("sin", DenseTensorType, None),
+            ("sinh", DenseTensorType, None),
+            ("sqrt", DenseTensorType, None),
+            ("tan", DenseTensorType, None),
+            ("tanh", DenseTensorType, None),
+            ("copy", DenseTensorType, None),
+            ("sum", DenseTensorType, ExitStack()),
+            ("prod", DenseTensorType, None),
+            ("mean", DenseTensorType, None),
+            ("var", DenseTensorType, None),
+            ("std", DenseTensorType, None),
+            ("min", DenseTensorType, None),
+            ("max", DenseTensorType, None),
+            ("argmin", DenseTensorType, None),
+            ("argmax", DenseTensorType, None),
+            ("nonzero", DenseTensorType, ExitStack()),
+            ("nonzero_values", DenseTensorType, None),
+            ("argsort", DenseTensorType, ExitStack()),
+            ("conj", DenseTensorType, None),
+            ("round", DenseTensorType, None),
+            ("trace", DenseTensorType, None),
+            ("zeros_like", SparseType, ExitStack()),
+            ("ones_like", DenseTensorType, ExitStack()),
+            ("cumsum", DenseTensorType, None),
+            ("cumprod", DenseTensorType, None),
+            ("ptp", DenseTensorType, None),
+            ("squeeze", DenseTensorType, None),
+            ("diagonal", DenseTensorType, None),
+        ],
+    )
+    def test_unary(self, method, exp_type, cm):
+        x = at.dmatrix("x")
+        x = sparse.csr_from_dense(x)
+
+        method_to_call = getattr(x, method)
+
+        if cm is None:
+            cm = pytest.warns(UserWarning, match=".*converted to dense.*")
+
+        if exp_type == SparseType:
+            exp_res_type = csr_matrix
+        else:
+            exp_res_type = np.ndarray
+
+        with cm:
+            z = method_to_call()
+
+        if not isinstance(z, tuple):
+            z_outs = (z,)
+        else:
+            z_outs = z
+
+        assert all(isinstance(out.type, exp_type) for out in z_outs)
+
+        f = aesara.function([x], z, on_unused_input="ignore")
+
+        res = f([[1.1, 0.0, 2.0], [-1.0, 0.0, 0.0]])
+
+        if not isinstance(res, list):
+            res_outs = [res]
+        else:
+            res_outs = res
+
+        assert all(isinstance(out, exp_res_type) for out in res_outs)
+
+    @pytest.mark.parametrize(
+        "method, exp_type",
+        [
+            ("__lt__", SparseType),
+            ("__le__", SparseType),
+            ("__gt__", SparseType),
+            ("__ge__", SparseType),
+            ("__and__", DenseTensorType),
+            ("__or__", DenseTensorType),
+            ("__xor__", DenseTensorType),
+            ("__add__", SparseType),
+            ("__sub__", SparseType),
+            ("__mul__", SparseType),
+            ("__pow__", DenseTensorType),
+            ("__mod__", DenseTensorType),
+            ("__divmod__", DenseTensorType),
+            ("__truediv__", DenseTensorType),
+            ("__floordiv__", DenseTensorType),
+        ],
+    )
+    def test_binary(self, method, exp_type):
+        x = at.lmatrix("x")
+        y = at.lmatrix("y")
+        x = sparse.csr_from_dense(x)
+        y = sparse.csr_from_dense(y)
+
+        method_to_call = getattr(x, method)
+
+        if exp_type == SparseType:
+            exp_res_type = csr_matrix
+            cm = ExitStack()
+        else:
+            exp_res_type = np.ndarray
+            cm = pytest.warns(UserWarning, match=".*converted to dense.*")
+
+        with cm:
+            z = method_to_call(y)
+
+        if not isinstance(z, tuple):
+            z_outs = (z,)
+        else:
+            z_outs = z
+
+        assert all(isinstance(out.type, exp_type) for out in z_outs)
+
+        f = aesara.function([x, y], z)
+        res = f(
+            [[1, 0, 2], [-1, 0, 0]],
+            [[1, 1, 2], [1, 4, 1]],
+        )
+
+        if not isinstance(res, list):
+            res_outs = [res]
+        else:
+            res_outs = res
+
+        assert all(isinstance(out, exp_res_type) for out in res_outs)
+
+    def test_reshape(self):
+        x = at.dmatrix("x")
+        x = sparse.csr_from_dense(x)
+
+        with pytest.warns(UserWarning, match=".*converted to dense.*"):
+            z = x.reshape((3, 2))
+
+        assert isinstance(z.type, DenseTensorType)
+
+        f = aesara.function([x], z)
+        exp_res = f([[1.1, 0.0, 2.0], [-1.0, 0.0, 0.0]])
+        assert isinstance(exp_res, np.ndarray)
+
+    def test_dimshuffle(self):
+        x = at.dmatrix("x")
+        x = sparse.csr_from_dense(x)
+
+        with pytest.warns(UserWarning, match=".*converted to dense.*"):
+            z = x.dimshuffle((1, 0))
+
+        assert isinstance(z.type, DenseTensorType)
+
+        f = aesara.function([x], z)
+        exp_res = f([[1.1, 0.0, 2.0], [-1.0, 0.0, 0.0]])
+        assert isinstance(exp_res, np.ndarray)
+
+    def test_getitem(self):
+        x = at.dmatrix("x")
+        x = sparse.csr_from_dense(x)
+
+        z = x[:, :2]
+        assert isinstance(z.type, SparseType)
+
+        f = aesara.function([x], z)
+        exp_res = f([[1.1, 0.0, 2.0], [-1.0, 0.0, 0.0]])
+        assert isinstance(exp_res, csr_matrix)
+
+    def test_dot(self):
+        x = at.lmatrix("x")
+        y = at.lmatrix("y")
+        x = sparse.csr_from_dense(x)
+        y = sparse.csr_from_dense(y)
+
+        z = x.__dot__(y)
+        assert isinstance(z.type, SparseType)
+
+        f = aesara.function([x, y], z)
+        exp_res = f(
+            [[1, 0, 2], [-1, 0, 0]],
+            [[-1], [2], [1]],
+        )
+        assert isinstance(exp_res, csr_matrix)
+
+    def test_repeat(self):
+        x = at.dmatrix("x")
+        x = sparse.csr_from_dense(x)
+
+        with pytest.warns(UserWarning, match=".*converted to dense.*"):
+            z = x.repeat(2, axis=1)
+
+        assert isinstance(z.type, DenseTensorType)
+
+        f = aesara.function([x], z)
+        exp_res = f([[1.1, 0.0, 2.0], [-1.0, 0.0, 0.0]])
+        assert isinstance(exp_res, np.ndarray)

--- a/tests/sparse/test_var.py
+++ b/tests/sparse/test_var.py
@@ -7,7 +7,7 @@ from scipy.sparse.csr import csr_matrix
 import aesara
 import aesara.sparse as sparse
 import aesara.tensor as at
-from aesara.sparse.type import SparseType
+from aesara.sparse.type import SparseTensorType
 from aesara.tensor.type import DenseTensorType
 
 
@@ -16,7 +16,7 @@ class TestSparseVariable:
         "method, exp_type, cm",
         [
             ("__abs__", DenseTensorType, None),
-            ("__neg__", SparseType, ExitStack()),
+            ("__neg__", SparseTensorType, ExitStack()),
             ("__ceil__", DenseTensorType, None),
             ("__floor__", DenseTensorType, None),
             ("__trunc__", DenseTensorType, None),
@@ -65,7 +65,7 @@ class TestSparseVariable:
             ("conj", DenseTensorType, None),
             ("round", DenseTensorType, None),
             ("trace", DenseTensorType, None),
-            ("zeros_like", SparseType, ExitStack()),
+            ("zeros_like", SparseTensorType, ExitStack()),
             ("ones_like", DenseTensorType, ExitStack()),
             ("cumsum", DenseTensorType, None),
             ("cumprod", DenseTensorType, None),
@@ -83,7 +83,7 @@ class TestSparseVariable:
         if cm is None:
             cm = pytest.warns(UserWarning, match=".*converted to dense.*")
 
-        if exp_type == SparseType:
+        if exp_type == SparseTensorType:
             exp_res_type = csr_matrix
         else:
             exp_res_type = np.ndarray
@@ -112,16 +112,16 @@ class TestSparseVariable:
     @pytest.mark.parametrize(
         "method, exp_type",
         [
-            ("__lt__", SparseType),
-            ("__le__", SparseType),
-            ("__gt__", SparseType),
-            ("__ge__", SparseType),
+            ("__lt__", SparseTensorType),
+            ("__le__", SparseTensorType),
+            ("__gt__", SparseTensorType),
+            ("__ge__", SparseTensorType),
             ("__and__", DenseTensorType),
             ("__or__", DenseTensorType),
             ("__xor__", DenseTensorType),
-            ("__add__", SparseType),
-            ("__sub__", SparseType),
-            ("__mul__", SparseType),
+            ("__add__", SparseTensorType),
+            ("__sub__", SparseTensorType),
+            ("__mul__", SparseTensorType),
             ("__pow__", DenseTensorType),
             ("__mod__", DenseTensorType),
             ("__divmod__", DenseTensorType),
@@ -137,7 +137,7 @@ class TestSparseVariable:
 
         method_to_call = getattr(x, method)
 
-        if exp_type == SparseType:
+        if exp_type == SparseTensorType:
             exp_res_type = csr_matrix
             cm = ExitStack()
         else:
@@ -198,7 +198,7 @@ class TestSparseVariable:
         x = sparse.csr_from_dense(x)
 
         z = x[:, :2]
-        assert isinstance(z.type, SparseType)
+        assert isinstance(z.type, SparseTensorType)
 
         f = aesara.function([x], z)
         exp_res = f([[1.1, 0.0, 2.0], [-1.0, 0.0, 0.0]])
@@ -211,7 +211,7 @@ class TestSparseVariable:
         y = sparse.csr_from_dense(y)
 
         z = x.__dot__(y)
-        assert isinstance(z.type, SparseType)
+        assert isinstance(z.type, SparseTensorType)
 
         f = aesara.function([x, y], z)
         exp_res = f(

--- a/tests/tensor/test_var.py
+++ b/tests/tensor/test_var.py
@@ -6,6 +6,7 @@ import aesara
 import tests.unittest_tools as utt
 from aesara.graph.basic import Constant, equal_computations
 from aesara.tensor import get_vector_length
+from aesara.tensor.basic import constant
 from aesara.tensor.elemwise import DimShuffle
 from aesara.tensor.math import dot
 from aesara.tensor.subtensor import AdvancedSubtensor, Subtensor
@@ -21,7 +22,12 @@ from aesara.tensor.type import (
     tensor3,
 )
 from aesara.tensor.type_other import MakeSlice
-from aesara.tensor.var import TensorConstant, TensorVariable
+from aesara.tensor.var import (
+    DenseTensorConstant,
+    DenseTensorVariable,
+    TensorConstant,
+    TensorVariable,
+)
 
 
 @pytest.mark.parametrize(
@@ -247,3 +253,14 @@ def test_get_vector_length():
     x = TensorVariable(TensorType("int64", (None,)))
     with pytest.raises(ValueError):
         get_vector_length(x)
+
+
+def test_dense_types():
+
+    x = matrix()
+    assert isinstance(x, DenseTensorVariable)
+    assert not isinstance(x, DenseTensorConstant)
+
+    x = constant(1)
+    assert not isinstance(x, DenseTensorVariable)
+    assert isinstance(x, DenseTensorConstant)

--- a/tests/test_ifelse.py
+++ b/tests/test_ifelse.py
@@ -335,13 +335,13 @@ class TestIfelse(utt.OptimizationTestMixin):
         z = aesara.sparse.matrix("csr", dtype=self.dtype, name="z")
         cond = iscalar("cond")
 
-        with pytest.raises(TypeError):
+        with pytest.raises(NotImplementedError):
             ifelse(cond, x, y)
-        with pytest.raises(TypeError):
+        with pytest.raises(NotImplementedError):
             ifelse(cond, y, x)
-        with pytest.raises(TypeError):
+        with pytest.raises(NotImplementedError):
             ifelse(cond, x, z)
-        with pytest.raises(TypeError):
+        with pytest.raises(NotImplementedError):
             ifelse(cond, z, x)
         with pytest.raises(TypeError):
             ifelse(cond, y, z)

--- a/tests/typed_list/test_basic.py
+++ b/tests/typed_list/test_basic.py
@@ -451,7 +451,7 @@ class TestIndex:
     def test_sparse(self):
         sp = pytest.importorskip("scipy")
         mySymbolicSparseList = TypedListType(
-            sparse.SparseType("csr", aesara.config.floatX)
+            sparse.SparseTensorType("csr", aesara.config.floatX)
         )()
         mySymbolicSparse = sparse.csr_matrix()
 
@@ -519,7 +519,7 @@ class TestCount:
     def test_sparse(self):
         sp = pytest.importorskip("scipy")
         mySymbolicSparseList = TypedListType(
-            sparse.SparseType("csr", aesara.config.floatX)
+            sparse.SparseTensorType("csr", aesara.config.floatX)
         )()
         mySymbolicSparse = sparse.csr_matrix()
 


### PR DESCRIPTION
This pull request is a continuation of the work in PR #303 on refactors the sparse tensor type structure so that sparse types extend the existing tensor types.

Closes #142.