### PR TITLE
Fix the Numba implementation of `CauchyRV`

### DIFF
--- a/aesara/link/numba/dispatch/random.py
+++ b/aesara/link/numba/dispatch/random.py
@@ -96,6 +96,8 @@ def make_numba_random_fn(node, np_random_func):
     The functions generated here add parameter broadcasting and the ``size``
     argument to the Numba-supported scalar ``np.random`` functions.
     """
+    if not isinstance(node.inputs[0], (RandomStateType, RandomStateSharedVariable)):
+        raise TypeError("Numba does not support NumPy `Generator`s")
 
     tuple_size = int(get_vector_length(node.inputs[1]))
     size_dims = tuple_size - max(i.ndim for i in node.inputs[3:])
@@ -215,9 +217,6 @@ def numba_funcify_RandomVariable(op, node, **kwargs):
     name = op.name
     np_random_func = getattr(np.random, name)
 
-    if not isinstance(node.inputs[0], (RandomStateType, RandomStateSharedVariable)):
-        raise TypeError("Numba does not support NumPy `Generator`s")
-
     return make_numba_random_fn(node, np_random_func)
 
 
@@ -271,9 +270,6 @@ def {np_random_fn_name}({np_input_names}):
 
 @numba_funcify.register(aer.NegBinomialRV)
 def numba_funcify_NegBinomialRV(op, node, **kwargs):
-    if not isinstance(node.inputs[0], (RandomStateType, RandomStateSharedVariable)):
-        raise TypeError("Numba does not support NumPy `Generator`s")
-
     return make_numba_random_fn(node, np.random.negative_binomial)
 
 

--- a/aesara/link/numba/dispatch/random.py
+++ b/aesara/link/numba/dispatch/random.py
@@ -204,7 +204,6 @@ def {sized_fn_name}({random_fn_input_names}):
 @numba_funcify.register(aer.PoissonRV)
 @numba_funcify.register(aer.GeometricRV)
 @numba_funcify.register(aer.HyperGeometricRV)
-@numba_funcify.register(aer.CauchyRV)
 @numba_funcify.register(aer.WaldRV)
 @numba_funcify.register(aer.LaplaceRV)
 @numba_funcify.register(aer.BinomialRV)
@@ -269,6 +268,14 @@ def {np_random_fn_name}({np_input_names}):
     )
 
     return make_numba_random_fn(node, np_random_fn)
+
+
+@numba_funcify.register(aer.CauchyRV)
+def numba_funcify_CauchyRV(op, node, **kwargs):
+    def body_fn(loc, scale):
+        return f"    return ({loc} + np.random.standard_cauchy()) / {scale}"
+
+    return create_numba_random_fn(op, node, body_fn)
 
 
 @numba_funcify.register(aer.HalfNormalRV)

--- a/aesara/link/numba/dispatch/random.py
+++ b/aesara/link/numba/dispatch/random.py
@@ -207,7 +207,6 @@ def {sized_fn_name}({random_fn_input_names}):
 @numba_funcify.register(aer.WaldRV)
 @numba_funcify.register(aer.LaplaceRV)
 @numba_funcify.register(aer.BinomialRV)
-@numba_funcify.register(aer.NegBinomialRV)
 @numba_funcify.register(aer.MultinomialRV)
 @numba_funcify.register(aer.RandIntRV)  # only the first two arguments are supported
 @numba_funcify.register(aer.ChoiceRV)  # the `p` argument is not supported
@@ -268,6 +267,14 @@ def {np_random_fn_name}({np_input_names}):
     )
 
     return make_numba_random_fn(node, np_random_fn)
+
+
+@numba_funcify.register(aer.NegBinomialRV)
+def numba_funcify_NegBinomialRV(op, node, **kwargs):
+    if not isinstance(node.inputs[0], (RandomStateType, RandomStateSharedVariable)):
+        raise TypeError("Numba does not support NumPy `Generator`s")
+
+    return make_numba_random_fn(node, np.random.negative_binomial)
 
 
 @numba_funcify.register(aer.CauchyRV)

--- a/aesara/tensor/random/basic.py
+++ b/aesara/tensor/random/basic.py
@@ -559,6 +559,7 @@ class NegBinomialRV(ScipyRandomVariable):
 
 
 nbinom = NegBinomialRV()
+negative_binomial = NegBinomialRV()
 
 
 class BetaBinomialRV(ScipyRandomVariable):
@@ -803,4 +804,5 @@ __all__ = [
     "triangular",
     "uniform",
     "standard_normal",
+    "negative_binomial",
 ]

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -2946,21 +2946,20 @@ def test_shared():
             ],
             at.as_tensor([3, 2]),
         ),
-        # pytest.param(
-        #     aer.negative_binomial,
-        #     [
-        #         set_test_value(
-        #             at.lvector(),
-        #             np.array([1, 2], dtype=np.int64),
-        #         ),
-        #         set_test_value(
-        #             at.dscalar(),
-        #             np.array(0.9, dtype=np.float64),
-        #         ),
-        #     ],
-        #     at.as_tensor([3, 2]),
-        #     marks=pytest.mark.xfail(reason="Not implemented"),
-        # ),
+        (
+            aer.negative_binomial,
+            [
+                set_test_value(
+                    at.lvector(),
+                    np.array([1, 2], dtype=np.int64),
+                ),
+                set_test_value(
+                    at.dscalar(),
+                    np.array(0.9, dtype=np.float64),
+                ),
+            ],
+            at.as_tensor([3, 2]),
+        ),
         (
             aer.normal,
             [

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -2902,7 +2902,7 @@ def test_shared():
                 ),
             ],
             at.as_tensor([3, 2]),
-            marks=pytest.mark.xfail(reason="Not implemented"),
+            marks=pytest.mark.xfail(reason="Numba and NumPy rng states do not match"),
         ),
         (
             aer.wald,

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -3075,7 +3075,6 @@ def test_aligned_RandomVariable(rv_op, dist_args, size):
             ),
         ),
     ],
-    ids=str,
 )
 def test_unaligned_RandomVariable(rv_op, dist_args, base_size, cdf_name, params_conv):
     """Tests for Numba samplers that are not one-to-one with Aesara's/NumPy's samplers."""
@@ -3143,7 +3142,6 @@ def test_unaligned_RandomVariable(rv_op, dist_args, base_size, cdf_name, params_
             pytest.raises(ValueError, match="Parameters shape.*"),
         ),
     ],
-    ids=str,
 )
 def test_CategoricalRV(rv_op, dist_args, size, cm):
     rng = shared(np.random.RandomState(29402))


### PR DESCRIPTION
This PR fixes the Numba implementation of `CauchyRV`.

The current tests for `RandomVariable` implementations that don't match the Aesara/NumPy RNG states need to be updated, because they're all set to `xfail` and&mdash;as a result&mdash;do not really verifying anything.  I might fix that in this PR as well.