### PR TITLE
Use static shape in outputs of `Elemwise` and `Alloc` `Op`s

### DIFF
--- a/aesara/compile/function/pfunc.py
+++ b/aesara/compile/function/pfunc.py
@@ -189,11 +189,8 @@ def rebuild_collect_shared(
                 (store_into, update_d[store_into]),
             )
 
-        # filter_variable ensure smooth conversion of cpu Types
         try:
-            update_val = store_into.type.filter_variable(
-                update_val, allow_convert=False
-            )
+            update_val = store_into.type.filter_variable(update_val, allow_convert=True)
         except TypeError:
             err_msg = (
                 "An update must have the same type as the"

--- a/aesara/tensor/nnet/conv3d2d.py
+++ b/aesara/tensor/nnet/conv3d2d.py
@@ -106,7 +106,10 @@ class DiagonalSubtensor(Op):
     def make_node(self, x, i0, i1):
         _i0 = at.as_tensor_variable(i0)
         _i1 = at.as_tensor_variable(i1)
-        return Apply(self, [x, _i0, _i1], [x.type()])
+        # TODO: We could produce a more precise static shape output type
+        type_shape = (1 if shape == 1 else None for shape in x.type.shape)
+        out_type = at.TensorType(x.type.dtype, shape=type_shape)
+        return Apply(self, [x, _i0, _i1], [out_type()])
 
     def perform(self, node, inputs, output_storage):
         xview = get_diagonal_subtensor_view(*inputs)

--- a/tests/tensor/test_elemwise.py
+++ b/tests/tensor/test_elemwise.py
@@ -21,6 +21,7 @@ from aesara.tensor.elemwise import CAReduce, CAReduceDtype, DimShuffle, Elemwise
 from aesara.tensor.exceptions import ShapeError
 from aesara.tensor.math import all as at_all
 from aesara.tensor.math import any as at_any
+from aesara.tensor.math import exp
 from aesara.tensor.type import (
     TensorType,
     bmatrix,
@@ -853,6 +854,27 @@ class TestElemwise(unittest_tools.InferShapeTester):
         (out_shape,) = z.owner.op.infer_shape(None, z.owner, [(lscalar(), 1), (50, 10)])
 
         assert all(isinstance(v.type, TensorType) for v in out_shape)
+
+    def test_static_shape_unary(self):
+        x = tensor("float64", shape=(None, 1, 5))
+        exp(x).type.shape == (None, 1, 5)
+
+    def test_static_shape_binary(self):
+        x = tensor("float64", shape=(None, 5))
+        y = tensor("float64", shape=(None, 5))
+        assert (x + y).type.shape == (None, 5)
+
+        x = tensor("float64", shape=(None, 5))
+        y = tensor("float64", shape=(10, 5))
+        assert (x + y).type.shape == (10, 5)
+
+        x = tensor("float64", shape=(1, 5))
+        y = tensor("float64", shape=(10, 5))
+        assert (x + y).type.shape == (10, 5)
+
+        x = tensor("float64", shape=(None, 1))
+        y = tensor("float64", shape=(1, 1))
+        assert (x + y).type.shape == (None, 1)
 
 
 def test_not_implemented_elemwise_grad():


### PR DESCRIPTION
This PR allows for known shapes to be propagated to the outputs of Elemwise OPs

It won't solve #732, but it doesn't seem like there was a good reason not to do it anyway...

```python
import aesara.tensor as at
x = at.TensorType("float64", (3, 3))()
y = x + 1
y.type.shape  # (3, 3)
```

Probably breaks a lot of other things... just checking what