### PR TITLE
Use `_props_dict` instead of `_props` in `random_make_inplace`

### DIFF
--- a/aesara/tensor/random/opt.py
+++ b/aesara/tensor/random/opt.py
@@ -44,8 +44,9 @@ def random_make_inplace(fgraph, node):
     op = node.op
 
     if isinstance(op, RandomVariable) and not op.inplace:
-        name, ndim_supp, ndims_params, dtype, _ = op._props()
-        new_op = type(op)(name, ndim_supp, ndims_params, dtype, True)
+        props = op._props_dict()
+        props["inplace"] = True
+        new_op = type(op)(**props)
         return new_op.make_node(*node.inputs).outputs
 
     return False


### PR DESCRIPTION
Closes #819 

This PR simply uses the Op's `_props_dict` instead of the `_props` list to create the inplace op in `random_make_inplace`. This enables the re-write to handle any potential extra props that could have been defined in a `RandomVariable` subclass