### PR TITLE
Get vector length alloc

### DIFF
--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -1669,6 +1669,14 @@ alloc = Alloc()
 pprint.assign(alloc, printing.FunctionPrinter(["alloc"]))
 
 
+@_get_vector_length.register(Alloc)
+def _get_vector_length_Alloc(var_inst, var):
+    try:
+        return get_scalar_constant_value(var.owner.inputs[1])
+    except NotScalarConstantError:
+        raise ValueError(f"Length of {var} cannot be determined")
+
+
 def full(shape, fill_value, dtype=None):
     """Return a new array of given shape and type, filled with `fill_value`.
 

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -1172,6 +1172,9 @@ def test_get_vector_length():
 
     assert np.allclose(f(4, 5), [5, 9, 4])
 
+    # Test `Alloc`s
+    assert 3 == get_vector_length(alloc(0, 3))
+
 
 class TestJoinAndSplit:
     # Split is tested by each verify_grad method.


### PR DESCRIPTION
This PR allows for known shapes to be propagated to the outputs of Elemwise Ops

```python
import aesara.tensor as at
x = at.TensorType("float64", (3, 3))()
y = x + 1
y.type.shape  # (3, 3)
```

Probably breaks a lot of other things... just checking what