### PR TITLE
Add mypy config and fix typing issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,10 @@ repos:
               aesara/tensor/linalg\.py
           )$
         args: ['--in-place', '--remove-all-unused-imports', '--remove-unused-variable']
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.931
+    hooks:
+      - id: mypy
+        additional_dependencies:
+        - types-filelock
+        - types-setuptools

--- a/aesara/compile/debugmode.py
+++ b/aesara/compile/debugmode.py
@@ -14,6 +14,7 @@ from io import StringIO
 from itertools import chain
 from itertools import product as itertools_product
 from logging import Logger
+from typing import Optional
 from warnings import warn
 
 import numpy as np
@@ -1362,14 +1363,14 @@ class _Linker(LocalLinker):
         self.maker = maker
         super().__init__(scheduler=schedule)
 
-    def accept(self, fgraph, no_recycling=None, profile=None):
+    def accept(self, fgraph, no_recycling: Optional[list] = None, profile=None):
         if no_recycling is None:
             no_recycling = []
         if self.fgraph is not None and self.fgraph is not fgraph:
             assert type(self) is _Linker
             return type(self)(maker=self.maker).accept(fgraph, no_recycling, profile)
         self.fgraph = fgraph
-        self.no_recycling = no_recycling
+        self.no_recycling: list = no_recycling
         return self
 
     def make_all(
@@ -1401,7 +1402,7 @@ class _Linker(LocalLinker):
         # check_preallocated_output even on the output of the function.
         # no_recycling in individual thunks does not really matter, since
         # the function's outputs will always be freshly allocated.
-        no_recycling = []
+        no_recycling: list = []
 
         input_storage, output_storage, storage_map = map_storage(
             fgraph, order, input_storage_, output_storage_, storage_map
@@ -1492,6 +1493,7 @@ class _Linker(LocalLinker):
         # Use self.no_recycling (that was passed in accept()) to always
         # use new memory storage when it is needed, in particular for the
         # function's outputs. no_recycling_map will be used in f() below.
+        no_recycling_map: list = []
         if self.no_recycling is True:
             no_recycling_map = list(storage_map.values())
             no_recycling_map = difference(no_recycling_map, input_storage)

--- a/aesara/configparser.py
+++ b/aesara/configparser.py
@@ -22,10 +22,9 @@ _logger = logging.getLogger("aesara.configparser")
 
 
 class AesaraConfigWarning(Warning):
+    @classmethod
     def warn(cls, message, stacklevel=0):
         warnings.warn(message, cls, stacklevel=stacklevel + 3)
-
-    warn = classmethod(warn)
 
 
 class ConfigAccessViolation(AttributeError):

--- a/aesara/gpuarray/basic_ops.py
+++ b/aesara/gpuarray/basic_ops.py
@@ -36,6 +36,7 @@ from aesara.gpuarray.type import (
     ContextNotDefined,
     GpuArrayConstant,
     GpuArrayType,
+    GpuContextType,
     get_context,
     gpu_context_type,
 )
@@ -307,7 +308,7 @@ class GpuKernelBase:
 
     """
 
-    params_type: Union[ParamsType, gpu_context_type] = gpu_context_type
+    params_type: Union[ParamsType, GpuContextType] = gpu_context_type
 
     def get_params(self, node):
         # Default implementation, suitable for most sub-classes.

--- a/aesara/gpuarray/type.py
+++ b/aesara/gpuarray/type.py
@@ -983,7 +983,7 @@ Py_INCREF(%(name)s);
 Instance of :class:`GpuContextType` to use for the context_type
 declaration of an operation.
 """
-gpu_context_type = GpuContextType()
+gpu_context_type: GpuContextType = GpuContextType()
 
 
 # THIS WORKS But GpuArray instances don't compare equal to one

--- a/aesara/graph/basic.py
+++ b/aesara/graph/basic.py
@@ -18,6 +18,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 import numpy as np
@@ -1615,6 +1616,7 @@ def get_var_by_name(
 
     results: Tuple[Variable, ...] = ()
     for var in walk(graphs, expand, False):
+        var = cast(Variable, var)
         if target_var_id == var.name or target_var_id == var.auto_name:
             results += (var,)
 

--- a/aesara/graph/fg.py
+++ b/aesara/graph/fg.py
@@ -508,7 +508,7 @@ class FunctionGraph(MetaObject):
                 attach(self)
             except AlreadyThere:
                 return
-        self.execute_callbacks_times.setdefault(feature, 0)
+        self.execute_callbacks_times.setdefault(feature, 0.0)
         # It would be nice if we could require a specific class instead of
         # a "workalike" so we could do actual error checking
         # if not isinstance(feature, Feature):

--- a/aesara/graph/op.py
+++ b/aesara/graph/op.py
@@ -197,6 +197,10 @@ class Op(MetaObject):
 
     """
 
+    itypes = None
+    otypes = None
+    params_type: Optional[ParamsType] = None
+
     def make_node(self, *inputs: Variable) -> Apply:
         """Construct an `Apply` node that represent the application of this operation to the given inputs.
 
@@ -208,13 +212,13 @@ class Op(MetaObject):
             The constructed `Apply` node.
 
         """
-        if not hasattr(self, "itypes"):
+        if self.itypes is None:
             raise NotImplementedError(
                 "You can either define itypes and otypes,\
              or implement make_node"
             )
 
-        if not hasattr(self, "otypes"):
+        if self.otypes is None:
             raise NotImplementedError(
                 "You can either define itypes and otypes,\
              or implement make_node"
@@ -446,7 +450,7 @@ class Op(MetaObject):
 
     def get_params(self, node: Apply) -> Params:
         """Try to get parameters for the `Op` when :attr:`Op.params_type` is set to a `ParamsType`."""
-        if hasattr(self, "params_type") and isinstance(self.params_type, ParamsType):
+        if isinstance(self.params_type, ParamsType):
             wrapper = self.params_type
             if not all(hasattr(self, field) for field in wrapper.fields):
                 # Let's print missing attributes for debugging.
@@ -1091,7 +1095,7 @@ class ExternalCOp(COp):
 
         """
         params: List[Tuple[str, Any]] = []
-        if hasattr(self, "params_type") and isinstance(self.params_type, ParamsType):
+        if isinstance(self.params_type, ParamsType):
             wrapper = self.params_type
             params.append(("PARAMS_TYPE", wrapper.name))
             for i in range(wrapper.length):
@@ -1111,7 +1115,7 @@ class ExternalCOp(COp):
 
     def c_code_cache_version(self):
         version = (hash(tuple(self.func_codes)),)
-        if hasattr(self, "params_type"):
+        if self.params_type is not None:
             version += (self.params_type.c_code_cache_version(),)
         return version
 

--- a/aesara/graph/opt.py
+++ b/aesara/graph/opt.py
@@ -1232,7 +1232,7 @@ class LocalOptGroup(LocalOptimizer):
             self.tracker.add_tracker(o)
 
             if self.profile:
-                self.time_opts.setdefault(o, 0)
+                self.time_opts.setdefault(o, 0.0)
                 self.process_count.setdefault(o, 0)
                 self.applied_true.setdefault(o, 0)
                 self.node_created.setdefault(o, 0)

--- a/aesara/graph/opt.py
+++ b/aesara/graph/opt.py
@@ -17,7 +17,7 @@ from collections import UserList, defaultdict, deque
 from collections.abc import Iterable
 from functools import partial, reduce
 from itertools import chain
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import aesara
 from aesara.configdefaults import config
@@ -1068,7 +1068,7 @@ class FromFunctionLocalOptimizer(LocalOptimizer):
 
 
 def local_optimizer(
-    tracks: Optional[List[Union[Op, type]]],
+    tracks: Optional[Sequence[Union[Op, type]]],
     inplace: bool = False,
     requirements: Optional[Tuple[type, ...]] = (),
 ):
@@ -1184,7 +1184,10 @@ class LocalOptGroup(LocalOptimizer):
     """
 
     def __init__(
-        self, *optimizers, apply_all_opts: bool = False, profile: bool = False
+        self,
+        *optimizers: Sequence[Rewriter],
+        apply_all_opts: bool = False,
+        profile: bool = False,
     ):
         """
 
@@ -1205,7 +1208,7 @@ class LocalOptGroup(LocalOptimizer):
         if len(optimizers) == 1 and isinstance(optimizers[0], list):
             # This happen when created by LocalGroupDB.
             optimizers = tuple(optimizers[0])
-        self.opts = optimizers
+        self.opts: Sequence[Rewriter] = optimizers
         assert isinstance(self.opts, tuple)
 
         self.reentrant = any(getattr(opt, "reentrant", True) for opt in optimizers)
@@ -1217,10 +1220,10 @@ class LocalOptGroup(LocalOptimizer):
 
         self.profile = profile
         if self.profile:
-            self.time_opts = {}
-            self.process_count = {}
-            self.applied_true = {}
-            self.node_created = {}
+            self.time_opts: Dict[Rewriter, float] = {}
+            self.process_count: Dict[Rewriter, int] = {}
+            self.applied_true: Dict[Rewriter, int] = {}
+            self.node_created: Dict[Rewriter, int] = {}
 
         self.tracker = LocalOptTracker()
 

--- a/aesara/graph/type.py
+++ b/aesara/graph/type.py
@@ -6,6 +6,8 @@ import re
 from abc import abstractmethod
 from typing import Any, Optional, Text, TypeVar, Union
 
+from typing_extensions import TypeAlias
+
 from aesara.graph import utils
 from aesara.graph.basic import Constant, Variable
 from aesara.graph.utils import MetaObject
@@ -33,12 +35,12 @@ class Type(MetaObject):
 
     """
 
-    Variable = Variable
+    Variable: TypeAlias = Variable
     """
     The `Type` that will be created by a call to `Type.make_variable`.
     """
 
-    Constant = Constant
+    Constant: TypeAlias = Constant
     """
     The `Type` that will be created by a call to `Type.make_constant`.
     """
@@ -109,7 +111,7 @@ class Type(MetaObject):
         storage: Any,
         strict: bool = False,
         allow_downcast: Optional[bool] = None,
-    ) -> None:
+    ):
         """Return data or an appropriately wrapped/converted data by converting it in-place.
 
         This method allows one to reuse old allocated memory.  If this method

--- a/aesara/graph/utils.py
+++ b/aesara/graph/utils.py
@@ -3,10 +3,12 @@ import sys
 import traceback
 from abc import ABCMeta
 from io import StringIO
-from typing import List
+from typing import List, Optional, Sequence, Tuple
 
 
-def simple_extract_stack(f=None, limit=None, skips=None):
+def simple_extract_stack(
+    f=None, limit: Optional[int] = None, skips: Optional[Sequence[str]] = None
+) -> List[Tuple[Optional[str], int, str, str]]:
     """This is traceback.extract_stack from python 2.7 with this change:
 
     - Comment the update of the cache.
@@ -33,7 +35,7 @@ def simple_extract_stack(f=None, limit=None, skips=None):
     if limit is None:
         if hasattr(sys, "tracebacklimit"):
             limit = sys.tracebacklimit
-    trace = []
+    trace: List[Tuple[Optional[str], int, str, str]] = []
     n = 0
     while f is not None and (limit is None or n < limit):
         lineno = f.f_lineno
@@ -67,7 +69,7 @@ def simple_extract_stack(f=None, limit=None, skips=None):
     return trace
 
 
-def add_tag_trace(thing, user_line=None):
+def add_tag_trace(thing, user_line: Optional[int] = None):
     """Add tag.trace to a node or variable.
 
     The argument is returned after being affected (inplace).

--- a/aesara/ifelse.py
+++ b/aesara/ifelse.py
@@ -13,7 +13,7 @@ is a global operation with a scalar condition.
 
 import logging
 from copy import deepcopy
-from typing import List, Union
+from typing import List, Sequence, Union
 
 import numpy as np
 
@@ -311,7 +311,7 @@ def ifelse(
     then_branch: Union[Variable, List[Variable]],
     else_branch: Union[Variable, List[Variable]],
     name: str = None,
-) -> Union[Variable, List[Variable]]:
+) -> Union[Variable, Sequence[Variable]]:
     """
     This function corresponds to an if statement, returning (and evaluating)
     inputs in the ``then_branch`` if ``condition`` evaluates to True or
@@ -340,13 +340,13 @@ def ifelse(
 
     Returns
     =======
-        A list of aesara variables or a single variable (depending on the
+        A sequence of aesara variables or a single variable (depending on the
         nature of the ``then_branch`` and ``else_branch``). More exactly if
         ``then_branch`` and ``else_branch`` is a tensor, then
         the return variable will be just a single variable, otherwise a
-        list. The value returns correspond either to the values in the
+        sequence. The value returns correspond either to the values in the
         ``then_branch`` or in the ``else_branch`` depending on the value of
-        ``cond``.
+        ``condition``.
     """
 
     rval_type = None

--- a/aesara/link/basic.py
+++ b/aesara/link/basic.py
@@ -51,7 +51,7 @@ class Container:
     def __init__(
         self,
         r: MetaObject,
-        storage: Any,
+        storage: List[Any],
         *,
         readonly: bool = False,
         strict: bool = False,

--- a/aesara/link/c/interface.py
+++ b/aesara/link/c/interface.py
@@ -148,7 +148,7 @@ class CLinkerObject:
         """Return a list of code snippets to be inserted in module initialization."""
         return []
 
-    def c_code_cache_version(self) -> Union[Tuple[int], Tuple]:
+    def c_code_cache_version(self) -> Union[Tuple[int, ...], Tuple]:
         """Return a tuple of integers indicating the version of this `Op`.
 
         An empty tuple indicates an "unversioned" `Op` that will not be cached
@@ -211,7 +211,7 @@ class CLinkerOp(CLinkerObject):
         """
         raise NotImplementedError()
 
-    def c_code_cache_version_apply(self, node: Apply) -> Tuple[int]:
+    def c_code_cache_version_apply(self, node: Apply) -> Tuple[int, ...]:
         """Return a tuple of integers indicating the version of this `Op`.
 
         An empty tuple indicates an "unversioned" `Op` that will not be

--- a/aesara/link/utils.py
+++ b/aesara/link/utils.py
@@ -24,7 +24,7 @@ def map_storage(
     order: Iterable[Apply],
     input_storage: Optional[List],
     output_storage: Optional[List],
-    storage_map: Dict = None,
+    storage_map: Optional[Dict] = None,
 ) -> Tuple[List, List, Dict]:
     """Ensure there is storage (a length-1 list) for inputs, outputs, and interior nodes.
 

--- a/aesara/printing.py
+++ b/aesara/printing.py
@@ -329,6 +329,7 @@ N.B.:
         return _file.getvalue()
     else:
         _file.flush()
+    return _file
 
 
 def _debugprint(
@@ -396,7 +397,7 @@ def _debugprint(
         Internal. Used to pass information when recursing.
     """
     if depth == 0:
-        return
+        return file
 
     if order is None:
         order = []
@@ -903,6 +904,7 @@ class PPrinter(Printer):
         for condition, printer in self.printers:
             if condition(pstate, r):
                 return printer.process(r, pstate)
+        return ""
 
     def clone(self):
         cp = copy(self)

--- a/aesara/printing.py
+++ b/aesara/printing.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from copy import copy
 from functools import reduce
 from io import IOBase, StringIO
-from typing import Callable, Dict, Iterable, List, Optional, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 
@@ -168,9 +168,9 @@ def debugprint(
         used_ids = dict()
 
     results_to_print = []
-    profile_list = []
-    order = []  # Toposort
-    smap = []  # storage_map
+    profile_list: List[Optional[Any]] = []
+    order: List[Optional[List[Apply]]] = []  # Toposort
+    smap: List[Optional[StorageMapType]] = []  # storage_map
 
     if isinstance(obj, (list, tuple, set)):
         lobj = obj
@@ -881,8 +881,8 @@ default_printer = DefaultPrinter()
 
 class PPrinter(Printer):
     def __init__(self):
-        self.printers = []
-        self.printers_dict = {}
+        self.printers: List[Tuple[Union[Op, type, Callable], Printer]] = []
+        self.printers_dict: Dict[Union[Op, type, Callable], Printer] = {}
 
     def assign(self, condition: Union[Op, type, Callable], printer: Printer):
         if isinstance(condition, (Op, type)):
@@ -999,7 +999,7 @@ else:
     )
 
 
-pprint = PPrinter()
+pprint: PPrinter = PPrinter()
 pprint.assign(lambda pstate, r: True, default_printer)
 pprint.assign(lambda pstate, r: isinstance(r, Constant), constant_printer)
 
@@ -1705,7 +1705,7 @@ def get_node_by_id(
     if isinstance(graphs, Variable):
         graphs = (graphs,)
 
-    used_ids = dict()
+    used_ids: Dict[Variable, str] = {}
 
     _ = debugprint(graphs, file="str", used_ids=used_ids, ids=ids)
 

--- a/aesara/scan/op.py
+++ b/aesara/scan/op.py
@@ -752,9 +752,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             # output sequence
             o = outputs[idx]
             self.output_types.append(
-                typeConstructor(
-                    shape=(False,) + o.type.broadcastable, dtype=o.type.dtype
-                )
+                typeConstructor((False,) + o.type.broadcastable, o.type.dtype)
             )
 
             idx += len(self.mit_mot_out_slices[jdx])
@@ -765,9 +763,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
 
         for o in outputs[idx:end]:
             self.output_types.append(
-                typeConstructor(
-                    shape=(False,) + o.type.broadcastable, dtype=o.type.dtype
-                )
+                typeConstructor((False,) + o.type.broadcastable, o.type.dtype)
             )
 
         # shared outputs + possibly the ending condition

--- a/aesara/scan/opt.py
+++ b/aesara/scan/opt.py
@@ -683,7 +683,7 @@ def push_out_inner_vars(
     outer_vars = [None] * len(inner_vars)
     new_scan_node = old_scan_node
     new_scan_args = old_scan_args
-    replacements = {}
+    replacements: Dict[Variable, Variable] = {}
 
     # For the inner_vars that already exist in the outer graph,
     # simply obtain a reference to them

--- a/aesara/scan/utils.py
+++ b/aesara/scan/utils.py
@@ -1016,7 +1016,7 @@ class ScanArgs:
 
     def find_among_fields(
         self, i: Variable, field_filter: Callable[[str], bool] = default_filter
-    ) -> Optional[Tuple[str, int, int, int]]:
+    ) -> Optional[FieldInfo]:
         """Find the type and indices of the field containing a given element.
 
         NOTE: This only returns the *first* field containing the given element.
@@ -1158,14 +1158,14 @@ class ScanArgs:
 
     def remove_from_fields(
         self, i: Variable, rm_dependents: bool = True
-    ) -> List[FieldInfo]:
+    ) -> List[Tuple[Variable, Optional[FieldInfo]]]:
 
         if rm_dependents:
             vars_to_remove = self.get_dependent_nodes(i) | {i}
         else:
             vars_to_remove = {i}
 
-        rm_info = []
+        rm_info: List[Tuple[Variable, Optional[FieldInfo]]] = []
         for v in vars_to_remove:
             dependent_rm_info = self._remove_from_fields(v)
             rm_info.append((v, dependent_rm_info))

--- a/aesara/tensor/__init__.py
+++ b/aesara/tensor/__init__.py
@@ -9,7 +9,7 @@ from aesara.graph.op import Op
 
 def as_tensor_variable(
     x: Any, name: Optional[str] = None, ndim: Optional[int] = None, **kwargs
-) -> Variable:
+) -> "TensorVariable":
     """Convert `x` into an equivalent `TensorVariable`.
 
     This function can be used to turn ndarrays, numbers, `Scalar` instances,
@@ -45,7 +45,7 @@ def as_tensor_variable(
 @singledispatch
 def _as_tensor_variable(
     x, name: Optional[str], ndim: Optional[int], **kwargs
-) -> NoReturn:
+) -> "TensorVariable":
     raise NotImplementedError(f"Cannot convert {x} to a tensor variable.")
 
 
@@ -80,7 +80,7 @@ def get_vector_length(v: Any):
 
 
 @singledispatch
-def _get_vector_length(op: Union[Op, Variable], var: Variable) -> NoReturn:
+def _get_vector_length(op: Union[Op, Variable], var: Variable):
     """`Op`-based dispatch for `get_vector_length`."""
     raise ValueError(f"Length of {var} cannot be determined")
 

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -184,7 +184,7 @@ def _as_tensor_bool(x, name, ndim, **kwargs):
 as_tensor = as_tensor_variable
 
 
-def constant(x, name=None, ndim=None, dtype=None):
+def constant(x, name=None, ndim=None, dtype=None) -> TensorConstant:
     """Return a `TensorConstant` with value `x`.
 
     Raises
@@ -795,7 +795,7 @@ register_rebroadcast_c_code(
 
 # to be removed as we get the epydoc routine-documenting thing going
 # -JB 20080924
-def _conversion(real_value, name):
+def _conversion(real_value: Op, name: str) -> Op:
     __oplist_tag(real_value, "casting")
     real_value.__module__ = "tensor.basic"
     pprint.assign(real_value, printing.FunctionPrinter([name]))
@@ -807,46 +807,50 @@ def _conversion(real_value, name):
 # what types you are casting to what.  That logic is implemented by the
 # `cast()` function below.
 
-_convert_to_bool = _conversion(Elemwise(aes.convert_to_bool), "bool")
+_convert_to_bool: Elemwise = _conversion(Elemwise(aes.convert_to_bool), "bool")
 """Cast to boolean"""
 
-_convert_to_int8 = _conversion(Elemwise(aes.convert_to_int8), "int8")
+_convert_to_int8: Elemwise = _conversion(Elemwise(aes.convert_to_int8), "int8")
 """Cast to 8-bit integer"""
 
-_convert_to_int16 = _conversion(Elemwise(aes.convert_to_int16), "int16")
+_convert_to_int16: Elemwise = _conversion(Elemwise(aes.convert_to_int16), "int16")
 """Cast to 16-bit integer"""
 
-_convert_to_int32 = _conversion(Elemwise(aes.convert_to_int32), "int32")
+_convert_to_int32: Elemwise = _conversion(Elemwise(aes.convert_to_int32), "int32")
 """Cast to 32-bit integer"""
 
-_convert_to_int64 = _conversion(Elemwise(aes.convert_to_int64), "int64")
+_convert_to_int64: Elemwise = _conversion(Elemwise(aes.convert_to_int64), "int64")
 """Cast to 64-bit integer"""
 
-_convert_to_uint8 = _conversion(Elemwise(aes.convert_to_uint8), "uint8")
+_convert_to_uint8: Elemwise = _conversion(Elemwise(aes.convert_to_uint8), "uint8")
 """Cast to unsigned 8-bit integer"""
 
-_convert_to_uint16 = _conversion(Elemwise(aes.convert_to_uint16), "uint16")
+_convert_to_uint16: Elemwise = _conversion(Elemwise(aes.convert_to_uint16), "uint16")
 """Cast to unsigned 16-bit integer"""
 
-_convert_to_uint32 = _conversion(Elemwise(aes.convert_to_uint32), "uint32")
+_convert_to_uint32: Elemwise = _conversion(Elemwise(aes.convert_to_uint32), "uint32")
 """Cast to unsigned 32-bit integer"""
 
-_convert_to_uint64 = _conversion(Elemwise(aes.convert_to_uint64), "uint64")
+_convert_to_uint64: Elemwise = _conversion(Elemwise(aes.convert_to_uint64), "uint64")
 """Cast to unsigned 64-bit integer"""
 
-_convert_to_float16 = _conversion(Elemwise(aes.convert_to_float16), "float16")
+_convert_to_float16: Elemwise = _conversion(Elemwise(aes.convert_to_float16), "float16")
 """Cast to half-precision floating point"""
 
-_convert_to_float32 = _conversion(Elemwise(aes.convert_to_float32), "float32")
+_convert_to_float32: Elemwise = _conversion(Elemwise(aes.convert_to_float32), "float32")
 """Cast to single-precision floating point"""
 
-_convert_to_float64 = _conversion(Elemwise(aes.convert_to_float64), "float64")
+_convert_to_float64: Elemwise = _conversion(Elemwise(aes.convert_to_float64), "float64")
 """Cast to double-precision floating point"""
 
-_convert_to_complex64 = _conversion(Elemwise(aes.convert_to_complex64), "complex64")
+_convert_to_complex64: Elemwise = _conversion(
+    Elemwise(aes.convert_to_complex64), "complex64"
+)
 """Cast to single-precision complex"""
 
-_convert_to_complex128 = _conversion(Elemwise(aes.convert_to_complex128), "complex128")
+_convert_to_complex128: Elemwise = _conversion(
+    Elemwise(aes.convert_to_complex128), "complex128"
+)
 """Cast to double-precision complex"""
 
 _cast_mapping = {
@@ -867,7 +871,7 @@ _cast_mapping = {
 }
 
 
-def cast(x, dtype):
+def cast(x, dtype: Union[str, np.dtype]) -> TensorVariable:
     """Symbolically cast `x` to a Tensor of type `dtype`."""
 
     if isinstance(dtype, str) and dtype == "floatX":

--- a/aesara/tensor/random/op.py
+++ b/aesara/tensor/random/op.py
@@ -1,5 +1,5 @@
 from copy import copy
-from typing import List, Optional, Sequence, Tuple
+from typing import Optional, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -27,9 +27,9 @@ from aesara.tensor.var import TensorVariable
 def default_supp_shape_from_params(
     ndim_supp: int,
     dist_params: Sequence[Variable],
-    rep_param_idx: Optional[int] = 0,
+    rep_param_idx: int = 0,
     param_shapes: Optional[Sequence[Tuple[ScalarVariable]]] = None,
-) -> Tuple[int, ...]:
+) -> Union[TensorVariable, Tuple[ScalarVariable, ...]]:
     """Infer the dimensions for the output of a `RandomVariable`.
 
     This is a function that derives a random variable's support
@@ -171,10 +171,10 @@ class RandomVariable(Op):
 
     def _infer_shape(
         self,
-        size: Tuple[TensorVariable],
-        dist_params: List[TensorVariable],
-        param_shapes: Optional[List[Tuple[TensorVariable]]] = None,
-    ) -> Tuple[ScalarVariable]:
+        size: TensorVariable,
+        dist_params: Sequence[TensorVariable],
+        param_shapes: Optional[Sequence[Tuple[Variable, ...]]] = None,
+    ) -> Union[TensorVariable, Tuple[ScalarVariable, ...]]:
         """Compute the output shape given the size and distribution parameters.
 
         Parameters

--- a/aesara/tensor/random/utils.py
+++ b/aesara/tensor/random/utils.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from functools import wraps
 from itertools import zip_longest
+from typing import Optional, Union
 
 import numpy as np
 
@@ -111,7 +112,9 @@ def broadcast_params(params, ndims_params):
     return bcast_params
 
 
-def normalize_size_param(size):
+def normalize_size_param(
+    size: Optional[Union[int, np.ndarray, Variable, Sequence]]
+) -> Variable:
     """Create an Aesara value for a ``RandomVariable`` ``size`` parameter."""
     if size is None:
         size = constant([], dtype="int64")

--- a/aesara/tensor/shape.py
+++ b/aesara/tensor/shape.py
@@ -16,7 +16,7 @@ from aesara.tensor import basic as at
 from aesara.tensor import get_vector_length
 from aesara.tensor.exceptions import NotScalarConstantError
 from aesara.tensor.type import TensorType, int_dtypes, tensor
-from aesara.tensor.var import TensorConstant
+from aesara.tensor.var import TensorConstant, TensorVariable
 
 
 def register_shape_c_code(type, code, version=()):
@@ -155,7 +155,7 @@ def _get_vector_length_Shape(op, var):
     return var.owner.inputs[0].type.ndim
 
 
-def shape_tuple(x: Variable) -> Tuple[Variable]:
+def shape_tuple(x: TensorVariable) -> Tuple[Variable, ...]:
     """Get a tuple of symbolic shape values.
 
     This will return a `ScalarConstant` with the value ``1`` wherever

--- a/aesara/tensor/subtensor.py
+++ b/aesara/tensor/subtensor.py
@@ -135,8 +135,8 @@ def as_index_constant(
 
 
 def as_index_literal(
-    idx: Union[Variable, slice, type(np.newaxis)]
-) -> Union[int, slice, type(np.newaxis)]:
+    idx: Optional[Union[Variable, slice]]
+) -> Optional[Union[int, slice]]:
     """Convert a symbolic index element to its Python equivalent.
 
     This is like the inverse of `as_index_constant`

--- a/environment.yml
+++ b/environment.yml
@@ -48,6 +48,7 @@ dependencies:
   # developer tools
   - pre-commit
   - packaging
+  - typing_extensions
   # optional
   - sympy
   - cython

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ diff-cover
 pre-commit
 isort
 packaging
+typing_extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,3 +76,281 @@ lines_between_sections = 1
 honor_noqa = True
 skip_gitignore = True
 skip = aesara/version.py, **/__init__.py
+
+[mypy]
+ignore_missing_imports = True
+no_implicit_optional = True
+check_untyped_defs = False
+strict_equality = True
+warn_redundant_casts = True
+warn_unused_configs = True
+warn_unused_ignores = True
+warn_return_any = True
+warn_no_return = False
+warn_unreachable = True
+show_error_codes = True
+allow_redefinition = False
+files = aesara,tests
+
+[mypy-versioneer]
+check_untyped_defs = False
+
+[mypy-doc.*]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-setup]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-tests.*]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara._version]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.gpuarray.*]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.graph.utils]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.graph.basic]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.graph.op]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.graph.fg]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.graph.opt]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.graph.type]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.graph.optdb]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.graph.opt_utils]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.graph.unify]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.graph.kanren]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.link.basic]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.link.utils]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.link.c.cmodule]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.link.c.cvm]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.link.c.lazylinker_c]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.compile.mode]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.compile.sharedvalue]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.compile.compilelock]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.compile.function.types]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.compile.debugmode]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.scalar.basic]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.scalar.math]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.type]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.var]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.basic]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.elemwise]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.math]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.basic_opt]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.subtensor]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.shape]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.extra_ops]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.type_other]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.blas]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.blas_headers]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.slinalg]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.sharedvar]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.math_opt]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.blas_c]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.random.op]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.random.basic]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.random.utils]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.link.numba.dispatch.extra_ops]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.link.numba.dispatch.elemwise]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.link.numba.dispatch.random]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.link.jax.dispatch]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.raise_op]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.printing]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.scan.op]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.scan.opt]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.scan.scan_perform_ext]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.scan.utils]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.nnet.conv3d2d]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.nnet.neighbours]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.nnet.abstract_conv]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.tensor.nnet.ctc]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.sandbox.*]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.ifelse]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.typed_list.*]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.sparse.basic]
+ignore_errors = True
+check_untyped_defs = False
+
+[mypy-aesara.sparse.sharedvar]
+ignore_errors = True
+check_untyped_defs = False

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ install_requires = [
     "logical-unification",
     "miniKanren",
     "cons",
+    "typing_extensions",
 ]
 
 


### PR DESCRIPTION
This PR adds a `mypy` configuration that should help to diagnose and fix typing problems in the codebase.
(Related to #200, part of #800.)

With a [`mypy_groupby.py` script](https://gist.github.com/michaelosthege/24d0703e5f37850c9e5679f69598930a) the mypy results can be grouped by error code instead of location, making it easier to prioritize certain kinds of problems.

In addition to the configuration, I fixed a bunch of type hints, mostly those with `[has-type]`, `[valid-type]` and `[var-annotated]` error codes.

The majority of the fixes were only the annotations and got bundled in one commit.

For some fixes (like missing returns) I had to modify the code itself and because this could possibly effect behavior these went into their own commit.

--------------

Generally, we should use invariant hints like `Sequence[Variable]`/`Iterable[Variable]` instead of `List[Variable]` in function signatures.
That's because lists are invariant and such annotations will require callers to pass lists with the exact same type.
However, mypy doesn't warn about this per se.
After merging #799 it will be much easier to spot such issues from the PyMC/aeppl side.