### PR TITLE
Add JAX conversion for CheckAndRaiseOp

### DIFF
--- a/aesara/link/jax/dispatch.py
+++ b/aesara/link/jax/dispatch.py
@@ -14,6 +14,7 @@ from aesara.configdefaults import config
 from aesara.graph.fg import FunctionGraph
 from aesara.ifelse import IfElse
 from aesara.link.utils import fgraph_to_python
+from aesara.raise_op import CheckAndRaise
 from aesara.scalar import Softplus
 from aesara.scalar.basic import Cast, Clip, Composite, Identity, ScalarOp, Second
 from aesara.scalar.math import Erf, Erfc, Erfinv, Psi
@@ -573,6 +574,21 @@ def jax_funcify_IfElse(op, **kwargs):
         return res if n_outs > 1 else res[0]
 
     return ifelse
+
+
+@jax_funcify.register(CheckAndRaise)
+def jax_funcify_CheckAndRaise(op, **kwargs):
+
+    raise NotImplementedError(
+        f"""This exception is raised because you tried to convert an aesara graph with a `CheckAndRaise` Op (message: {op.msg}) to JAX.
+
+        JAX uses tracing to jit-compile functions, and assertions typically
+        don't do well with tracing. The appropriate workaround depends on what
+        you intended to do with the assertions in the first place.
+
+        Note that all assertions can be removed from the graph by adding
+        `local_remove_all_assert` to the rewrites."""
+    )
 
 
 @jax_funcify.register(Subtensor)

--- a/tests/link/test_jax.py
+++ b/tests/link/test_jax.py
@@ -17,6 +17,7 @@ from aesara.graph.op import Op, get_test_value
 from aesara.graph.optdb import OptimizationQuery
 from aesara.ifelse import ifelse
 from aesara.link.jax import JAXLinker
+from aesara.raise_op import assert_op
 from aesara.scalar.basic import Composite
 from aesara.scan.basic import scan
 from aesara.tensor import basic as at
@@ -768,6 +769,17 @@ def test_jax_ifelse():
     x_fg = FunctionGraph([a], [x])  # I.e. False
 
     compare_jax_and_py(x_fg, [get_test_value(i) for i in x_fg.inputs])
+
+
+def test_jax_checkandraise():
+    p = scalar()
+    p.tag.test_value = 0
+
+    res = assert_op(p, p < 1.0)
+    res_fg = FunctionGraph([p], [res])
+
+    with pytest.raises(NotImplementedError):
+        compare_jax_and_py(res_fg, [1.0])
 
 
 def test_jax_CAReduce():


### PR DESCRIPTION
In this PR I had a jax conversion for the `CheckAndRaise` op. Closes #629.

The tests are currently not passing; there is an issue linked to JAX's tracing that I did not foresee when I started working on the PR. The following code:

```python
import jax

def fn(x):
    if x < 0:
        return 1
    return x

f = jax.jit(fn)
f(-1)
```
will raise a `ConcretizationTypeError`. One way around it is to specify `x` as a `static_argnum` when jitting the function, but this is not desirable in most cases as a change in `x`'s value will trigger recompilation.

It seems to me that `aesara` automatically jit-compiles the functions, _I thus suggest to simply skip the assertions when compiling to JAX_.

+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [x] There are tests covering the changes introduced in the PR.
