### PR TITLE
Update the high-level API documentation

### DIFF
--- a/doc/library/index.rst
+++ b/doc/library/index.rst
@@ -53,8 +53,4 @@ There are also some top-level imports that you might find more convenient:
 
     Alias for :class:`function.In`
 
-.. function:: dot(x, y)
-
-    Works like :func:`tensor.dot` for both sparse and dense matrix products
-
 .. autofunction:: aesara.clone_replace

--- a/doc/library/index.rst
+++ b/doc/library/index.rst
@@ -41,9 +41,7 @@ There are also some top-level imports that you might find more convenient:
     Alias for :func:`aesara.compile.function.function`
 
 
-.. function:: function_dump(...)
 
-    Alias for :func:`aesara.compile.function.function_dump`
 
 .. function:: shared(...)
 
@@ -53,7 +51,6 @@ There are also some top-level imports that you might find more convenient:
 .. class:: In
    Alias for :func:`aesara.scan.basic.scan`
 
-    Alias for :class:`function.In`
 
 .. autofunction:: aesara.dprint(...)
 

--- a/doc/library/index.rst
+++ b/doc/library/index.rst
@@ -9,6 +9,9 @@ API Documentation
 This documentation covers Aesara module-wise.  This is suited to finding the
 Types and Ops that you can use to build and compile expression graphs.
 
+Modules
+=======
+
 .. toctree::
    :maxdepth: 1
 
@@ -28,32 +31,39 @@ Types and Ops that you can use to build and compile expression graphs.
    tensor/index
    typed_list
 
-There are also some top-level imports that you might find more convenient:
-
-
 .. module:: aesara
    :platform: Unix, Windows
    :synopsis: Aesara top-level import
 .. moduleauthor:: LISA
 
-.. function:: function(...)
+There are also some top-level imports that you might find more convenient:
 
-    Alias for :func:`aesara.compile.function.function`
-
-
-
+Graph
+=====
 
 .. function:: shared(...)
 
-    Alias for :func:`aesara.compile.sharedvalue.shared`
+   Alias for :func:`aesara.compile.sharedvalue.shared`
+
+.. function:: function(...)
+
+   Alias for :func:`aesara.compile.function.function`
+
+.. autofunction:: aesara.clone_replace(...)
+
+   Alias for :func:`aesara.graph.basic.clone_replace`
+
+Control flow
+============
+
 .. autofunction:: aesara.scan(...)
 
-.. class:: In
    Alias for :func:`aesara.scan.basic.scan`
 
+Debug
+=====
 
 .. autofunction:: aesara.dprint(...)
 
    Alias for :func:`aesara.printing.debugprint`
 
-.. autofunction:: aesara.clone_replace

--- a/doc/library/index.rst
+++ b/doc/library/index.rst
@@ -48,9 +48,15 @@ There are also some top-level imports that you might find more convenient:
 .. function:: shared(...)
 
     Alias for :func:`aesara.compile.sharedvalue.shared`
+.. autofunction:: aesara.scan(...)
 
 .. class:: In
+   Alias for :func:`aesara.scan.basic.scan`
 
     Alias for :class:`function.In`
+
+.. autofunction:: aesara.dprint(...)
+
+   Alias for :func:`aesara.printing.debugprint`
 
 .. autofunction:: aesara.clone_replace


### PR DESCRIPTION
This PR makes a few small changes to the index page of the API documentation:

- Document the fact that `scan` and `dprint` are available in the `aesara` namespace
- Remove reference to the deprecated `aesara.dot`
- Divide the page into sections