### PR TITLE
Make `Feature`s less stateful

### DIFF
--- a/aesara/compile/builders.py
+++ b/aesara/compile/builders.py
@@ -47,7 +47,8 @@ def infer_shape(outs, inputs, input_shapes):
             assert len(inp_shp) == inp.type.ndim
 
     shape_feature = ShapeFeature()
-    shape_feature.on_attach(FunctionGraph([], []))
+    dummy_fgraph = FunctionGraph([], [])
+    shape_feature.on_attach(dummy_fgraph)
 
     # Initialize shape_of with the input shapes
     for inp, inp_shp in zip(inputs, input_shapes):
@@ -72,7 +73,6 @@ def infer_shape(outs, inputs, input_shapes):
 
             # shape_feature.on_import does not actually use an fgraph
             # It will call infer_shape and set_shape appropriately
-            dummy_fgraph = None
             shape_feature.on_import(dummy_fgraph, out.owner, reason="dummy")
 
     ret = []

--- a/aesara/graph/destroyhandler.py
+++ b/aesara/graph/destroyhandler.py
@@ -502,7 +502,7 @@ class DestroyHandler(Bookkeeper):
                 )
             elif len(fgraph.clients[inp]) > 1:
                 fgraph.fail_validate[app] = InconsistencyError(
-                    "Destroyed variable has more than one client. " + str(reason)
+                    f"Destroyed variable has more than one client. {reason}"
                 )
             elif inp.owner:
                 app2 = inp.owner
@@ -513,13 +513,13 @@ class DestroyHandler(Bookkeeper):
                     v = v.get(inp_idx2, [])
                     if len(v) > 0:
                         fgraph.fail_validate[app] = InconsistencyError(
-                            "Destroyed variable has view_map. " + str(reason)
+                            f"Destroyed variable has view_map. {reason}"
                         )
                 elif d:
                     d = d.get(inp_idx2, [])
                     if len(d) > 0:
                         fgraph.fail_validate[app] = InconsistencyError(
-                            "Destroyed variable has destroy_map. " + str(reason)
+                            f"Destroyed variable has destroy_map. {reason}"
                         )
 
                 # These 2 assertions are commented since this function is called so many times

--- a/aesara/graph/destroyhandler.py
+++ b/aesara/graph/destroyhandler.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING, Deque, Dict, Iterable, List, Optional, Set, Tu
 from typing import Type as TypingType
 from typing import Union, cast
 
-from typing_extensions import Literal
-
 from aesara.configdefaults import config
 from aesara.graph.basic import Constant
 from aesara.graph.features import AlreadyThere, Bookkeeper
@@ -328,13 +326,7 @@ class DestroyHandler(Bookkeeper):
 
     """
 
-    pickle_rm_attr = ["destroyers", "has_destroyers"]
-
-    def __init__(
-        self,
-        do_imports_on_attach=True,
-        algo: Optional[Literal["fast", "regular"]] = None,
-    ):
+    def __init__(self, do_imports_on_attach=True, algo=None):
         self.do_imports_on_attach = do_imports_on_attach
 
         if algo is None:
@@ -365,8 +357,6 @@ class DestroyHandler(Bookkeeper):
             raise AlreadyThere("DestroyHandler feature is already present")
 
         fgraph.destroy_handler = self
-
-        self.unpickle(fgraph)
 
         fgraph.fail_validate: Dict["Variable", "Variable"] = OrderedDict()
         """
@@ -413,7 +403,6 @@ class DestroyHandler(Bookkeeper):
         if self.do_imports_on_attach:
             super().on_attach(fgraph)
 
-    def unpickle(self, fgraph) -> None:
         def get_destroyers_of(
             fgraph: "FunctionGraph", r: "Variable"
         ) -> List["Variable"]:

--- a/aesara/graph/type.py
+++ b/aesara/graph/type.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Any, Generic, Optional, Text, Tuple, TypeVar, Union
 
 from typing_extensions import TypeAlias
@@ -262,14 +262,33 @@ class Type(MetaObject, Generic[D]):
         return cls.values_eq(a, b)
 
 
-class HasDataType:
+class HasDataType(ABC):
     """A mixin for a type that has a :attr:`dtype` attribute."""
 
     dtype: str
 
+    @classmethod
+    def __subclasshook__(cls, C):
+        if cls is HasDataType:
+            if any("dtype" in B.__dict__ for B in C.__mro__):
+                return True
+        return NotImplemented
 
-class HasShape:
+
+class HasShape(ABC):
     """A mixin for a type that has :attr:`shape` and :attr:`ndim` attributes."""
 
     ndim: int
     shape: Tuple[Optional[int], ...]
+
+    @classmethod
+    def __subclasshook__(cls, C):
+        if cls is HasShape:
+            has_shape, has_ndim = False, False
+            for B in C.__mro__:
+                has_shape = has_shape or ("shape" in B.__dict__)
+                has_ndim = has_ndim or ("ndim" in B.__dict__)
+
+                if has_shape and has_ndim:
+                    return True
+        return NotImplemented

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -69,6 +69,8 @@ from aesara.tensor.var import TensorConstant, TensorVariable, get_unique_value
 
 
 if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
     from aesara.tensor import TensorLike
 
 
@@ -260,8 +262,11 @@ _scalar_constant_value_elemwise_ops = (
 
 
 def get_scalar_constant_value(
-    orig_v, elemwise=True, only_process_constants=False, max_recur=10
-):
+    orig_v,
+    elemwise: bool = True,
+    only_process_constants: bool = False,
+    max_recur: int = 10,
+) -> "NDArray":
     """Return the constant scalar(0-D) value underlying variable `v`.
 
     If `v` is the output of dimshuffles, fills, allocs, etc,

--- a/aesara/tensor/rewriting/basic.py
+++ b/aesara/tensor/rewriting/basic.py
@@ -326,7 +326,7 @@ def local_elemwise_alloc(fgraph, node):
         return False
 
     input_shapes = [
-        tuple(fgraph.shape_feature.get_shape(i, j) for j in range(i.type.ndim))
+        tuple(fgraph.shape_feature.get_shape(fgraph, i, j) for j in range(i.type.ndim))
         for i in node.inputs
     ]
     bcasted_shape = broadcast_shape(
@@ -1022,7 +1022,7 @@ def local_useless_switch(fgraph, node):
             out = correct_out
 
         input_shapes = [
-            tuple(shape_feature.get_shape(inp, i) for i in range(inp.type.ndim))
+            tuple(shape_feature.get_shape(fgraph, inp, i) for i in range(inp.type.ndim))
             for inp in node.inputs
         ]
 

--- a/aesara/typed_list/type.py
+++ b/aesara/typed_list/type.py
@@ -146,3 +146,4 @@ class TypedListType(CType):
 
     dtype = property(lambda self: self.ttype)
     ndim = property(lambda self: self.ttype.ndim + 1)
+    shape = property(lambda self: (None,) + self.ttype.shape)

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -188,27 +188,27 @@ import ``aesara`` and print the config variable, as in:
 
 .. attribute:: cycle_detection
 
-    String value, either ``regular`` or ``fast```
+    String value, either ``"regular"`` or ``"fast"```
 
-    Default: ``regular``
+    Default: ``"regular"``
 
-    If :attr:`cycle_detection` is set to ``regular``, most in-place operations are allowed,
-    but graph compilation is slower. If :attr:`cycle_detection` is set to ``faster``,
+    If :attr:`cycle_detection` is set to ``"regular"``, most in-place operations are allowed,
+    but graph compilation is slower. If :attr:`cycle_detection` is set to ``"fast"``,
     less in-place operations are allowed, but graph compilation is faster.
 
 .. attribute:: check_stack_trace
 
-    String value, either ``off``, ``log``, ``warn``, ``raise``
+    String value, either ``"off"``, ``"log"``, ``"warn"``, ``"raise"``
 
-    Default: ``off``
+    Default: ``"off"``
 
     This is a flag for checking stack traces during graph rewriting.
-    If :attr:`check_stack_trace` is set to ``off``, no check is performed on the
-    stack trace. If :attr:`check_stack_trace` is set to ``log`` or ``warn``, a
+    If :attr:`check_stack_trace` is set to ``"off"``, no check is performed on the
+    stack trace. If :attr:`check_stack_trace` is set to ``"log"`` or ``"warn"``, a
     dummy stack trace is inserted that indicates which rewrite inserted the
-    variable that had an empty stack trace, but, when ``warn`` is set, a warning
+    variable that had an empty stack trace, but, when ``"warn"`` is set, a warning
     is also printed.
-    If :attr:`check_stack_trace` is set to ``raise``, an exception is raised if a
+    If :attr:`check_stack_trace` is set to ``"raise"``, an exception is raised if a
     stack trace is missing.
 
 .. attribute:: openmp

--- a/tests/graph/test_destroyhandler.py
+++ b/tests/graph/test_destroyhandler.py
@@ -1,3 +1,4 @@
+import pickle
 from copy import copy
 
 import pytest
@@ -460,3 +461,17 @@ def test_multiple_inplace():
     ).rewrite(g)
     assert g.consistent()
     assert fail.failures == 1
+
+
+def test_pickle():
+    x, y, z = inputs()
+    tv = transpose_view(x)
+    e = add_in_place(x, tv)
+    fg = create_fgraph([x, y], [e], False)
+    assert not fg.consistent()
+
+    fg_pkld = pickle.dumps(fg)
+    fg_unpkld = pickle.loads(fg_pkld)
+
+    assert any(isinstance(ft, DestroyHandler) for ft in fg_unpkld._features)
+    assert all(hasattr(fg, attr) for attr in ("_destroyhandler_destroyers",))

--- a/tests/graph/test_features.py
+++ b/tests/graph/test_features.py
@@ -60,17 +60,12 @@ class TestNodeFinder:
         def MyVariable(name):
             return Variable(MyType(name), None, None)
 
-        def inputs():
-            x = MyVariable("x")
-            y = MyVariable("y")
-            z = MyVariable("z")
-            return x, y, z
-
-        x, y, z = inputs()
+        x, y, z = MyVariable("x"), MyVariable("y"), MyVariable("z")
         e0 = dot(y, z)
         e = add(add(sigmoid(x), sigmoid(sigmoid(z))), dot(add(x, y), e0))
         g = FunctionGraph([x, y, z], [e], clone=False)
-        g.attach_feature(NodeFinder())
+        nf = NodeFinder()
+        g.attach_feature(nf)
 
         assert hasattr(g, "get_nodes")
         for type, num in ((add, 3), (sigmoid, 3), (dot, 2)):
@@ -85,6 +80,10 @@ class TestNodeFinder:
         for type, num in ((add, 4), (sigmoid, 3), (dot, 1)):
             if len([t for t in g.get_nodes(type)]) != num:
                 raise Exception("Expected: %i times %s" % (num, type))
+
+        g.remove_feature(nf)
+        assert not hasattr(g, "get_nodes")
+        assert not hasattr(g, "_finder_ops_to_nodes")
 
 
 class TestReplaceValidate:


### PR DESCRIPTION
This PR moves most `Feature`s' state (e.g. variables/collections used to track the state of a `FunctionGraph`) to the `FunctionGraph` upon which the `Feature`s are operating, instead of dedicating one `Feature` and its state to a single `FunctionGraph`&mdash;as is currently done.  With these changes, a few complications surrounding `FunctionGraph` `pickle`ing and the general dynamic addition/attachment of `Feature`s are more easily addressed and/or avoided altogether.

Some more details:
* Many `Feature`s aren't truly stateful in a way that makes the relevant state specific to the `Feature` as much as the `FunctionGraph`.  In other words, most `Feature`s really only care about the state of the `FunctionGraph`s on which they operate, so, if that state is held by the `FunctionGraph`s themselves, `Feature`s can be more versatile.
* It's not possible/easy to transfer `Feature`s from one `FunctionGraph` to another (e.g. as is attempted in `FunctionGraph.clone_get_equiv`), because many `Feature`s are unnecessarily dedicated to a single `FunctionGraph`.