### PR TITLE
Temporarily pin to `scipy<1.8.0`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - python
   - compilers
   - numpy>=1.17.0
-  - scipy>=0.14
+  - scipy>=0.14,<1.8.0
   - filelock
   - etuples
   - logical-unification

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ CLASSIFIERS = [_f for _f in CLASSIFIERS.split("\n") if _f]
 
 install_requires = [
     "numpy>=1.17.0",
-    "scipy>=0.14",
+    "scipy>=0.14,<1.8.0",
     "filelock",
     "etuples",
     "logical-unification",


### PR DESCRIPTION
A new SciPy release appeared and broke imports.
According to the [release notes](https://github.com/scipy/scipy/releases), they restructured their private/public API.
At least the `scipy.signal´, but probably many more imports need to be refactored until the imports are compatible.
This will most probably increase the lower limit on the SciPy version.

This PR pins to `scipy<1.8.0` to unblock ongoing activities until SciPy 1.8.0 compatibility is established.

Also see tracking issue #810.