### PR TITLE
Allow partial shape information in `SpecifyShape` `Op`

### DIFF
--- a/aesara/link/jax/dispatch.py
+++ b/aesara/link/jax/dispatch.py
@@ -335,7 +335,7 @@ def jax_funcify_Shape_i(op, **kwargs):
 
 @jax_funcify.register(SpecifyShape)
 def jax_funcify_SpecifyShape(op, **kwargs):
-    def specifyshape(x, shape):
+    def specifyshape(x, *shape):
         assert x.ndim == len(shape)
         assert jnp.all(x.shape == tuple(shape)), (
             "got shape",

--- a/aesara/tensor/subtensor_opt.py
+++ b/aesara/tensor/subtensor_opt.py
@@ -1646,7 +1646,7 @@ def local_subtensor_SpecifyShape_lift(fgraph, node):
         return False
 
     obj_arg = specify_shape_node.owner.inputs[0]
-    shape_arg = specify_shape_node.owner.inputs[1]
+    shape_arg = specify_shape_node.owner.inputs[1:]
 
     indices = get_idx_list(node.inputs, node.op.idx_list)
 

--- a/tests/link/test_jax.py
+++ b/tests/link/test_jax.py
@@ -185,7 +185,7 @@ def test_jax_specify_shape():
 
     with config.change_flags(compute_test_value="off"):
 
-        x = SpecifyShape()(at.as_tensor_variable(x_np), (2, 3))
+        x = SpecifyShape()(at.as_tensor_variable(x_np), *(2, 3))
         x_fg = FunctionGraph([], [x])
 
         with pytest.raises(AssertionError):

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -896,10 +896,15 @@ def test_Reshape_scalar():
             (1, 1),
             True,
         ),
+        (
+            set_test_value(at.matrix(), np.array([[1.0, 2.0]], dtype=config.floatX)),
+            (1, None),
+            False,
+        ),
     ],
 )
 def test_SpecifyShape(v, shape, fails):
-    g = SpecifyShape()(v, shape)
+    g = SpecifyShape()(v, *shape)
     g_fg = FunctionGraph(outputs=[g])
     cm = contextlib.suppress() if not fails else pytest.raises(AssertionError)
     with cm:

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -22,6 +22,7 @@ from aesara.graph.op import Op
 from aesara.misc.safe_asarray import _asarray
 from aesara.raise_op import Assert
 from aesara.scalar import autocast_float, autocast_float_as
+from aesara.tensor import NoneConst
 from aesara.tensor.basic import (
     Alloc,
     AllocDiag,
@@ -3523,6 +3524,19 @@ class TestGetScalarConstantValue:
         d += 1
         e = extract_constant(c)
         assert e == 3, (c, d, e)
+
+    @pytest.mark.parametrize("only_process_constants", (True, False))
+    def test_None_and_NoneConst(self, only_process_constants):
+        with pytest.raises(NotScalarConstantError):
+            get_scalar_constant_value(
+                None, only_process_constants=only_process_constants
+            )
+        assert (
+            get_scalar_constant_value(
+                NoneConst, only_process_constants=only_process_constants
+            )
+            is None
+        )
 
 
 def test_complex_mod_failure():

--- a/tests/tensor/test_basic_opt.py
+++ b/tests/tensor/test_basic_opt.py
@@ -2975,6 +2975,24 @@ def test_local_Shape_of_SpecifyShape(shape):
     assert shape in fgraph.variables
 
 
+@pytest.mark.parametrize(
+    "s1",
+    [lscalar(), iscalar()],
+)
+def test_local_Shape_of_SpecifyShape_partial(s1):
+    x = matrix()
+    s = specify_shape(x, (s1, None)).shape
+
+    fgraph = FunctionGraph(outputs=[s], clone=False)
+    assert any(isinstance(apply.op, SpecifyShape) for apply in fgraph.apply_nodes)
+
+    _ = optimize_graph(fgraph, clone=False)
+
+    assert x in fgraph.variables
+    assert s1 in fgraph.variables
+    assert not any(isinstance(apply.op, SpecifyShape) for apply in fgraph.apply_nodes)
+
+
 def test_local_Shape_i_of_broadcastable():
     x = tensor(np.float64, [False, True])
     s = Shape_i(1)(x)

--- a/tests/tensor/test_sharedvar.py
+++ b/tests/tensor/test_sharedvar.py
@@ -474,7 +474,7 @@ def makeSharedTester(
             assert np.all(self.ref_fct(specify_shape_fct()) == self.ref_fct(x1_2))
             topo_specify = specify_shape_fct.maker.fgraph.toposort()
             if aesara.config.mode != "FAST_COMPILE":
-                assert len(topo_specify) == 4
+                assert len(topo_specify) == 3
 
             # Test that we put the shape info into the graph
             shape_constant_fct = aesara.function([], x1_specify_shape.shape)

--- a/tests/tensor/test_subtensor_opt.py
+++ b/tests/tensor/test_subtensor_opt.py
@@ -2103,6 +2103,13 @@ def test_local_subtensor_shape_constant():
     "x, s, idx, x_val, s_val",
     [
         (
+            vector(),
+            (iscalar(),),
+            (1,),
+            np.array([1, 2], dtype=config.floatX),
+            np.array([2], dtype=np.int64),
+        ),
+        (
             matrix(),
             (iscalar(), iscalar()),
             (1,),
@@ -2110,16 +2117,38 @@ def test_local_subtensor_shape_constant():
             np.array([2, 2], dtype=np.int64),
         ),
         (
-            vector(),
-            (iscalar(),),
-            (1,),
-            np.array([1, 2], dtype=config.floatX),
-            np.array([2], dtype=np.int64),
+            matrix(),
+            (iscalar(), iscalar()),
+            (0,),
+            np.array([[1, 2, 3], [4, 5, 6]], dtype=config.floatX),
+            np.array([2, 3], dtype=np.int64),
+        ),
+        (
+            matrix(),
+            (iscalar(), iscalar()),
+            (1, 1),
+            np.array([[1, 2, 3], [4, 5, 6]], dtype=config.floatX),
+            np.array([2, 3], dtype=np.int64),
+        ),
+        (
+            tensor3(),
+            (iscalar(), iscalar(), iscalar()),
+            (-1,),
+            np.arange(2 * 3 * 5, dtype=config.floatX).reshape((2, 3, 5)),
+            np.array([2, 3, 5], dtype=np.int64),
+        ),
+        (
+            tensor3(),
+            (iscalar(), iscalar(), iscalar()),
+            (-1, 0),
+            np.arange(2 * 3 * 5, dtype=config.floatX).reshape((2, 3, 5)),
+            np.array([2, 3, 5], dtype=np.int64),
         ),
     ],
 )
 def test_local_subtensor_SpecifyShape_lift(x, s, idx, x_val, s_val):
     y = specify_shape(x, s)[idx]
+    assert isinstance(y.owner.inputs[0].owner.op, SpecifyShape)
 
     opts = OptimizationQuery(include=[None])
     no_opt_mode = Mode(optimizer=opts)
@@ -2130,7 +2159,12 @@ def test_local_subtensor_SpecifyShape_lift(x, s, idx, x_val, s_val):
     # This optimization should appear in the canonicalizations
     y_opt = optimize_graph(y, clone=False)
 
-    assert isinstance(y_opt.owner.op, SpecifyShape)
+    if y.ndim == 0:
+        # SpecifyShape should be removed altogether
+        assert isinstance(y_opt.owner.op, Subtensor)
+        assert y_opt.owner.inputs[0] is x
+    else:
+        assert isinstance(y_opt.owner.op, SpecifyShape)
 
     y_opt_fn = function([x] + list(s), y_opt, on_unused_input="ignore")
     y_opt_val = y_opt_fn(*([x_val] + [s_ for s_ in s_val]))


### PR DESCRIPTION
Shape values of `None` can be used for dimensions that are not fixed

This seemed necessary to replace the more limited use of Rebroadcast in `convert_variable`:
https://github.com/aesara-devs/aesara/blob/c34f37f140a4e3c2006107b7a4dedc26064bb249/aesara/tensor/type.py#L326-L329

The ultimate goal, would be to allow us to work more gradually towards #732, such as in #821

***
Misc ideas:
* Leave original `SpecifyShape` intact and create new `SpecifyPartialShape` (some esoteric optimizations that used to work no longer do, see disabled subtensor tests)