### PR TITLE
Pin `jaxlib` to a version less than or equal to 0.1.75

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython pytest coverage pytest-cov sympy
           if [[ $INSTALL_NUMBA == "1" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.55" numba-scipy; fi
-          mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib
+          mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax "jaxlib <= 0.1.75"
           pip install -e ./
           mamba list && pip freeze
           python -c 'import aesara; print(aesara.config.__str__(print_doc=False))'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cython
 sympy
 versioneer
 jax
-jaxlib
+jaxlib<=0.1.75
 numba>=0.55
 numba-scipy>=0.3.0
 diff-cover


### PR DESCRIPTION
This prevents low-level errors recently introduced by newer versions of `jaxlib` (e.g. see [here](https://github.com/aesara-devs/aesara/runs/5255142205?check_suite_focus=true#step:6:23)).