### PR TITLE
Support SciPy >= 1.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,7 @@ jobs:
         shell: bash -l {0}
         run: |
           mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython libgpuarray pygpu
-          if [[ $INSTALL_NUMBA == "1" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.52" numba-scipy; fi
+          if [[ $INSTALL_NUMBA == "1" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.55" numba-scipy; fi
           mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib
           pip install -q -r requirements.txt
           mamba list && pip freeze

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,7 @@ jobs:
         python-version: ["3.7", "3.9"]
         fast-compile: [0]
         float32: [0]
+        install-numba: [1]
         part:
           - "tests --ignore=tests/tensor --ignore=tests/sparse --ignore=tests/tensor/nnet"
           - "tests/tensor tests/sparse --ignore=tests/tensor/test_basic.py --ignore=tests/tensor/test_math.py --ignore=tests/tensor/test_math_scipy.py --ignore=tests/tensor/test_inplace.py --ignore=tests/tensor/test_elemwise.py --ignore=tests/tensor/test_basic_opt.py --ignore=tests/tensor/test_math_opt.py --ignore=tests/tensor/nnet"
@@ -80,27 +81,39 @@ jobs:
           - python-version: "3.7"
             fast-compile: 1
             float32: 1
+            install-numba: 1
             part: "tests --ignore=tests/tensor/nnet --ignore=tests/tensor/signal"
           - python-version: "3.7"
             fast-compile: 1
             float32: 0
+            install-numba: 1
             part: "tests --ignore=tests/tensor/nnet --ignore=tests/tensor/signal"
           - python-version: "3.7"
             fast-compile: 1
             float32: 1
+            install-numba: 1
             part: "tests/tensor/nnet"
           - python-version: "3.7"
             fast-compile: 1
             float32: 0
+            install-numba: 1
             part: "tests/tensor/nnet"
           - python-version: "3.7"
             fast-compile: 1
             float32: 1
+            install-numba: 1
             part: "tests/tensor/signal"
           - python-version: "3.7"
             fast-compile: 1
             float32: 0
+            install-numba: 1
             part: "tests/tensor/signal"
+          - python-version: "3.9"
+            fast-compile: 0
+            float32: 0
+            install-numba: 0
+            # This should run using the most recent version of SciPy
+            part: "tests/tensor/nnet/test_conv.py tests/tensor/nnet/test_abstract_conv.py"
 
     steps:
       - uses: actions/checkout@v2
@@ -128,14 +141,16 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython libgpuarray pygpu "numba>=0.52" numba-scipy
-          if [[ "$PYTHON_VERSION" != "3.6" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib; fi
+          mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython libgpuarray pygpu
+          if [[ $INSTALL_NUMBA == "1" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.52" numba-scipy; fi
+          mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib
           pip install -q -r requirements.txt
           mamba list && pip freeze
           python -c 'import aesara; print(aesara.config.__str__(print_doc=False))'
           python -c 'import aesara; assert(aesara.config.blas__ldflags != "")'
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
+          INSTALL_NUMBA: ${{ matrix.install-numba }}
 
       - name: Run tests
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,10 +141,10 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython libgpuarray pygpu
+          mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython pytest coverage pytest-cov sympy
           if [[ $INSTALL_NUMBA == "1" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.55" numba-scipy; fi
           mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib
-          pip install -q -r requirements.txt
+          pip install -e ./
           mamba list && pip freeze
           python -c 'import aesara; print(aesara.config.__str__(print_doc=False))'
           python -c 'import aesara; assert(aesara.config.blas__ldflags != "")'

--- a/aesara/tensor/nnet/abstract_conv.py
+++ b/aesara/tensor/nnet/abstract_conv.py
@@ -15,8 +15,14 @@ except ImportError:
 import warnings
 
 import numpy as np
-from scipy.signal.signaltools import _bvalfromboundary, _valfrommode, convolve
-from scipy.signal.sigtools import _convolve2d
+
+
+try:
+    from scipy.signal.signaltools import _bvalfromboundary, _valfrommode, convolve
+    from scipy.signal.sigtools import _convolve2d
+except ImportError:
+    from scipy.signal._signaltools import _bvalfromboundary, _valfrommode, convolve
+    from scipy.signal._sigtools import _convolve2d
 
 import aesara
 from aesara import tensor as at

--- a/aesara/tensor/nnet/conv.py
+++ b/aesara/tensor/nnet/conv.py
@@ -13,8 +13,14 @@ import logging
 import warnings
 
 import numpy as np
-from scipy.signal.signaltools import _bvalfromboundary, _valfrommode
-from scipy.signal.sigtools import _convolve2d
+
+
+try:
+    from scipy.signal.signaltools import _bvalfromboundary, _valfrommode
+    from scipy.signal.sigtools import _convolve2d
+except ImportError:
+    from scipy.signal._signaltools import _bvalfromboundary, _valfrommode
+    from scipy.signal._sigtools import _convolve2d
 
 import aesara
 from aesara.graph.basic import Apply

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - mkl-service
   - libblas=*=*mkl
   # numba backend
-  - numba
+  - numba>=0.55
   - numba-scipy
   # GPU
   - libgpuarray

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - python
   - compilers
   - numpy>=1.17.0
-  - scipy>=0.14,<1.8.0
+  - scipy>=0.14
   - filelock
   - etuples
   - logical-unification

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ sympy
 versioneer
 jax
 jaxlib
-numba
+numba>=0.55
 numba-scipy>=0.3.0
 diff-cover
 pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ black>=20.8b1
 pytest-cov>=2.6.1
 coverage>=5.1
 pytest
-coveralls
 cython
 sympy
 versioneer

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ CLASSIFIERS = [_f for _f in CLASSIFIERS.split("\n") if _f]
 
 install_requires = [
     "numpy>=1.17.0",
-    "scipy>=0.14,<1.8.0",
+    "scipy>=0.14",
     "filelock",
     "etuples",
     "logical-unification",

--- a/tests/tensor/nnet/speed_test_conv.py
+++ b/tests/tensor/nnet/speed_test_conv.py
@@ -103,8 +103,13 @@ def exec_multilayer_conv_nnet_old(
         outval = np.zeros(np.r_[bsize, outshp])
         if validate:
             # causes an atexit problem
-            from scipy.signal.signaltools import _bvalfromboundary, _valfrommode
-            from scipy.signal.sigtools import _convolve2d
+
+            try:
+                from scipy.signal.signaltools import _bvalfromboundary, _valfrommode
+                from scipy.signal.sigtools import _convolve2d
+            except ImportError:
+                from scipy.signal._signaltools import _bvalfromboundary, _valfrommode
+                from scipy.signal._sigtools import _convolve2d
 
             val = _valfrommode(conv_mode)
             bval = _bvalfromboundary("fill")


### PR DESCRIPTION
This PR make the changes necessary to support SciPy versions greater than 1.8.

- [ ] `numba-scipy` doesn't support SciPy >= 1.8, and that requirement is currently downgrading SciPy to 1.6.1 in CI, so we'll need to alter the CI steps in order to test this.