### PR TITLE
Refactor updates functionality and `Scan` inner-graph compilation

### DIFF
--- a/aesara/compile/builders.py
+++ b/aesara/compile/builders.py
@@ -800,7 +800,7 @@ class OpFromGraph(Op, HasInnerGraph):
             # If the new shared variables are inconsistent with the inner-graph,
             # such errors should arise in this step
             new_inner_outputs = clone_replace(
-                self.inner_outputs, replace=replace, share_inputs=True
+                self.inner_outputs, replace=replace, copy_inputs_over=True
             )
 
             # It's possible that the new shared variable inputs aren't actually

--- a/aesara/compile/builders.py
+++ b/aesara/compile/builders.py
@@ -1,5 +1,6 @@
 """Define new Ops from existing Ops"""
 from collections import OrderedDict
+from copy import copy
 from functools import partial
 from typing import List, Optional, Sequence, cast
 
@@ -914,6 +915,11 @@ class OpFromGraph(Op, HasInnerGraph):
     @property
     def inner_outputs(self):
         return self.fgraph.outputs
+
+    def clone(self):
+        res = copy(self)
+        res.fgraph = res.fgraph.clone()
+        return res
 
     def perform(self, node, inputs, outputs):
         variables = self.fn(*inputs)

--- a/aesara/compile/debugmode.py
+++ b/aesara/compile/debugmode.py
@@ -433,7 +433,9 @@ def _optcheck_fgraph(input_specs, output_specs, accept_inplace=False):
 
     """
     equivalence_tracker = _VariableEquivalenceTracker()
-    fgraph, updates = std_fgraph(input_specs, output_specs, accept_inplace)
+    fgraph, updates = std_fgraph(
+        input_specs, output_specs, accept_inplace, force_clone=True
+    )
     fgraph.attach_feature(equivalence_tracker)
     return fgraph, updates, equivalence_tracker
 
@@ -2006,6 +2008,7 @@ class _Maker(FunctionMaker):  # inheritance buys a few helper functions
         fgraph=None,  # If present the optimized graph. we ignore it.
         output_keys=None,
         name=None,
+        no_fgraph_prep=False,
     ):
         self.mode = mode
         self.profile = profile

--- a/aesara/compile/debugmode.py
+++ b/aesara/compile/debugmode.py
@@ -31,7 +31,7 @@ from aesara.compile.ops import OutputGuard, _output_guard
 from aesara.configdefaults import config
 from aesara.graph.basic import Variable, io_toposort
 from aesara.graph.destroyhandler import DestroyHandler
-from aesara.graph.features import BadOptimization
+from aesara.graph.features import AlreadyThere, BadOptimization
 from aesara.graph.op import HasInnerGraph, Op
 from aesara.graph.utils import InconsistencyError, MethodNotDefined
 from aesara.link.basic import Container, LocalLinker
@@ -1206,7 +1206,9 @@ class _VariableEquivalenceTracker:
         self.fgraph = None
 
     def on_attach(self, fgraph):
-        assert self.fgraph is None
+        if self.fgraph is not None:
+            raise AlreadyThere()
+
         self.equiv = {}
         self.active_nodes = set()
         self.inactive_nodes = set()

--- a/aesara/compile/debugmode.py
+++ b/aesara/compile/debugmode.py
@@ -2152,6 +2152,7 @@ class _Maker(FunctionMaker):  # inheritance buys a few helper functions
         fgraph.name = name
         self.indices = indices
         self.inputs = inputs
+        # TODO: Get rid of all this `expanded_inputs` nonsense
         self.expanded_inputs = inputs
         self.outputs = outputs
         self.unpack_single = unpack_single

--- a/aesara/compile/function/types.py
+++ b/aesara/compile/function/types.py
@@ -110,6 +110,9 @@ def fgraph_updated_vars(fgraph, expanded_inputs):
     Reconstruct the full "updates" dictionary, mapping from FunctionGraph input
     variables to the fgraph outputs that will replace their values.
 
+    TODO: Get rid of all this `expanded_inputs` nonsense and use
+    only `fgraph.update_mapping`.
+
     Returns
     -------
     dict variable -> variable
@@ -555,6 +558,7 @@ class Function:
         self._value = ValueAttribute()
         self._container = ContainerAttribute()
 
+        # TODO: Get rid of all this `expanded_inputs` nonsense
         assert len(self.maker.expanded_inputs) == len(self.input_storage)
 
         # This is used only when `fn.need_update_inputs` is `False`, because
@@ -1048,6 +1052,8 @@ class Function:
                     # WARNING: This circumvents the 'readonly' attribute in x
                     o_container.storage[0] = None
 
+        # TODO: Get rid of this and `expanded_inputs`, since all the VMs now
+        # perform the updates themselves
         if getattr(self.fn, "need_update_inputs", True):
             # Update the inputs that have an update function
             for input, storage in reversed(
@@ -1565,11 +1571,15 @@ class FunctionMaker:
             self.linker = linker.accept(fgraph, profile=profile)
 
         if hasattr(linker, "accept_var_updates"):
-            # hacky thing so VMLinker knows about updates
+            # TODO: This is a hack that makes `VMLinker` aware of updates;
+            # clean this up.
             self.linker.accept_var_updates(fgraph_updated_vars(fgraph, inputs))
+
         fgraph.name = name
         self.indices = indices
         self.inputs = inputs
+
+        # TODO: Get rid of all this `expanded_inputs` nonsense
         self.expanded_inputs = inputs
         self.outputs = outputs
         self.unpack_single = unpack_single

--- a/aesara/compile/function/types.py
+++ b/aesara/compile/function/types.py
@@ -116,12 +116,14 @@ def fgraph_updated_vars(fgraph, expanded_inputs):
 
     """
     updated_vars = {}
-    potential_values = list(fgraph.outputs)  # copy the list
+
     if len(expanded_inputs) != len(fgraph.inputs):
         raise ValueError("expanded_inputs must match len(fgraph.inputs)")
-    for e_input, ivar in reversed(list(zip(expanded_inputs, fgraph.inputs))):
-        if e_input.update is not None:
-            updated_vars[ivar] = potential_values.pop()
+
+    for out_idx, in_idx in fgraph.update_mapping.items():
+        assert expanded_inputs[in_idx].update is not None
+        updated_vars[fgraph.inputs[in_idx]] = fgraph.outputs[out_idx]
+
     return updated_vars
 
 

--- a/aesara/compile/function/types.py
+++ b/aesara/compile/function/types.py
@@ -142,6 +142,9 @@ class Supervisor(Feature):
         self.fgraph = None
         self.protected = list(protected)
 
+    def clone(self):
+        return type(self)(self.protected)
+
     def on_attach(self, fgraph):
         if hasattr(fgraph, "_supervisor"):
             raise AlreadyThere(f"A Supervisor is already attached to {fgraph}.")

--- a/aesara/compile/io.py
+++ b/aesara/compile/io.py
@@ -197,7 +197,7 @@ class In(SymbolicInput):
         # the input can be destroyed. borrow simply implies the output can be
         # aliased to the input. Thus mutable=True should require borrow=True.
         if mutable and not self.borrow:
-            raise AssertionError(
+            raise ValueError(
                 f"Symbolic input for variable {variable} (name={name}) has "
                 "flags mutable=True, borrow=False. This combination is "
                 "incompatible since mutable=True implies that the "

--- a/aesara/compile/mode.py
+++ b/aesara/compile/mode.py
@@ -7,7 +7,6 @@ import logging
 import warnings
 from typing import Optional, Tuple, Union
 
-import aesara
 from aesara.compile.function.types import Supervisor
 from aesara.configdefaults import config
 from aesara.graph.destroyhandler import DestroyHandler
@@ -441,9 +440,7 @@ class Mode:
 # FunctionMaker, the Mode will be taken from this dictionary using the
 # string as the key
 # Use VM_linker to allow lazy evaluation by default.
-FAST_COMPILE = Mode(
-    aesara.link.vm.VMLinker(use_cloop=False, c_thunks=False), "fast_compile"
-)
+FAST_COMPILE = Mode(VMLinker(use_cloop=False, c_thunks=False), "fast_compile")
 if config.cxx:
     FAST_RUN = Mode("cvm", "fast_run")
 else:

--- a/aesara/compile/mode.py
+++ b/aesara/compile/mode.py
@@ -137,9 +137,7 @@ class AddDestroyHandler(GlobalOptimizer):
                 break
         if not supervisor_added:
             warnings.warn(
-                "Supervisor is not added. Please build a FunctionGraph"
-                "via aesara.compile.function.types.std_graph()"
-                "or add the Supervisor class manually.",
+                f"A Supervisor feature is missing from {fgraph}.",
                 stacklevel=3,
             )
 

--- a/aesara/compile/profiling.py
+++ b/aesara/compile/profiling.py
@@ -217,7 +217,7 @@ class ProfileStats:
     #
 
     vm_call_time = 0.0
-    # Total time spent in Function.fn.__call__
+    # Total time spent in Function.vm.__call__
     #
 
     apply_time = None
@@ -781,7 +781,7 @@ class ProfileStats:
         )
         if self.fct_call_time > 0:
             print(
-                f"  Time in Function.fn.__call__: {self.vm_call_time}s ({100 * self.vm_call_time / self.fct_call_time:.3f}%)",
+                f"  Time in Function.vm.__call__: {self.vm_call_time}s ({100 * self.vm_call_time / self.fct_call_time:.3f}%)",
                 file=file,
             )
             local_time = sum(self.apply_time.values())

--- a/aesara/configdefaults.py
+++ b/aesara/configdefaults.py
@@ -1186,10 +1186,10 @@ def add_vm_configvars():
 
     config.add(
         "vm__lazy",
-        "Useful only for the vm linkers. When lazy is None,"
+        "Useful only for the VM Linkers. When lazy is None,"
         " auto detect if lazy evaluation is needed and use the appropriate"
-        " version. If lazy is True/False, force the version used between"
-        " Loop/LoopGC and Stack.",
+        " version. If the C loop isn't being used and lazy is True, use "
+        "the Stack VM; otherwise, use the Loop VM.",
         ConfigParam("None", apply=_filter_vm_lazy),
         in_c_key=False,
     )

--- a/aesara/gradient.py
+++ b/aesara/gradient.py
@@ -13,7 +13,7 @@ import aesara
 from aesara.compile.ops import ViewOp
 from aesara.configdefaults import config
 from aesara.graph import utils
-from aesara.graph.basic import Variable
+from aesara.graph.basic import NominalVariable, Variable
 from aesara.graph.null_type import NullType, null_type
 from aesara.graph.op import get_test_values
 from aesara.graph.type import Type
@@ -1295,15 +1295,16 @@ def _populate_grad_dict(var_to_app_to_idx, grad_dict, wrt, cost_name=None):
                 # has the right shape
                 if hasattr(term, "shape"):
                     orig_ipt = inputs[i]
-                    for orig_ipt_v, term_v in get_test_values(orig_ipt, term):
-                        i_shape = orig_ipt_v.shape
-                        t_shape = term_v.shape
-                        if i_shape != t_shape:
-                            raise ValueError(
-                                f"{node.op}.grad returned object of "
-                                f"shape {t_shape} as gradient term on input {int(i)} "
-                                f"of shape {i_shape}"
-                            )
+                    if not isinstance(orig_ipt, NominalVariable):
+                        for orig_ipt_v, term_v in get_test_values(orig_ipt, term):
+                            i_shape = orig_ipt_v.shape
+                            t_shape = term_v.shape
+                            if i_shape != t_shape:
+                                raise ValueError(
+                                    f"{node.op}.grad returned object of "
+                                    f"shape {t_shape} as gradient term on input {int(i)} "
+                                    f"of shape {i_shape}"
+                                )
 
                 if not isinstance(term.type, (NullType, DisconnectedType)):
                     if term.type.dtype not in aesara.tensor.type.float_dtypes:

--- a/aesara/graph/basic.py
+++ b/aesara/graph/basic.py
@@ -1139,9 +1139,9 @@ def clone_replace(
 
     Parameters
     ----------
-    output : Aesara Variables (or Aesara expressions)
+    output
         Aesara expression that represents the computational graph.
-    replace : dict
+    replace
         Dictionary describing which subgraphs should be replaced by what.
     rebuild_kwds
         Keywords to `rebuild_collect_shared`.

--- a/aesara/graph/destroyhandler.py
+++ b/aesara/graph/destroyhandler.py
@@ -347,24 +347,12 @@ class DestroyHandler(Bookkeeper):  # noqa
 
         """
 
-        # Do the checking #
-        already_there = False
-        if self.fgraph is fgraph:
-            already_there = True
-        if self.fgraph is not None:
-            raise Exception(
-                "A DestroyHandler instance can only serve one"
-                " FunctionGraph. (Matthew 6:24)"
-            )
-        for attr in ("destroyers", "destroy_handler"):
-            if hasattr(fgraph, attr):
-                already_there = True
+        if any(hasattr(fgraph, attr) for attr in ("destroyers", "destroy_handler")):
+            raise AlreadyThere("DestroyHandler feature is already present")
 
-        if already_there:
-            # FunctionGraph.attach_feature catches AlreadyThere and cancels the attachment
-            raise AlreadyThere(
-                "DestroyHandler feature is already present"
-                " or in conflict with another plugin."
+        if self.fgraph is not None and self.fgraph != fgraph:
+            raise Exception(
+                "A DestroyHandler instance can only serve one FunctionGraph"
             )
 
         # Annotate the FunctionGraph #

--- a/aesara/graph/destroyhandler.py
+++ b/aesara/graph/destroyhandler.py
@@ -330,6 +330,9 @@ class DestroyHandler(Bookkeeper):  # noqa
         self.algo = algo
         self.fail_validate = OrderedDict()
 
+    def clone(self):
+        return type(self)(self.do_imports_on_attach, self.algo)
+
     def on_attach(self, fgraph):
         """
         When attaching to a new fgraph, check that

--- a/aesara/graph/features.py
+++ b/aesara/graph/features.py
@@ -641,14 +641,10 @@ class NodeFinder(Bookkeeper):
         self.d = {}
 
     def on_attach(self, fgraph):
-        if self.fgraph is not None:
-            raise Exception(
-                "A NodeFinder instance can only serve one " "FunctionGraph."
-            )
         if hasattr(fgraph, "get_nodes"):
-            raise AlreadyThere(
-                "NodeFinder is already present or in conflict" " with another plugin."
-            )
+            raise AlreadyThere("NodeFinder is already present")
+        if self.fgraph is not None and self.fgraph != fgraph:
+            raise Exception("A NodeFinder instance can only serve one FunctionGraph.")
         self.fgraph = fgraph
         fgraph.get_nodes = partial(self.query, fgraph)
         Bookkeeper.on_attach(self, fgraph)

--- a/aesara/graph/fg.py
+++ b/aesara/graph/fg.py
@@ -18,7 +18,7 @@ from typing_extensions import Literal
 
 import aesara
 from aesara.configdefaults import config
-from aesara.graph.basic import Apply, AtomicVariable, Node, Variable, applys_between
+from aesara.graph.basic import Apply, AtomicVariable, Variable, applys_between
 from aesara.graph.basic import as_string as graph_as_string
 from aesara.graph.basic import clone_get_equiv, graph_inputs, io_toposort, vars_between
 from aesara.graph.features import AlreadyThere, Feature, ReplaceValidate
@@ -69,7 +69,7 @@ class FunctionGraph(MetaObject):
         features: Optional[Sequence[Feature]] = None,
         clone: bool = True,
         update_mapping: Optional[Dict[Variable, Variable]] = None,
-        memo: Optional[Dict[Variable, Variable]] = None,
+        memo: Optional[Dict] = None,
         copy_inputs: bool = True,
         copy_orphans: bool = True,
     ):
@@ -111,7 +111,7 @@ class FunctionGraph(MetaObject):
                 outputs,
                 copy_inputs=copy_inputs,
                 copy_orphans=copy_orphans,
-                memo=cast(Dict[Node, Node], memo),
+                memo=memo,
             )
             outputs = [cast(Variable, _memo[o]) for o in outputs]
             inputs = [cast(Variable, _memo[i]) for i in inputs]
@@ -869,7 +869,7 @@ class FunctionGraph(MetaObject):
 
     def clone_get_equiv(
         self, check_integrity: bool = True, attach_feature: bool = True
-    ) -> Tuple["FunctionGraph", Dict[Node, Node]]:
+    ) -> Tuple["FunctionGraph", Dict]:
         """Clone the graph and return a ``dict`` that maps old nodes to new nodes.
 
         Parameters

--- a/aesara/graph/fg.py
+++ b/aesara/graph/fg.py
@@ -900,7 +900,7 @@ class FunctionGraph(MetaObject):
 
         if attach_feature:
             for feature in self._features:
-                e.attach_feature(feature)
+                e.attach_feature(feature.clone())
         return e, equiv
 
     def __getstate__(self):

--- a/aesara/graph/fg.py
+++ b/aesara/graph/fg.py
@@ -18,7 +18,7 @@ from typing_extensions import Literal
 
 import aesara
 from aesara.configdefaults import config
-from aesara.graph.basic import Apply, Constant, Node, Variable, applys_between
+from aesara.graph.basic import Apply, AtomicVariable, Node, Variable, applys_between
 from aesara.graph.basic import as_string as graph_as_string
 from aesara.graph.basic import clone_get_equiv, graph_inputs, io_toposort, vars_between
 from aesara.graph.features import AlreadyThere, Feature, ReplaceValidate
@@ -101,7 +101,9 @@ class FunctionGraph(MetaObject):
             raise ValueError("No outputs specified")
 
         if inputs is None:
-            inputs = [i for i in graph_inputs(outputs) if not isinstance(i, Constant)]
+            inputs = [
+                i for i in graph_inputs(outputs) if not isinstance(i, AtomicVariable)
+            ]
 
         if clone:
             _memo = clone_get_equiv(
@@ -306,7 +308,7 @@ class FunctionGraph(MetaObject):
             self.import_node(var.owner, reason=reason, import_missing=import_missing)
         elif (
             var.owner is None
-            and not isinstance(var, Constant)
+            and not isinstance(var, AtomicVariable)
             and var not in self.inputs
         ):
             from aesara.graph.null_type import NullType
@@ -354,7 +356,7 @@ class FunctionGraph(MetaObject):
                 for var in node.inputs:
                     if (
                         var.owner is None
-                        and not isinstance(var, Constant)
+                        and not isinstance(var, AtomicVariable)
                         and var not in self.inputs
                     ):
                         if import_missing:
@@ -515,9 +517,6 @@ class FunctionGraph(MetaObject):
                     )
 
         for node, i in list(self.clients[var]):
-            assert (node == "output" and self.outputs[i] is var) or (
-                isinstance(node, Apply) and node.inputs[i] is var
-            )
             self.change_node_input(
                 node, i, new_var, reason=reason, import_missing=import_missing
             )
@@ -839,7 +838,7 @@ class FunctionGraph(MetaObject):
             if (
                 variable.owner is None
                 and variable not in self.inputs
-                and not isinstance(variable, Constant)
+                and not isinstance(variable, AtomicVariable)
             ):
                 raise Exception(f"Undeclared input: {variable}")
             for cl_node, i in self.clients[variable]:

--- a/aesara/graph/op.py
+++ b/aesara/graph/op.py
@@ -1,7 +1,7 @@
 import copy
 import sys
 import warnings
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -612,7 +612,7 @@ class _NoPythonOp(Op):
         raise NotImplementedError("No Python implementation is provided by this Op.")
 
 
-class HasInnerGraph:
+class HasInnerGraph(ABC):
     r"""A mixin for an `Op` that contain an inner graph."""
 
     fgraph: "FunctionGraph"
@@ -621,7 +621,7 @@ class HasInnerGraph:
     @property
     @abstractmethod
     def fn(self) -> "Function":
-        """The inner function."""
+        """The compiled inner-graph function."""
 
     @property
     @abstractmethod
@@ -632,6 +632,10 @@ class HasInnerGraph:
     @abstractmethod
     def inner_outputs(self) -> List[Variable]:
         """The inner function's outputs."""
+
+    @abstractmethod
+    def clone(self) -> Op:
+        """Clone the `Op` and its inner-graph."""
 
 
 def get_test_value(v: Any) -> Any:

--- a/aesara/graph/op.py
+++ b/aesara/graph/op.py
@@ -615,6 +615,9 @@ class _NoPythonOp(Op):
 class HasInnerGraph:
     r"""A mixin for an `Op` that contain an inner graph."""
 
+    fgraph: "FunctionGraph"
+    """A `FunctionGraph` of the inner function."""
+
     @property
     @abstractmethod
     def fn(self) -> "Function":

--- a/aesara/graph/opt.py
+++ b/aesara/graph/opt.py
@@ -534,6 +534,9 @@ class MergeFeature(Feature):
         for node in fgraph.toposort():
             self.on_import(fgraph, node, "on_attach")
 
+    def clone(self):
+        return type(self)()
+
     def on_change_input(self, fgraph, node, i, r, new_r, reason):
         if node in self.nodes_seen:
             # If inputs to a node change, it's not guaranteed that the node is
@@ -2105,6 +2108,9 @@ class ChangeTracker(Feature):
     def __init__(self):
         self.changed = False
         self.nb_imported = 0
+
+    def clone(self):
+        return type(self)()
 
     def on_import(self, fgraph, node, reason):
         self.nb_imported += 1

--- a/aesara/graph/opt.py
+++ b/aesara/graph/opt.py
@@ -31,7 +31,7 @@ from aesara.graph.basic import (
     io_toposort,
     vars_between,
 )
-from aesara.graph.features import Feature, NodeFinder
+from aesara.graph.features import AlreadyThere, Feature, NodeFinder
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.op import Op
 from aesara.graph.utils import AssocList, InconsistencyError
@@ -496,7 +496,9 @@ class MergeFeature(Feature):
     """
 
     def on_attach(self, fgraph):
-        assert not hasattr(fgraph, "merge_feature")
+        if hasattr(fgraph, "merge_feature"):
+            raise AlreadyThere()
+
         fgraph.merge_feature = self
 
         self.seen_atomics = set()
@@ -2111,6 +2113,8 @@ class ChangeTracker(Feature):
         self.changed = False
 
     def on_attach(self, fgraph):
+        if hasattr(fgraph, "change_tracker"):
+            raise AlreadyThere()
         fgraph.change_tracker = self
 
     def on_detach(self, fgraph):

--- a/aesara/graph/opt.py
+++ b/aesara/graph/opt.py
@@ -353,6 +353,10 @@ class SeqOptimizer(GlobalOptimizer, UserList):
             nb_nodes,
             callbacks_time,
         ) = prof
+
+        validate_time = validate_time or float("nan")
+        callback_time = callback_time or float("nan")
+
         blanc = "    " * level
 
         print(blanc, "SeqOptimizer", end=" ", file=stream)
@@ -804,6 +808,9 @@ class MergeOptimizer(GlobalOptimizer):
             nb_merged,
             nb_atomic,
         ) = prof
+
+        validate_time = validate_time or float("nan")
+        callback_time = callback_time or float("nan")
 
         blanc = "    " * level
         print(blanc, "MergeOptimizer", file=stream)

--- a/aesara/graph/opt.py
+++ b/aesara/graph/opt.py
@@ -276,7 +276,7 @@ class SeqOptimizer(GlobalOptimizer, UserList):
                 try:
                     nb_nodes_before = len(fgraph.apply_nodes)
                     t0 = time.time()
-                    sub_prof = optimizer.optimize(fgraph)
+                    sub_prof = optimizer.apply(fgraph)
                     l.append(float(time.time() - t0))
                     sub_profs.append(sub_prof)
                     nb_nodes.append((nb_nodes_before, len(fgraph.apply_nodes)))
@@ -323,6 +323,10 @@ class SeqOptimizer(GlobalOptimizer, UserList):
 
     def __repr__(self):
         return f"SeqOpt({self.data})"
+
+    def add_requirements(self, fgraph):
+        for opt in self.data:
+            opt.add_requirements(fgraph)
 
     def print_summary(self, stream=sys.stdout, level=0, depth=-1):
         name = getattr(self, "name", None)

--- a/aesara/graph/utils.py
+++ b/aesara/graph/utils.py
@@ -3,7 +3,7 @@ import sys
 import traceback
 from abc import ABCMeta
 from io import StringIO
-from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, TypeVar, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Tuple, TypeVar, Union
 
 
 if TYPE_CHECKING:
@@ -281,6 +281,13 @@ class Scratchpad:
         print(f"<aesara.graph.utils.scratchpad instance at {id(self)}>")
         for k, v in self.__dict__.items():
             print(f"  {k}: {v}")
+
+    # These two methods have been added to help Mypy
+    def __getattribute__(self, name):
+        return super().__getattribute__(name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        self.__dict__[name] = value
 
 
 class ValidatingScratchpad(Scratchpad):

--- a/aesara/link/c/c_code/lazylinker_c.c
+++ b/aesara/link/c/c_code/lazylinker_c.c
@@ -1,12 +1,12 @@
-#include <Python.h>
 #include "aesara_mod_helper.h"
 #include "structmember.h"
+#include <Python.h>
 #include <sys/time.h>
 
 #if PY_VERSION_HEX >= 0x03000000
 #include "numpy/npy_3kcompat.h"
-#define PyCObject_AsVoidPtr  NpyCapsule_AsVoidPtr
-#define PyCObject_GetDesc  NpyCapsule_GetDesc
+#define PyCObject_AsVoidPtr NpyCapsule_AsVoidPtr
+#define PyCObject_GetDesc NpyCapsule_GetDesc
 #define PyCObject_Check NpyCapsule_Check
 #endif
 
@@ -18,52 +18,79 @@
 
 TODO:
 - Check max supported depth of recursion
-- CLazyLinker should add context information to errors caught during evaluation. Say what node we were on, add the traceback attached to the node.
+- CLazyLinker should add context information to errors caught during evaluation.
+Say what node we were on, add the traceback attached to the node.
 - Clear containers of fully-useed intermediate results if allow_gc is 1
 - Add timers for profiling
 - Add support for profiling space used.
 
 
   */
-static double pytime(const struct timeval * tv)
-{
+static double pytime(const struct timeval *tv) {
   struct timeval t;
-  if (!tv)
-    {
-      tv = &t;
-      gettimeofday(&t, NULL);
-    }
-  return (double) tv->tv_sec + (double) tv->tv_usec / 1000000.0;
+  if (!tv) {
+    tv = &t;
+    gettimeofday(&t, NULL);
+  }
+  return (double)tv->tv_sec + (double)tv->tv_usec / 1000000.0;
 }
 
 /**
   Helper routine to convert a PyList of integers to a c array of integers.
   */
-static int unpack_list_of_ssize_t(PyObject * pylist, Py_ssize_t **dst, Py_ssize_t *len,
-                                  const char* kwname)
-{
+static int unpack_list_of_ssize_t(PyObject *pylist, Py_ssize_t **dst,
+                                  Py_ssize_t *len, const char *kwname) {
   Py_ssize_t buflen, *buf;
-  if (!PyList_Check(pylist))
-    {
-      PyErr_Format(PyExc_TypeError, "%s must be list", kwname);
+  if (!PyList_Check(pylist)) {
+    PyErr_Format(PyExc_TypeError, "%s must be list", kwname);
+    return -1;
+  }
+  assert(NULL == *dst);
+  *len = buflen = PyList_Size(pylist);
+  *dst = buf = (Py_ssize_t *)calloc(buflen, sizeof(Py_ssize_t));
+  assert(buf);
+  for (int ii = 0; ii < buflen; ++ii) {
+    PyObject *el_i = PyList_GetItem(pylist, ii);
+    Py_ssize_t n_i = PyNumber_AsSsize_t(el_i, PyExc_IndexError);
+    if (PyErr_Occurred()) {
+      free(buf);
+      *dst = NULL;
       return -1;
     }
-  assert (NULL == *dst);
-  *len = buflen = PyList_Size(pylist);
-  *dst = buf = (Py_ssize_t*)calloc(buflen, sizeof(Py_ssize_t));
+    buf[ii] = n_i;
+  }
+  return 0;
+}
+
+static int unpack_nested_tuples_of_ssize_t(PyObject *pytuple, Py_ssize_t **dst,
+                                           Py_ssize_t *len,
+                                           const char *kwname) {
+  Py_ssize_t buflen, *buf;
+  if (!PyTuple_Check(pytuple)) {
+    PyErr_Format(PyExc_TypeError, "%s must be a tuple of tuples", kwname);
+    return -1;
+  }
+  *len = buflen = PyTuple_Size(pytuple);
+  *dst = buf = (Py_ssize_t *) malloc(sizeof(Py_ssize_t *) * buflen * 2);
   assert(buf);
-  for (int ii = 0; ii < buflen; ++ii)
-    {
-      PyObject * el_i = PyList_GetItem(pylist, ii);
-      Py_ssize_t n_i = PyNumber_AsSsize_t(el_i, PyExc_IndexError);
-      if (PyErr_Occurred())
-        {
-          free(buf);
-          *dst = NULL;
-          return -1;
-        }
-      buf[ii] = n_i;
+  for (int ii = 0; ii < buflen; ++ii) {
+    PyObject *el_i = PyTuple_GetItem(pytuple, ii);
+
+    PyObject *el_i_1 = PyTuple_GetItem(el_i, 0);
+    PyObject *el_i_2 = PyTuple_GetItem(el_i, 1);
+
+    Py_ssize_t n_1 = PyNumber_AsSsize_t(el_i_1, PyExc_IndexError);
+    Py_ssize_t n_2 = PyNumber_AsSsize_t(el_i_2, PyExc_IndexError);
+
+    if (PyErr_Occurred()) {
+      free(buf);
+      dst = NULL;
+      return -1;
     }
+
+    buf[ii * 2 + 0] = n_1;
+    buf[ii * 2 + 1] = n_2;
+  }
   return 0;
 }
 
@@ -74,53 +101,53 @@ static int unpack_list_of_ssize_t(PyObject * pylist, Py_ssize_t **dst, Py_ssize_
 
   */
 typedef struct {
-    PyObject_HEAD
-    /* Type-specific fields go here. */
-    PyObject * nodes; // the python list of nodes
-    PyObject * thunks; // python list of thunks
-    PyObject * pre_call_clear; //list of cells to clear on call.
-    int allow_gc;
-    Py_ssize_t n_applies;
-    int n_vars;    // number of variables in the graph
-    int * var_computed; // 1 or 0 for every variable
-    PyObject ** var_computed_cells;
-    PyObject ** var_value_cells;
-    Py_ssize_t **dependencies; // list of vars dependencies for GC
-    Py_ssize_t *n_dependencies;
+  PyObject_HEAD
+      /* Type-specific fields go here. */
+      PyObject *nodes;      // the python list of nodes
+  PyObject *thunks;         // python list of thunks
+  PyObject *pre_call_clear; // list of cells to clear on call.
+  int allow_gc;
+  Py_ssize_t n_applies;
+  int n_vars;        // number of variables in the graph
+  int *var_computed; // 1 or 0 for every variable
+  PyObject **var_computed_cells;
+  PyObject **var_value_cells;
+  Py_ssize_t **dependencies; // list of vars dependencies for GC
+  Py_ssize_t *n_dependencies;
 
-    Py_ssize_t n_output_vars;
-    Py_ssize_t * output_vars; // variables that *must* be evaluated by call
+  Py_ssize_t n_output_vars;
+  Py_ssize_t *output_vars; // variables that *must* be evaluated by call
 
-    int * is_lazy; // 1 or 0 for every thunk
+  int *is_lazy; // 1 or 0 for every thunk
 
-    Py_ssize_t * var_owner; // nodes[[var_owner[var_idx]]] is var[var_idx]->owner
-    int * var_has_owner; //  1 or 0
+  Py_ssize_t *var_owner; // nodes[[var_owner[var_idx]]] is var[var_idx]->owner
+  int *var_has_owner;    //  1 or 0
 
-    Py_ssize_t * node_n_inputs;
-    Py_ssize_t * node_n_outputs;
-    Py_ssize_t ** node_inputs;
-    Py_ssize_t ** node_outputs;
-    Py_ssize_t * node_inputs_outputs_base; // node_inputs and node_outputs point into this
-    Py_ssize_t * node_n_prereqs;
-    Py_ssize_t ** node_prereqs;
+  Py_ssize_t *node_n_inputs;
+  Py_ssize_t *node_n_outputs;
+  Py_ssize_t **node_inputs;
+  Py_ssize_t **node_outputs;
+  Py_ssize_t
+      *node_inputs_outputs_base; // node_inputs and node_outputs point into this
+  Py_ssize_t *node_n_prereqs;
+  Py_ssize_t **node_prereqs;
 
-    Py_ssize_t * update_storage; // input cells to update with the last outputs in output_vars
-    Py_ssize_t n_updates;
+  Py_ssize_t *update_storage; // (input_idx, output_idx) pairs specifying
+                              // output-to-input updates
+  Py_ssize_t n_updates;
 
-    void ** thunk_cptr_fn;
-    void ** thunk_cptr_data;
-    PyObject * call_times;
-    PyObject * call_counts;
-    int do_timing;
-    int need_update_inputs;
-    int position_of_error; // -1 for no error, otw the index into `thunks` that failed.
+  void **thunk_cptr_fn;
+  void **thunk_cptr_data;
+  PyObject *call_times;
+  PyObject *call_counts;
+  int do_timing;
+  int need_update_inputs;
+  int position_of_error; // -1 for no error, otw the index into `thunks` that
+                         // failed.
 } CLazyLinker;
 
-
-static void
-CLazyLinker_dealloc(PyObject* _self)
-{
-  CLazyLinker* self = (CLazyLinker *) _self;
+static void CLazyLinker_dealloc(PyObject *_self) {
+  CLazyLinker *self = (CLazyLinker *)_self;
   free(self->thunk_cptr_fn);
   free(self->thunk_cptr_data);
 
@@ -128,13 +155,11 @@ CLazyLinker_dealloc(PyObject* _self)
 
   free(self->update_storage);
 
-  if (self->node_n_prereqs)
-    {
-      for (int i = 0; i < self->n_applies; ++i)
-        {
-          free(self->node_prereqs[i]);
-        }
+  if (self->node_n_prereqs) {
+    for (int i = 0; i < self->n_applies; ++i) {
+      free(self->node_prereqs[i]);
     }
+  }
   free(self->node_n_prereqs);
   free(self->node_prereqs);
   free(self->node_inputs_outputs_base);
@@ -143,27 +168,23 @@ CLazyLinker_dealloc(PyObject* _self)
   free(self->node_inputs);
   free(self->node_outputs);
 
-  if (self->dependencies)
-    {
-      for (int i = 0; i < self->n_vars; ++i)
-        {
-          free(self->dependencies[i]);
-        }
-      free(self->dependencies);
-      free(self->n_dependencies);
+  if (self->dependencies) {
+    for (int i = 0; i < self->n_vars; ++i) {
+      free(self->dependencies[i]);
     }
+    free(self->dependencies);
+    free(self->n_dependencies);
+  }
 
   free(self->var_owner);
   free(self->var_has_owner);
   free(self->var_computed);
-  if (self->var_computed_cells)
-    {
-      for (int i = 0; i < self->n_vars; ++i)
-        {
-          Py_DECREF(self->var_computed_cells[i]);
-          Py_DECREF(self->var_value_cells[i]);
-        }
+  if (self->var_computed_cells) {
+    for (int i = 0; i < self->n_vars; ++i) {
+      Py_DECREF(self->var_computed_cells[i]);
+      Py_DECREF(self->var_value_cells[i]);
     }
+  }
   free(self->var_computed_cells);
   free(self->var_value_cells);
   free(self->output_vars);
@@ -173,393 +194,361 @@ CLazyLinker_dealloc(PyObject* _self)
   Py_XDECREF(self->call_times);
   Py_XDECREF(self->call_counts);
   Py_XDECREF(self->pre_call_clear);
-  Py_TYPE(self)->tp_free((PyObject*)self);
+  Py_TYPE(self)->tp_free((PyObject *)self);
 }
-static PyObject *
-CLazyLinker_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
-{
-    CLazyLinker *self;
+static PyObject *CLazyLinker_new(PyTypeObject *type, PyObject *args,
+                                 PyObject *kwds) {
+  CLazyLinker *self;
 
-    self = (CLazyLinker *)type->tp_alloc(type, 0);
-    if (self != NULL) {
-      self->nodes = NULL;
-      self->thunks = NULL;
-      self->pre_call_clear = NULL;
+  self = (CLazyLinker *)type->tp_alloc(type, 0);
+  if (self != NULL) {
+    self->nodes = NULL;
+    self->thunks = NULL;
+    self->pre_call_clear = NULL;
 
-      self->allow_gc = 1;
-      self->n_applies = 0;
-      self->n_vars = 0;
-      self->var_computed = NULL;
-      self->var_computed_cells = NULL;
-      self->var_value_cells = NULL;
-      self->dependencies = NULL;
-      self->n_dependencies = NULL;
+    self->allow_gc = 1;
+    self->n_applies = 0;
+    self->n_vars = 0;
+    self->var_computed = NULL;
+    self->var_computed_cells = NULL;
+    self->var_value_cells = NULL;
+    self->dependencies = NULL;
+    self->n_dependencies = NULL;
 
-      self->n_output_vars = 0;
-      self->output_vars = NULL;
+    self->n_output_vars = 0;
+    self->output_vars = NULL;
 
-      self->is_lazy = NULL;
+    self->is_lazy = NULL;
 
-      self->var_owner = NULL;
-      self->var_has_owner = NULL;
+    self->var_owner = NULL;
+    self->var_has_owner = NULL;
 
-      self->node_n_inputs = NULL;
-      self->node_n_outputs = NULL;
-      self->node_inputs = NULL;
-      self->node_outputs = NULL;
-      self->node_inputs_outputs_base = NULL;
-      self->node_prereqs = NULL;
-      self->node_n_prereqs = NULL;
+    self->node_n_inputs = NULL;
+    self->node_n_outputs = NULL;
+    self->node_inputs = NULL;
+    self->node_outputs = NULL;
+    self->node_inputs_outputs_base = NULL;
+    self->node_prereqs = NULL;
+    self->node_n_prereqs = NULL;
 
-      self->update_storage = NULL;
-      self->n_updates = 0;
+    self->update_storage = NULL;
+    self->n_updates = 0;
 
-      self->thunk_cptr_data = NULL;
-      self->thunk_cptr_fn = NULL;
-      self->call_times = NULL;
-      self->call_counts = NULL;
-      self->do_timing = 0;
+    self->thunk_cptr_data = NULL;
+    self->thunk_cptr_fn = NULL;
+    self->call_times = NULL;
+    self->call_counts = NULL;
+    self->do_timing = 0;
 
-      self->need_update_inputs = 0;
-      self->position_of_error = -1;
-    }
-    return (PyObject *)self;
+    self->need_update_inputs = 0;
+    self->position_of_error = -1;
+  }
+  return (PyObject *)self;
 }
 
-static int
-CLazyLinker_init(CLazyLinker *self, PyObject *args, PyObject *kwds)
-{
-    static char *kwlist[] = {
-      (char*)"nodes",
-      (char*)"thunks",
-      (char*)"pre_call_clear",
-      (char*)"allow_gc",
-      (char*)"call_counts",
-      (char*)"call_times",
-      (char*)"compute_map_list",
-      (char*)"storage_map_list",
-      (char*)"base_input_output_list",
-      (char*)"node_n_inputs",
-      (char*)"node_n_outputs",
-      (char*)"node_input_offset",
-      (char*)"node_output_offset",
-      (char*)"var_owner",
-      (char*)"is_lazy_list",
-      (char*)"output_vars",
-      (char*)"node_prereqs",
-      (char*)"node_output_size",
-      (char*)"update_storage",
-      (char*)"dependencies",
-      NULL};
+static int CLazyLinker_init(CLazyLinker *self, PyObject *args, PyObject *kwds) {
+  static char *kwlist[] = {(char *)"nodes",
+                           (char *)"thunks",
+                           (char *)"pre_call_clear",
+                           (char *)"allow_gc",
+                           (char *)"call_counts",
+                           (char *)"call_times",
+                           (char *)"compute_map_list",
+                           (char *)"storage_map_list",
+                           (char *)"base_input_output_list",
+                           (char *)"node_n_inputs",
+                           (char *)"node_n_outputs",
+                           (char *)"node_input_offset",
+                           (char *)"node_output_offset",
+                           (char *)"var_owner",
+                           (char *)"is_lazy_list",
+                           (char *)"output_vars",
+                           (char *)"node_prereqs",
+                           (char *)"node_output_size",
+                           (char *)"update_storage",
+                           (char *)"dependencies",
+                           NULL};
 
-    PyObject *compute_map_list=NULL,
-             *storage_map_list=NULL,
-             *base_input_output_list=NULL,
-             *node_n_inputs=NULL,
-             *node_n_outputs=NULL,
-             *node_input_offset=NULL,
-             *node_output_offset=NULL,
-             *var_owner=NULL,
-             *is_lazy=NULL,
-             *output_vars=NULL,
-             *node_prereqs=NULL,
-             *node_output_size=NULL,
-             *update_storage=NULL,
-             *dependencies=NULL;
+  PyObject *compute_map_list = NULL, *storage_map_list = NULL,
+           *base_input_output_list = NULL, *node_n_inputs = NULL,
+           *node_n_outputs = NULL, *node_input_offset = NULL,
+           *node_output_offset = NULL, *var_owner = NULL, *is_lazy = NULL,
+           *output_vars = NULL, *node_prereqs = NULL, *node_output_size = NULL,
+    *dependencies = NULL, *update_storage=NULL;
 
-    assert(!self->nodes);
-    if (! PyArg_ParseTupleAndKeywords(args, kwds, "OOOiOOOOOOOOOOOOOOOO", kwlist,
-                                      &self->nodes,
-                                      &self->thunks,
-                                      &self->pre_call_clear,
-                                      &self->allow_gc,
-                                      &self->call_counts,
-                                      &self->call_times,
-                                      &compute_map_list,
-                                      &storage_map_list,
-                                      &base_input_output_list,
-                                      &node_n_inputs,
-                                      &node_n_outputs,
-                                      &node_input_offset,
-                                      &node_output_offset,
-                                      &var_owner,
-                                      &is_lazy,
-                                      &output_vars,
-                                      &node_prereqs,
-                                      &node_output_size,
-                                      &update_storage,
-                                      &dependencies
-                                      ))
-        return -1;
-    Py_INCREF(self->nodes);
-    Py_INCREF(self->thunks);
-    Py_INCREF(self->pre_call_clear);
-    Py_INCREF(self->call_counts);
-    Py_INCREF(self->call_times);
+  assert(!self->nodes);
+  if (!PyArg_ParseTupleAndKeywords(
+          args, kwds, "OOOiOOOOOOOOOOOOOOOO", kwlist, &self->nodes,
+          &self->thunks, &self->pre_call_clear, &self->allow_gc,
+          &self->call_counts, &self->call_times, &compute_map_list,
+          &storage_map_list, &base_input_output_list, &node_n_inputs,
+          &node_n_outputs, &node_input_offset, &node_output_offset, &var_owner,
+          &is_lazy, &output_vars, &node_prereqs, &node_output_size,
+          &update_storage, &dependencies))
+    return -1;
+  Py_INCREF(self->nodes);
+  Py_INCREF(self->thunks);
+  Py_INCREF(self->pre_call_clear);
+  Py_INCREF(self->call_counts);
+  Py_INCREF(self->call_times);
 
-    Py_ssize_t n_applies = PyList_Size(self->nodes);
+  Py_ssize_t n_applies = PyList_Size(self->nodes);
 
-    self->n_applies = n_applies;
-    self->n_vars = PyList_Size(var_owner);
+  self->n_applies = n_applies;
+  self->n_vars = PyList_Size(var_owner);
 
-    if (PyList_Size(self->thunks) != n_applies) return -1;
-    if (PyList_Size(self->call_counts) != n_applies) return -1;
-    if (PyList_Size(self->call_times) != n_applies) return -1;
+  if (PyList_Size(self->thunks) != n_applies)
+    return -1;
+  if (PyList_Size(self->call_counts) != n_applies)
+    return -1;
+  if (PyList_Size(self->call_times) != n_applies)
+    return -1;
 
-    // allocated and initialize thunk_cptr_data and thunk_cptr_fn
-    if (n_applies)
-      {
-        self->thunk_cptr_data = (void**)calloc(n_applies, sizeof(void*));
-        self->thunk_cptr_fn = (void**)calloc(n_applies, sizeof(void*));
-        self->is_lazy = (int*)calloc(n_applies, sizeof(int));
-        self->node_prereqs = (Py_ssize_t**)calloc(n_applies, sizeof(Py_ssize_t*));
-        self->node_n_prereqs = (Py_ssize_t*)calloc(n_applies, sizeof(Py_ssize_t));
-        assert(self->node_prereqs);
-        assert(self->node_n_prereqs);
-        assert(self->is_lazy);
-        assert(self->thunk_cptr_fn);
-        assert(self->thunk_cptr_data);
+  // allocated and initialize thunk_cptr_data and thunk_cptr_fn
+  if (n_applies) {
+    self->thunk_cptr_data = (void **)calloc(n_applies, sizeof(void *));
+    self->thunk_cptr_fn = (void **)calloc(n_applies, sizeof(void *));
+    self->is_lazy = (int *)calloc(n_applies, sizeof(int));
+    self->node_prereqs = (Py_ssize_t **)calloc(n_applies, sizeof(Py_ssize_t *));
+    self->node_n_prereqs = (Py_ssize_t *)calloc(n_applies, sizeof(Py_ssize_t));
+    assert(self->node_prereqs);
+    assert(self->node_n_prereqs);
+    assert(self->is_lazy);
+    assert(self->thunk_cptr_fn);
+    assert(self->thunk_cptr_data);
 
-        for (int i = 0; i < n_applies; ++i)
-          {
-            PyObject * thunk = PyList_GetItem(self->thunks, i);
-            //thunk is borrowed
-            if (PyObject_HasAttrString(thunk, "cthunk"))
-              {
-                PyObject * cthunk = PyObject_GetAttrString(thunk, "cthunk");
-                //new reference
-                assert (cthunk && PyCObject_Check(cthunk));
-                self->thunk_cptr_fn[i] = PyCObject_AsVoidPtr(cthunk);
-                self->thunk_cptr_data[i] = PyCObject_GetDesc(cthunk);
-                Py_DECREF(cthunk);
-                // cthunk is kept alive by membership in self->thunks
-              }
-
-            PyObject * el_i = PyList_GetItem(is_lazy, i);
-            self->is_lazy[i] = PyNumber_AsSsize_t(el_i, NULL);
-
-            /* now get the prereqs */
-            el_i = PyList_GetItem(node_prereqs, i);
-            assert (PyList_Check(el_i));
-            self->node_n_prereqs[i] = PyList_Size(el_i);
-            if (self->node_n_prereqs[i])
-              {
-                self->node_prereqs[i] = (Py_ssize_t*)malloc(
-                              PyList_Size(el_i)*sizeof(Py_ssize_t));
-                for (int j = 0; j < PyList_Size(el_i); ++j)
-                  {
-                    PyObject * el_ij = PyList_GetItem(el_i, j);
-                    Py_ssize_t N = PyNumber_AsSsize_t(el_ij, PyExc_IndexError);
-                    if (PyErr_Occurred())
-                      return -1;
-                    // N < n. variables
-                    assert(N < PyList_Size(var_owner));
-                    self->node_prereqs[i][j] = N;
-                  }
-              }
-          }
-      }
-    if (PyList_Check(base_input_output_list))
-      {
-        Py_ssize_t n_inputs_outputs_base = PyList_Size(base_input_output_list);
-        self->node_inputs_outputs_base = (Py_ssize_t*)calloc(n_inputs_outputs_base,sizeof(Py_ssize_t));
-        assert(self->node_inputs_outputs_base);
-        for (int i = 0; i < n_inputs_outputs_base; ++i)
-          {
-            PyObject *el_i = PyList_GetItem(base_input_output_list, i);
-            Py_ssize_t idx = PyNumber_AsSsize_t(el_i, PyExc_IndexError);
-            if (PyErr_Occurred()) return -1;
-            self->node_inputs_outputs_base[i] = idx;
-          }
-        self->node_n_inputs = (Py_ssize_t*)calloc(n_applies,sizeof(Py_ssize_t));
-        assert(self->node_n_inputs);
-        self->node_n_outputs = (Py_ssize_t*)calloc(n_applies,sizeof(Py_ssize_t));
-        assert(self->node_n_outputs);
-        self->node_inputs = (Py_ssize_t**)calloc(n_applies,sizeof(Py_ssize_t*));
-        assert(self->node_inputs);
-        self->node_outputs = (Py_ssize_t**)calloc(n_applies,sizeof(Py_ssize_t*));
-        assert(self->node_outputs);
-        for (int i = 0; i < n_applies; ++i)
-          {
-            Py_ssize_t N;
-            N = PyNumber_AsSsize_t(PyList_GetItem(node_n_inputs, i),PyExc_IndexError);
-            if (PyErr_Occurred()) return -1;
-            assert (N <= n_inputs_outputs_base);
-            self->node_n_inputs[i] = N;
-            N = PyNumber_AsSsize_t(PyList_GetItem(node_n_outputs, i),PyExc_IndexError);
-            if (PyErr_Occurred()) return -1;
-            assert (N <= n_inputs_outputs_base);
-            self->node_n_outputs[i] = N;
-            N = PyNumber_AsSsize_t(PyList_GetItem(node_input_offset, i),PyExc_IndexError);
-            if (PyErr_Occurred()) return -1;
-            assert (N <= n_inputs_outputs_base);
-            self->node_inputs[i] = &self->node_inputs_outputs_base[N];
-            N = PyNumber_AsSsize_t(PyList_GetItem(node_output_offset, i),PyExc_IndexError);
-            if (PyErr_Occurred()) return -1;
-            assert (N <= n_inputs_outputs_base);
-            self->node_outputs[i] = &self->node_inputs_outputs_base[N];
-          }
-      }
-    else
-      {
-        PyErr_SetString(PyExc_TypeError, "base_input_output_list must be list");
-        return -1;
+    for (int i = 0; i < n_applies; ++i) {
+      PyObject *thunk = PyList_GetItem(self->thunks, i);
+      // thunk is borrowed
+      if (PyObject_HasAttrString(thunk, "cthunk")) {
+        PyObject *cthunk = PyObject_GetAttrString(thunk, "cthunk");
+        // new reference
+        assert(cthunk && PyCObject_Check(cthunk));
+        self->thunk_cptr_fn[i] = PyCObject_AsVoidPtr(cthunk);
+        self->thunk_cptr_data[i] = PyCObject_GetDesc(cthunk);
+        Py_DECREF(cthunk);
+        // cthunk is kept alive by membership in self->thunks
       }
 
-    // allocation for var_owner
-    if (PyList_Check(var_owner))
-      {
-        self->var_owner = (Py_ssize_t*)calloc(self->n_vars,sizeof(Py_ssize_t));
-        self->var_has_owner = (int*)calloc(self->n_vars,sizeof(int));
-        self->var_computed = (int*)calloc(self->n_vars,sizeof(int));
-        self->var_computed_cells = (PyObject**)calloc(self->n_vars,sizeof(PyObject*));
-        self->var_value_cells = (PyObject**)calloc(self->n_vars,sizeof(PyObject*));
-        for (int i = 0; i < self->n_vars; ++i)
-          {
-            PyObject * el_i = PyList_GetItem(var_owner, i);
-            if (el_i == Py_None)
-              {
-                self->var_has_owner[i] = 0;
-              }
-            else
-              {
-                Py_ssize_t N = PyNumber_AsSsize_t(el_i, PyExc_IndexError);
-                if (PyErr_Occurred()) return -1;
-                assert (N <= n_applies);
-                self->var_owner[i] = N;
-                self->var_has_owner[i] = 1;
-              }
-            self->var_computed_cells[i] = PyList_GetItem(compute_map_list, i);
-            Py_INCREF(self->var_computed_cells[i]);
-            self->var_value_cells[i] = PyList_GetItem(storage_map_list, i);
-            Py_INCREF(self->var_value_cells[i]);
-          }
-      }
-    else
-      {
-        PyErr_SetString(PyExc_TypeError, "var_owner must be list");
-        return -1;
-      }
+      PyObject *el_i = PyList_GetItem(is_lazy, i);
+      self->is_lazy[i] = PyNumber_AsSsize_t(el_i, NULL);
 
-    if (dependencies != Py_None)
-      {
-        self->dependencies = (Py_ssize_t**)calloc(self->n_vars, sizeof(Py_ssize_t *));
-        self->n_dependencies = (Py_ssize_t*)calloc(self->n_vars, sizeof(Py_ssize_t));
-        assert(self->dependencies);
-        assert(self->n_dependencies);
-
-        for (int i = 0; i < self->n_vars; ++i)
-          {
-            PyObject *tmp = PyList_GetItem(dependencies, i);
-            // refcounting - tmp is borrowed
-            if (unpack_list_of_ssize_t(tmp, &self->dependencies[i], &self->n_dependencies[i],
-                                       "dependencies"))
-              return -1;
-          }
-      }
-
-    if (unpack_list_of_ssize_t(output_vars, &self->output_vars, &self->n_output_vars,
-                               "output_vars"))
-      return -1;
-    for (int i = 0; i < self->n_output_vars; ++i)
-      {
-        assert(self->output_vars[i] < self->n_vars);
-      }
-    if (unpack_list_of_ssize_t(update_storage, &self->update_storage, &self->n_updates,
-                               "updates_storage"))
-      return -1;
-    return 0;
-}
-static void set_position_of_error(CLazyLinker * self, int owner_idx)
-{
-  if (self->position_of_error == -1)
-    {
-      self->position_of_error = owner_idx;
-    }
-}
-static PyObject * pycall(CLazyLinker * self, Py_ssize_t node_idx, int verbose)
-{
-  // call thunk to see which inputs it wants
-  PyObject * thunk = PyList_GetItem(self->thunks, node_idx);
-  // refcounting - thunk is borrowed
-  PyObject * rval = NULL;
-  if (self->do_timing)
-    {
-      double t0 = pytime(NULL);
-      if (verbose) fprintf(stderr, "calling via Python (node %i)\n", (int)node_idx);
-      rval = PyObject_CallObject(thunk, NULL);
-      if (rval)
-        {
-          double t1 = pytime(NULL);
-          double ti = PyFloat_AsDouble(
-                         PyList_GetItem(self->call_times, node_idx));
-          PyList_SetItem(self->call_times, node_idx,
-                         PyFloat_FromDouble(t1 - t0 + ti));
-          PyObject * count = PyList_GetItem(self->call_counts, node_idx);
-          long icount = PyInt_AsLong(count);
-          PyList_SetItem(self->call_counts, node_idx,
-                         PyInt_FromLong(icount + 1));
-      }
-    }
-  else
-    {
-      if (verbose)
-        {
-          fprintf(stderr, "calling via Python (node %i)\n", (int)node_idx);
+      /* now get the prereqs */
+      el_i = PyList_GetItem(node_prereqs, i);
+      assert(PyList_Check(el_i));
+      self->node_n_prereqs[i] = PyList_Size(el_i);
+      if (self->node_n_prereqs[i]) {
+        self->node_prereqs[i] =
+            (Py_ssize_t *)malloc(PyList_Size(el_i) * sizeof(Py_ssize_t));
+        for (int j = 0; j < PyList_Size(el_i); ++j) {
+          PyObject *el_ij = PyList_GetItem(el_i, j);
+          Py_ssize_t N = PyNumber_AsSsize_t(el_ij, PyExc_IndexError);
+          if (PyErr_Occurred())
+            return -1;
+          // N < n. variables
+          assert(N < PyList_Size(var_owner));
+          self->node_prereqs[i][j] = N;
         }
-      rval = PyObject_CallObject(thunk, NULL);
+      }
     }
-  return rval;
+  }
+  if (PyList_Check(base_input_output_list)) {
+    Py_ssize_t n_inputs_outputs_base = PyList_Size(base_input_output_list);
+    self->node_inputs_outputs_base =
+        (Py_ssize_t *)calloc(n_inputs_outputs_base, sizeof(Py_ssize_t));
+    assert(self->node_inputs_outputs_base);
+    for (int i = 0; i < n_inputs_outputs_base; ++i) {
+      PyObject *el_i = PyList_GetItem(base_input_output_list, i);
+      Py_ssize_t idx = PyNumber_AsSsize_t(el_i, PyExc_IndexError);
+      if (PyErr_Occurred())
+        return -1;
+      self->node_inputs_outputs_base[i] = idx;
+    }
+    self->node_n_inputs = (Py_ssize_t *)calloc(n_applies, sizeof(Py_ssize_t));
+    assert(self->node_n_inputs);
+    self->node_n_outputs = (Py_ssize_t *)calloc(n_applies, sizeof(Py_ssize_t));
+    assert(self->node_n_outputs);
+    self->node_inputs = (Py_ssize_t **)calloc(n_applies, sizeof(Py_ssize_t *));
+    assert(self->node_inputs);
+    self->node_outputs = (Py_ssize_t **)calloc(n_applies, sizeof(Py_ssize_t *));
+    assert(self->node_outputs);
+    for (int i = 0; i < n_applies; ++i) {
+      Py_ssize_t N;
+      N = PyNumber_AsSsize_t(PyList_GetItem(node_n_inputs, i),
+                             PyExc_IndexError);
+      if (PyErr_Occurred())
+        return -1;
+      assert(N <= n_inputs_outputs_base);
+      self->node_n_inputs[i] = N;
+      N = PyNumber_AsSsize_t(PyList_GetItem(node_n_outputs, i),
+                             PyExc_IndexError);
+      if (PyErr_Occurred())
+        return -1;
+      assert(N <= n_inputs_outputs_base);
+      self->node_n_outputs[i] = N;
+      N = PyNumber_AsSsize_t(PyList_GetItem(node_input_offset, i),
+                             PyExc_IndexError);
+      if (PyErr_Occurred())
+        return -1;
+      assert(N <= n_inputs_outputs_base);
+      self->node_inputs[i] = &self->node_inputs_outputs_base[N];
+      N = PyNumber_AsSsize_t(PyList_GetItem(node_output_offset, i),
+                             PyExc_IndexError);
+      if (PyErr_Occurred())
+        return -1;
+      assert(N <= n_inputs_outputs_base);
+      self->node_outputs[i] = &self->node_inputs_outputs_base[N];
+    }
+  } else {
+    PyErr_SetString(PyExc_TypeError, "base_input_output_list must be list");
+    return -1;
+  }
+
+  // allocation for var_owner
+  if (PyList_Check(var_owner)) {
+    self->var_owner = (Py_ssize_t *)calloc(self->n_vars, sizeof(Py_ssize_t));
+    self->var_has_owner = (int *)calloc(self->n_vars, sizeof(int));
+    self->var_computed = (int *)calloc(self->n_vars, sizeof(int));
+    self->var_computed_cells =
+        (PyObject **)calloc(self->n_vars, sizeof(PyObject *));
+    self->var_value_cells =
+        (PyObject **)calloc(self->n_vars, sizeof(PyObject *));
+    for (int i = 0; i < self->n_vars; ++i) {
+      PyObject *el_i = PyList_GetItem(var_owner, i);
+      if (el_i == Py_None) {
+        self->var_has_owner[i] = 0;
+      } else {
+        Py_ssize_t N = PyNumber_AsSsize_t(el_i, PyExc_IndexError);
+        if (PyErr_Occurred())
+          return -1;
+        assert(N <= n_applies);
+        self->var_owner[i] = N;
+        self->var_has_owner[i] = 1;
+      }
+      self->var_computed_cells[i] = PyList_GetItem(compute_map_list, i);
+      Py_INCREF(self->var_computed_cells[i]);
+      self->var_value_cells[i] = PyList_GetItem(storage_map_list, i);
+      Py_INCREF(self->var_value_cells[i]);
+    }
+  } else {
+    PyErr_SetString(PyExc_TypeError, "var_owner must be list");
+    return -1;
+  }
+
+  if (dependencies != Py_None) {
+    self->dependencies =
+        (Py_ssize_t **)calloc(self->n_vars, sizeof(Py_ssize_t *));
+    self->n_dependencies =
+        (Py_ssize_t *)calloc(self->n_vars, sizeof(Py_ssize_t));
+    assert(self->dependencies);
+    assert(self->n_dependencies);
+
+    for (int i = 0; i < self->n_vars; ++i) {
+      PyObject *tmp = PyList_GetItem(dependencies, i);
+      // refcounting - tmp is borrowed
+      if (unpack_list_of_ssize_t(tmp, &self->dependencies[i],
+                                 &self->n_dependencies[i], "dependencies"))
+        return -1;
+    }
+  }
+
+  if (unpack_list_of_ssize_t(output_vars, &self->output_vars,
+                             &self->n_output_vars, "output_vars"))
+    return -1;
+
+  for (int i = 0; i < self->n_output_vars; ++i) {
+    assert(self->output_vars[i] < self->n_vars);
+  }
+
+  if (unpack_nested_tuples_of_ssize_t(update_storage, &self->update_storage,
+                                      &self->n_updates, "updates_storage"))
+    return -1;
+
+  return 0;
 }
-static int c_call(CLazyLinker * self, Py_ssize_t node_idx, int verbose)
-{
-  void * ptr_addr = self->thunk_cptr_fn[node_idx];
-  int (*fn)(void*) = (int (*)(void*))(ptr_addr);
-  if (verbose) fprintf(stderr, "calling non-lazy shortcut (node %i)\n", (int)node_idx);
-  int err = 0;
-  if (self->do_timing)
-    {
-      double t0 = pytime(NULL);
-      err = fn(self->thunk_cptr_data[node_idx]);
+static void set_position_of_error(CLazyLinker *self, int owner_idx) {
+  if (self->position_of_error == -1) {
+    self->position_of_error = owner_idx;
+  }
+}
+static PyObject *pycall(CLazyLinker *self, Py_ssize_t node_idx, int verbose) {
+  // call thunk to see which inputs it wants
+  PyObject *thunk = PyList_GetItem(self->thunks, node_idx);
+  // refcounting - thunk is borrowed
+  PyObject *rval = NULL;
+  if (self->do_timing) {
+    double t0 = pytime(NULL);
+    if (verbose)
+      fprintf(stderr, "calling via Python (node %i)\n", (int)node_idx);
+    rval = PyObject_CallObject(thunk, NULL);
+    if (rval) {
       double t1 = pytime(NULL);
       double ti = PyFloat_AsDouble(PyList_GetItem(self->call_times, node_idx));
-      PyList_SetItem(self->call_times, node_idx, PyFloat_FromDouble(t1 - t0 + ti));
-      PyObject * count = PyList_GetItem(self->call_counts, node_idx);
+      PyList_SetItem(self->call_times, node_idx,
+                     PyFloat_FromDouble(t1 - t0 + ti));
+      PyObject *count = PyList_GetItem(self->call_counts, node_idx);
       long icount = PyInt_AsLong(count);
-      PyList_SetItem(self->call_counts, node_idx, PyInt_FromLong(icount+1));
+      PyList_SetItem(self->call_counts, node_idx, PyInt_FromLong(icount + 1));
     }
-  else
-    {
-      err = fn(self->thunk_cptr_data[node_idx]);
+  } else {
+    if (verbose) {
+      fprintf(stderr, "calling via Python (node %i)\n", (int)node_idx);
     }
+    rval = PyObject_CallObject(thunk, NULL);
+  }
+  return rval;
+}
+static int c_call(CLazyLinker *self, Py_ssize_t node_idx, int verbose) {
+  void *ptr_addr = self->thunk_cptr_fn[node_idx];
+  int (*fn)(void *) = (int (*)(void *))(ptr_addr);
+  if (verbose)
+    fprintf(stderr, "calling non-lazy shortcut (node %i)\n", (int)node_idx);
+  int err = 0;
+  if (self->do_timing) {
+    double t0 = pytime(NULL);
+    err = fn(self->thunk_cptr_data[node_idx]);
+    double t1 = pytime(NULL);
+    double ti = PyFloat_AsDouble(PyList_GetItem(self->call_times, node_idx));
+    PyList_SetItem(self->call_times, node_idx,
+                   PyFloat_FromDouble(t1 - t0 + ti));
+    PyObject *count = PyList_GetItem(self->call_counts, node_idx);
+    long icount = PyInt_AsLong(count);
+    PyList_SetItem(self->call_counts, node_idx, PyInt_FromLong(icount + 1));
+  } else {
+    err = fn(self->thunk_cptr_data[node_idx]);
+  }
 
+  if (err) {
+    // cast the argument to a PyList (as described near line 226 of cc.py)
+    PyObject *__ERROR = ((PyObject **)self->thunk_cptr_data[node_idx])[0];
+    assert(PyList_Check(__ERROR));
+    assert(PyList_Size(__ERROR) == 3);
+    PyObject *err_type = PyList_GetItem(__ERROR, 0);  // stolen ref
+    PyObject *err_msg = PyList_GetItem(__ERROR, 1);   // stolen ref
+    PyObject *err_trace = PyList_GetItem(__ERROR, 2); // stolen ref
+    PyList_SET_ITEM(__ERROR, 0, Py_None);
+    Py_INCREF(Py_None); // clobbers old ref
+    PyList_SET_ITEM(__ERROR, 1, Py_None);
+    Py_INCREF(Py_None); // clobbers old ref
+    PyList_SET_ITEM(__ERROR, 2, Py_None);
+    Py_INCREF(Py_None); // clobbers old ref
+
+    assert(!PyErr_Occurred()); // because CLinker hid the exception in __ERROR
+                               // aka data
+    PyErr_Restore(err_type, err_msg, err_trace); // steals refs to args
+  }
   if (err)
-    {
-      // cast the argument to a PyList (as described near line 226 of cc.py)
-      PyObject * __ERROR = ((PyObject**)self->thunk_cptr_data[node_idx])[0];
-      assert (PyList_Check(__ERROR));
-      assert (PyList_Size(__ERROR) == 3);
-      PyObject * err_type = PyList_GetItem(__ERROR, 0); //stolen ref
-      PyObject * err_msg = PyList_GetItem(__ERROR, 1); //stolen ref
-      PyObject * err_trace = PyList_GetItem(__ERROR, 2); //stolen ref
-      PyList_SET_ITEM(__ERROR, 0, Py_None); Py_INCREF(Py_None); //clobbers old ref
-      PyList_SET_ITEM(__ERROR, 1, Py_None); Py_INCREF(Py_None); //clobbers old ref
-      PyList_SET_ITEM(__ERROR, 2, Py_None); Py_INCREF(Py_None); //clobbers old ref
-
-      assert(!PyErr_Occurred()); // because CLinker hid the exception in __ERROR aka data
-      PyErr_Restore(err_type, err_msg, err_trace); //steals refs to args
-    }
-  if (err) set_position_of_error(self, node_idx);
+    set_position_of_error(self, node_idx);
   return err;
 }
-static
-int lazy_rec_eval(CLazyLinker * self, Py_ssize_t var_idx, PyObject*one, PyObject*zero)
-{
+static int lazy_rec_eval(CLazyLinker *self, Py_ssize_t var_idx, PyObject *one,
+                         PyObject *zero) {
   PyObject *rval = NULL;
   int verbose = 0;
   int err = 0;
 
-  if (verbose) fprintf(stderr, "lazy_rec computing %i\n", (int)var_idx);
+  if (verbose)
+    fprintf(stderr, "lazy_rec computing %i\n", (int)var_idx);
 
   if (self->var_computed[var_idx] || !self->var_has_owner[var_idx])
     return 0;
@@ -568,237 +557,207 @@ int lazy_rec_eval(CLazyLinker * self, Py_ssize_t var_idx, PyObject*one, PyObject
 
   // STEP 1: compute the pre-requirements of the node
   // Includes input nodes for non-lazy ops.
-  for (int i = 0; i < self->node_n_prereqs[owner_idx]; ++i)
-    {
-      Py_ssize_t prereq_idx = self->node_prereqs[owner_idx][i];
-      if (!self->var_computed[prereq_idx])
-        {
-          err = lazy_rec_eval(self, prereq_idx, one, zero);
-          if (err) return err;
-        }
-      assert (self->var_computed[prereq_idx]);
+  for (int i = 0; i < self->node_n_prereqs[owner_idx]; ++i) {
+    Py_ssize_t prereq_idx = self->node_prereqs[owner_idx][i];
+    if (!self->var_computed[prereq_idx]) {
+      err = lazy_rec_eval(self, prereq_idx, one, zero);
+      if (err)
+        return err;
     }
+    assert(self->var_computed[prereq_idx]);
+  }
 
   // STEP 2: compute the node itself
-  if (self->is_lazy[owner_idx])
-    {
-      // update the compute_map cells corresponding to the inputs of this thunk
-      for (int i = 0; i < self->node_n_inputs[owner_idx]; ++i)
-        {
-          int in_idx = self->node_inputs[owner_idx][i];
-          if (self->var_computed[in_idx])
-            {
-              Py_INCREF(one);
-              err = PyList_SetItem(self->var_computed_cells[in_idx], 0, one);
-            }
-          else
-            {
-              Py_INCREF(zero);
-              err = PyList_SetItem(self->var_computed_cells[in_idx], 0, zero);
-            }
-          if (err) goto fail;
-        }
+  if (self->is_lazy[owner_idx]) {
+    // update the compute_map cells corresponding to the inputs of this thunk
+    for (int i = 0; i < self->node_n_inputs[owner_idx]; ++i) {
+      int in_idx = self->node_inputs[owner_idx][i];
+      if (self->var_computed[in_idx]) {
+        Py_INCREF(one);
+        err = PyList_SetItem(self->var_computed_cells[in_idx], 0, one);
+      } else {
+        Py_INCREF(zero);
+        err = PyList_SetItem(self->var_computed_cells[in_idx], 0, zero);
+      }
+      if (err)
+        goto fail;
+    }
 
-      rval = pycall(self, owner_idx, verbose);
-      // refcounting - rval is new ref
-      //TODO: to prevent infinite loops
-      // - consider check that a thunk does not ask for an input that is already computed
-      if (rval == NULL)
-        {
-          assert (PyErr_Occurred());
+    rval = pycall(self, owner_idx, verbose);
+    // refcounting - rval is new ref
+    // TODO: to prevent infinite loops
+    // - consider check that a thunk does not ask for an input that is already
+    // computed
+    if (rval == NULL) {
+      assert(PyErr_Occurred());
+      err = 1;
+      goto fail;
+    }
+
+    // update the computed-ness of any output cells
+    for (int i = 0; i < self->node_n_outputs[owner_idx]; ++i) {
+      int out_idx = self->node_outputs[owner_idx][i];
+      PyObject *el_i = PyList_GetItem(self->var_computed_cells[out_idx], 0);
+      Py_ssize_t N = PyNumber_AsSsize_t(el_i, PyExc_IndexError);
+      if (PyErr_Occurred()) {
+        err = -1;
+        goto pyfail;
+      }
+      assert(N == 0 || N == 1);
+      self->var_computed[out_idx] = N;
+    }
+    if (!self->var_computed[var_idx]) {
+      /*
+       * If self is not computed after the call, this means that some
+       * inputs are needed.  Compute the ones on the returned list
+       * and try to compute the current node again (with recursive call).
+       * This allows a node to request more nodes more than once before
+       * finally yielding a result.
+       */
+      if (!PyList_Check(rval)) {
+        // TODO: More helpful error to help find *which node* made this
+        // bad thunk
+        PyErr_SetString(PyExc_TypeError, "lazy thunk should return a list");
+        err = 1;
+        goto pyfail;
+      }
+
+      if (!PyList_Size(rval)) {
+        PyErr_SetString(
+            PyExc_ValueError,
+            "lazy thunk returned empty list without computing output");
+        err = 1;
+        goto pyfail;
+      }
+
+      for (int i = 0; i < PyList_Size(rval); ++i) {
+        PyObject *el_i = PyList_GetItem(rval, i);
+        Py_ssize_t N = PyNumber_AsSsize_t(el_i, PyExc_IndexError);
+        if (PyErr_Occurred()) {
           err = 1;
-          goto fail;
+          goto pyfail;
         }
-
-      //update the computed-ness of any output cells
-      for (int i = 0; i < self->node_n_outputs[owner_idx]; ++i)
-        {
-          int out_idx = self->node_outputs[owner_idx][i];
-          PyObject * el_i = PyList_GetItem(self->var_computed_cells[out_idx], 0);
-          Py_ssize_t N = PyNumber_AsSsize_t(el_i, PyExc_IndexError);
-          if (PyErr_Occurred())
-            {
-              err = -1;
-              goto pyfail;
-            }
-          assert (N==0 || N==1);
-          self->var_computed[out_idx] = N;
-        }
-      if (!self->var_computed[var_idx])
-        {
-          /*
-           * If self is not computed after the call, this means that some
-           * inputs are needed.  Compute the ones on the returned list
-           * and try to compute the current node again (with recursive call).
-           * This allows a node to request more nodes more than once before
-           * finally yielding a result.
-           */
-          if (!PyList_Check(rval))
-            {
-              //TODO: More helpful error to help find *which node* made this
-              // bad thunk
-              PyErr_SetString(PyExc_TypeError,
-                              "lazy thunk should return a list");
-              err = 1;
-              goto pyfail;
-            }
-
-          if (!PyList_Size(rval))
-            {
-              PyErr_SetString(PyExc_ValueError,
-                              "lazy thunk returned empty list without computing output");
-              err = 1;
-              goto pyfail;
-            }
-
-          for (int i = 0; i < PyList_Size(rval); ++i)
-            {
-              PyObject * el_i = PyList_GetItem(rval, i);
-              Py_ssize_t N = PyNumber_AsSsize_t(el_i, PyExc_IndexError);
-              if (PyErr_Occurred())
-                {
-                  err = 1;
-                  goto pyfail;
-                }
-              assert (N <= self->node_n_inputs[owner_idx]);
-              Py_ssize_t input_idx = self->node_inputs[owner_idx][N];
-              err = lazy_rec_eval(self, input_idx, one, zero);
-              if (err) goto pyfail;
-            }
-
-          Py_DECREF(rval);
-          /*
-           * We intentionally skip all the end-of-function processing
-           * (mark outputs, GC) as it will be performed by the call
-           * that actually manages to compute the result.
-           */
-          return lazy_rec_eval(self, var_idx, one, zero);
-        }
+        assert(N <= self->node_n_inputs[owner_idx]);
+        Py_ssize_t input_idx = self->node_inputs[owner_idx][N];
+        err = lazy_rec_eval(self, input_idx, one, zero);
+        if (err)
+          goto pyfail;
+      }
 
       Py_DECREF(rval);
+      /*
+       * We intentionally skip all the end-of-function processing
+       * (mark outputs, GC) as it will be performed by the call
+       * that actually manages to compute the result.
+       */
+      return lazy_rec_eval(self, var_idx, one, zero);
     }
-  else //owner is not a lazy op. Ensure all inputs are evaluated.
-    {
-      // loop over inputs to owner
-      // call lazy_rec_eval on each one that is not computed.
-      // if there's an error, pass it up the stack
-      for (int i = 0; i < self->node_n_inputs[owner_idx]; ++i)
-        {
-          Py_ssize_t input_idx = self->node_inputs[owner_idx][i];
-          if (!self->var_computed[input_idx])
-            {
-              err = lazy_rec_eval(self, input_idx, one, zero);
-              if (err) return err;
-            }
-          assert (self->var_computed[input_idx]);
-        }
 
-      // call the thunk for this owner.
-      if (self->thunk_cptr_fn[owner_idx])
-        {
-          err = c_call(self, owner_idx, verbose);
-          if (err) goto fail;
-        }
-      else
-        {
-          rval = pycall(self, owner_idx, verbose);
-          //rval is new ref
-          if (rval) //pycall returned normally (no exception)
-            {
-              if (rval == Py_None)
-                {
-                  Py_DECREF(rval); //ignore a return of None
-                }
-              else if (PyList_Check(rval))
-                {
-                  PyErr_SetString(PyExc_TypeError,
-                                  "non-lazy thunk should return None, not list");
-                  err = 1;
-                  goto pyfail;
-                }
-              else // don't know what it returned, but it wasn't right.
-                {
-                  PyErr_SetObject(PyExc_TypeError, rval);
-                  err = 1;
-                  // We don't release rval since we put it in the error above
-                  goto fail;
-                }
-            }
-          else // pycall returned NULL (internal error)
-            {
-              err = 1;
-              goto fail;
-            }
-        }
+    Py_DECREF(rval);
+  } else // owner is not a lazy op. Ensure all inputs are evaluated.
+  {
+    // loop over inputs to owner
+    // call lazy_rec_eval on each one that is not computed.
+    // if there's an error, pass it up the stack
+    for (int i = 0; i < self->node_n_inputs[owner_idx]; ++i) {
+      Py_ssize_t input_idx = self->node_inputs[owner_idx][i];
+      if (!self->var_computed[input_idx]) {
+        err = lazy_rec_eval(self, input_idx, one, zero);
+        if (err)
+          return err;
+      }
+      assert(self->var_computed[input_idx]);
     }
+
+    // call the thunk for this owner.
+    if (self->thunk_cptr_fn[owner_idx]) {
+      err = c_call(self, owner_idx, verbose);
+      if (err)
+        goto fail;
+    } else {
+      rval = pycall(self, owner_idx, verbose);
+      // rval is new ref
+      if (rval) // pycall returned normally (no exception)
+      {
+        if (rval == Py_None) {
+          Py_DECREF(rval); // ignore a return of None
+        } else if (PyList_Check(rval)) {
+          PyErr_SetString(PyExc_TypeError,
+                          "non-lazy thunk should return None, not list");
+          err = 1;
+          goto pyfail;
+        } else // don't know what it returned, but it wasn't right.
+        {
+          PyErr_SetObject(PyExc_TypeError, rval);
+          err = 1;
+          // We don't release rval since we put it in the error above
+          goto fail;
+        }
+      } else // pycall returned NULL (internal error)
+      {
+        err = 1;
+        goto fail;
+      }
+    }
+  }
 
   // loop over all outputs and mark them as computed
-  for (int i = 0; i < self->node_n_outputs[owner_idx]; ++i)
-    {
-      self->var_computed[self->node_outputs[owner_idx][i]] = 1;
-    }
+  for (int i = 0; i < self->node_n_outputs[owner_idx]; ++i) {
+    self->var_computed[self->node_outputs[owner_idx][i]] = 1;
+  }
 
   // Free vars that are not needed anymore
-  if (self->allow_gc)
-    {
-      for (int i = 0; i < self->node_n_inputs[owner_idx]; ++i)
-        {
-          int cleanup = 1;
-          Py_ssize_t i_idx = self->node_inputs[owner_idx][i];
-          if (!self->var_has_owner[i_idx])
-            continue;
+  if (self->allow_gc) {
+    for (int i = 0; i < self->node_n_inputs[owner_idx]; ++i) {
+      int cleanup = 1;
+      Py_ssize_t i_idx = self->node_inputs[owner_idx][i];
+      if (!self->var_has_owner[i_idx])
+        continue;
 
-          for (int j = 0; j < self->n_output_vars; ++j)
-            {
-              if (i_idx == self->output_vars[j])
-                {
-                  cleanup = 0;
-                  break;
-                }
-            }
-          if (!cleanup) continue;
-
-          for (int j = 0; j < self->n_dependencies[i_idx]; ++j)
-            {
-              if (!self->var_computed[self->dependencies[i_idx][j]])
-                {
-                  cleanup = 0;
-                  break;
-                }
-            }
-          if (!cleanup) continue;
-
-          Py_INCREF(Py_None);
-          err = PyList_SetItem(self->var_value_cells[i_idx], 0, Py_None);
-//See the Stack gc implementation for why we change it to 2 and not 0.
-          self->var_computed[i_idx] = 2;
-          if (err) goto fail;
+      for (int j = 0; j < self->n_output_vars; ++j) {
+        if (i_idx == self->output_vars[j]) {
+          cleanup = 0;
+          break;
         }
+      }
+      if (!cleanup)
+        continue;
+
+      for (int j = 0; j < self->n_dependencies[i_idx]; ++j) {
+        if (!self->var_computed[self->dependencies[i_idx][j]]) {
+          cleanup = 0;
+          break;
+        }
+      }
+      if (!cleanup)
+        continue;
+
+      Py_INCREF(Py_None);
+      err = PyList_SetItem(self->var_value_cells[i_idx], 0, Py_None);
+      // See the Stack gc implementation for why we change it to 2 and not 0.
+      self->var_computed[i_idx] = 2;
+      if (err)
+        goto fail;
     }
+  }
 
   return 0;
- pyfail:
+pyfail:
   Py_DECREF(rval);
- fail:
+fail:
   set_position_of_error(self, owner_idx);
   return err;
 }
 
-static PyObject *
-CLazyLinker_call(PyObject *_self, PyObject *args, PyObject *kwds)
-{
-  CLazyLinker * self = (CLazyLinker*)_self;
-  static char *kwlist[] = {
-    (char *)"time_thunks",
-    (char *)"n_calls",
-    (char *)"output_subset",
-    NULL};
-  int n_calls=1;
+static PyObject *CLazyLinker_call(PyObject *_self, PyObject *args,
+                                  PyObject *kwds) {
+  CLazyLinker *self = (CLazyLinker *)_self;
+  static char *kwlist[] = {(char *)"time_thunks", (char *)"n_calls",
+                           (char *)"output_subset", NULL};
+  int n_calls = 1;
   PyObject *output_subset_ptr = NULL;
-  if (! PyArg_ParseTupleAndKeywords(args, kwds, "|iiO", kwlist,
-                                    &self->do_timing,
-                                    &n_calls,
-                                    &output_subset_ptr))
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|iiO", kwlist, &self->do_timing,
+                                   &n_calls, &output_subset_ptr))
     return NULL;
 
   int err = 0;
@@ -806,148 +765,127 @@ CLazyLinker_call(PyObject *_self, PyObject *args, PyObject *kwds)
   // it is stored as a bool list of length n_output_vars: calculate a var or not
   char *output_subset = NULL;
   int output_subset_size = -1;
-  if (output_subset_ptr != NULL)
-    {
-      if (! PyList_Check(output_subset_ptr))
-        {
+  if (output_subset_ptr != NULL) {
+    if (!PyList_Check(output_subset_ptr)) {
+      err = 1;
+      PyErr_SetString(PyExc_RuntimeError, "Output_subset is not a list");
+    } else {
+      output_subset_size = PyList_Size(output_subset_ptr);
+      output_subset = (char *)calloc(self->n_output_vars, sizeof(char));
+      for (int it = 0; it < output_subset_size; ++it) {
+        PyObject *elem = PyList_GetItem(output_subset_ptr, it);
+        if (!PyInt_Check(elem)) {
           err = 1;
-          PyErr_SetString(PyExc_RuntimeError, "Output_subset is not a list");
+          PyErr_SetString(PyExc_RuntimeError,
+                          "Some elements of output_subset list are not int");
         }
-      else
-        {
-          output_subset_size = PyList_Size(output_subset_ptr);
-          output_subset = (char*)calloc(self->n_output_vars, sizeof(char));
-          for (int it = 0; it < output_subset_size; ++it)
-            {
-              PyObject *elem = PyList_GetItem(output_subset_ptr, it);
-              if (! PyInt_Check(elem))
-                {
-                  err = 1;
-                  PyErr_SetString(PyExc_RuntimeError, "Some elements of output_subset list are not int");
-                }
-              output_subset[PyInt_AsLong(elem)] = 1;
-            }
-        }
+        output_subset[PyInt_AsLong(elem)] = 1;
+      }
     }
+  }
 
   self->position_of_error = -1;
   // create constants used to fill the var_compute_cells
-  PyObject * one = PyInt_FromLong(1);
-  PyObject * zero = PyInt_FromLong(0);
+  PyObject *one = PyInt_FromLong(1);
+  PyObject *zero = PyInt_FromLong(0);
 
   // pre-allocate our return value
   Py_INCREF(Py_None);
-  PyObject * rval = Py_None;
-  //clear storage of pre_call_clear elements
-  for (int call_i = 0; call_i < n_calls && (!err); ++call_i)
-    {
-      Py_ssize_t n_pre_call_clear = PyList_Size(self->pre_call_clear);
-      assert(PyList_Check(self->pre_call_clear));
-      for (int i = 0; i < n_pre_call_clear; ++i)
-        {
-          PyObject * el_i = PyList_GetItem(self->pre_call_clear, i);
-          Py_INCREF(Py_None);
-          PyList_SetItem(el_i, 0, Py_None);
-        }
-      //clear the computed flag out of all non-input vars
-      for (int i = 0; i < self->n_vars; ++i)
-        {
-          self->var_computed[i] = !self->var_has_owner[i];
-          if (self->var_computed[i])
-            {
-              Py_INCREF(one);
-              PyList_SetItem(self->var_computed_cells[i], 0, one);
-            }
-          else
-            {
-              Py_INCREF(zero);
-              PyList_SetItem(self->var_computed_cells[i], 0, zero);
-            }
-        }
-
-      int first_updated = self->n_output_vars - self->n_updates;
-      for (int i = 0; i < self->n_output_vars && (!err); ++i)
-        {
-          if (i >= first_updated || output_subset == NULL || output_subset[i] == 1)
-            {
-              err = lazy_rec_eval(self, self->output_vars[i], one, zero);
-            }
-        }
-
-      if (!err)
-        {
-          // save references to outputs prior to updating storage containers
-          assert (self->n_output_vars >= self->n_updates);
-          Py_DECREF(rval);
-          rval = PyList_New(self->n_output_vars);
-          for (int i = 0; i < (self->n_output_vars); ++i)
-            {
-              Py_ssize_t src = self->output_vars[i];
-              PyObject * item = PyList_GetItem(self->var_value_cells[src], 0);
-              if ((output_subset == NULL || output_subset[i]) &&
-                  self->var_computed[src] != 1)
-                {
-                  err = 1;
-                  PyErr_Format(PyExc_AssertionError,
-                               "The compute map of output %d should contain "
-                               "1 at the end of execution, not %d.",
-                               i, self->var_computed[src]);
-                  break;
-                }
-              Py_INCREF(item);
-              PyList_SetItem(rval, i, item);
-            }
-        }
-
-      if (!err)
-        {
-          // Update the inputs that have an update rule
-          for (int i = 0; i < self->n_updates; ++i)
-            {
-              PyObject* tmp = PyList_GetItem(rval, self->n_output_vars - self->n_updates + i);
-              Py_INCREF(tmp);
-              Py_ssize_t dst = self->update_storage[i];
-              PyList_SetItem(self->var_value_cells[dst], 0, tmp);
-            }
-        }
+  PyObject *rval = Py_None;
+  // clear storage of pre_call_clear elements
+  for (int call_i = 0; call_i < n_calls && (!err); ++call_i) {
+    Py_ssize_t n_pre_call_clear = PyList_Size(self->pre_call_clear);
+    assert(PyList_Check(self->pre_call_clear));
+    for (int i = 0; i < n_pre_call_clear; ++i) {
+      PyObject *el_i = PyList_GetItem(self->pre_call_clear, i);
+      Py_INCREF(Py_None);
+      PyList_SetItem(el_i, 0, Py_None);
     }
+    // clear the computed flag out of all non-input vars
+    for (int i = 0; i < self->n_vars; ++i) {
+      self->var_computed[i] = !self->var_has_owner[i];
+      if (self->var_computed[i]) {
+        Py_INCREF(one);
+        PyList_SetItem(self->var_computed_cells[i], 0, one);
+      } else {
+        Py_INCREF(zero);
+        PyList_SetItem(self->var_computed_cells[i], 0, zero);
+      }
+    }
+
+    int first_updated = self->n_output_vars - self->n_updates;
+    for (int i = 0; i < self->n_output_vars && (!err); ++i) {
+      if (i >= first_updated || output_subset == NULL ||
+          output_subset[i] == 1) {
+        err = lazy_rec_eval(self, self->output_vars[i], one, zero);
+      }
+    }
+
+    if (!err) {
+      // save references to outputs prior to updating storage containers
+      assert(self->n_output_vars >= self->n_updates);
+      Py_DECREF(rval);
+      rval = PyList_New(self->n_output_vars);
+      for (int i = 0; i < (self->n_output_vars); ++i) {
+        Py_ssize_t src = self->output_vars[i];
+        PyObject *item = PyList_GetItem(self->var_value_cells[src], 0);
+        if ((output_subset == NULL || output_subset[i]) &&
+            self->var_computed[src] != 1) {
+          err = 1;
+          PyErr_Format(PyExc_AssertionError,
+                       "The compute map of output %d should contain "
+                       "1 at the end of execution, not %d.",
+                       i, self->var_computed[src]);
+          break;
+        }
+        Py_INCREF(item);
+        PyList_SetItem(rval, i, item);
+      }
+    }
+
+    if (!err) {
+      // Update the inputs that have an update rule
+      for (int i = 0; i < self->n_updates; ++i) {
+        Py_ssize_t in_idx = self->update_storage[i * 2 + 0];
+        Py_ssize_t out_idx = self->update_storage[i * 2 + 1];
+        PyObject *tmp = PyList_GetItem(rval, out_idx);
+        Py_INCREF(tmp);
+        PyList_SetItem(self->var_value_cells[in_idx], 0, tmp);
+      }
+    }
+  }
 
   /*
     Clear everything that is left and not an output. This is needed
     for lazy evaluation since the current GC algo is too conservative
     with lazy graphs.
   */
-  if (self->allow_gc && !err)
-    {
-      for (Py_ssize_t i = 0; i < self->n_vars; ++i)
-        {
-          int do_cleanup = 1;
-          if (!self->var_has_owner[i] || !self->var_computed[i])
-            continue;
-          for (int j = 0; j < self->n_output_vars; ++j)
-            {
-              if (i == self->output_vars[j])
-                {
-                  do_cleanup = 0;
-                  break;
-                }
-            }
-          if (!do_cleanup)
-            continue;
-          Py_INCREF(Py_None);
-          PyList_SetItem(self->var_value_cells[i], 0, Py_None);
+  if (self->allow_gc && !err) {
+    for (Py_ssize_t i = 0; i < self->n_vars; ++i) {
+      int do_cleanup = 1;
+      if (!self->var_has_owner[i] || !self->var_computed[i])
+        continue;
+      for (int j = 0; j < self->n_output_vars; ++j) {
+        if (i == self->output_vars[j]) {
+          do_cleanup = 0;
+          break;
         }
+      }
+      if (!do_cleanup)
+        continue;
+      Py_INCREF(Py_None);
+      PyList_SetItem(self->var_value_cells[i], 0, Py_None);
     }
+  }
   if (output_subset != NULL)
     free(output_subset);
 
   Py_DECREF(one);
   Py_DECREF(zero);
-  if (err)
-    {
-      Py_DECREF(rval);
-      return NULL;
-    }
+  if (err) {
+    Py_DECREF(rval);
+    return NULL;
+  }
   return rval;
 }
 
@@ -960,17 +898,13 @@ static PyMethodDef CLazyLinker_methods[] = {
 };
 #endif
 
-
-static PyObject *
-CLazyLinker_get_allow_gc(CLazyLinker *self, void *closure)
-{
-    return PyBool_FromLong(self->allow_gc);
+static PyObject *CLazyLinker_get_allow_gc(CLazyLinker *self, void *closure) {
+  return PyBool_FromLong(self->allow_gc);
 }
 
-static int
-CLazyLinker_set_allow_gc(CLazyLinker *self, PyObject *value, void *closure)
-{
-  if(!PyBool_Check(value))
+static int CLazyLinker_set_allow_gc(CLazyLinker *self, PyObject *value,
+                                    void *closure) {
+  if (!PyBool_Check(value))
     return -1;
 
   if (value == Py_True)
@@ -981,124 +915,119 @@ CLazyLinker_set_allow_gc(CLazyLinker *self, PyObject *value, void *closure)
 }
 
 static PyGetSetDef CLazyLinker_getset[] = {
-  {(char*)"allow_gc",
-   (getter)CLazyLinker_get_allow_gc,
-   (setter)CLazyLinker_set_allow_gc,
-   (char*)"do this function support allow_gc",
-   NULL},
-  {NULL, NULL, NULL, NULL}  /* Sentinel */
+    {(char *)"allow_gc", (getter)CLazyLinker_get_allow_gc,
+     (setter)CLazyLinker_set_allow_gc,
+     (char *)"do this function support allow_gc", NULL},
+    {NULL, NULL, NULL, NULL} /* Sentinel */
 };
 static PyMemberDef CLazyLinker_members[] = {
-    {(char*)"nodes", T_OBJECT_EX, offsetof(CLazyLinker, nodes), 0,
-     (char*)"list of nodes"},
-    {(char*)"thunks", T_OBJECT_EX, offsetof(CLazyLinker, thunks), 0,
-     (char*)"list of thunks in program"},
-    {(char*)"call_counts", T_OBJECT_EX, offsetof(CLazyLinker, call_counts), 0,
-     (char*)"number of calls of each thunk"},
-    {(char*)"call_times", T_OBJECT_EX, offsetof(CLazyLinker, call_times), 0,
-     (char*)"total runtime in each thunk"},
-    {(char*)"position_of_error", T_INT, offsetof(CLazyLinker, position_of_error), 0,
-     (char*)"position of failed thunk"},
-    {(char*)"time_thunks", T_INT, offsetof(CLazyLinker, do_timing), 0,
-     (char*)"bool: nonzero means call will time thunks"},
-    {(char*)"need_update_inputs", T_INT, offsetof(CLazyLinker, need_update_inputs), 0,
-     (char*)"bool: nonzero means Function.__call__ must implement update mechanism"},
-    {NULL}  /* Sentinel */
+    {(char *)"nodes", T_OBJECT_EX, offsetof(CLazyLinker, nodes), 0,
+     (char *)"list of nodes"},
+    {(char *)"thunks", T_OBJECT_EX, offsetof(CLazyLinker, thunks), 0,
+     (char *)"list of thunks in program"},
+    {(char *)"call_counts", T_OBJECT_EX, offsetof(CLazyLinker, call_counts), 0,
+     (char *)"number of calls of each thunk"},
+    {(char *)"call_times", T_OBJECT_EX, offsetof(CLazyLinker, call_times), 0,
+     (char *)"total runtime in each thunk"},
+    {(char *)"position_of_error", T_INT,
+     offsetof(CLazyLinker, position_of_error), 0,
+     (char *)"position of failed thunk"},
+    {(char *)"time_thunks", T_INT, offsetof(CLazyLinker, do_timing), 0,
+     (char *)"bool: nonzero means call will time thunks"},
+    {(char *)"need_update_inputs", T_INT,
+     offsetof(CLazyLinker, need_update_inputs), 0,
+     (char *)"bool: nonzero means Function.__call__ must implement update "
+             "mechanism"},
+    {NULL} /* Sentinel */
 };
 
 static PyTypeObject lazylinker_ext_CLazyLinkerType = {
 #if defined(NPY_PY3K)
     PyVarObject_HEAD_INIT(NULL, 0)
 #else
-    PyObject_HEAD_INIT(NULL)
-    0,                         /*ob_size*/
+    PyObject_HEAD_INIT(NULL) 0, /*ob_size*/
 #endif
-    "lazylinker_ext.CLazyLinker",             /*tp_name*/
-    sizeof(CLazyLinker), /*tp_basicsize*/
-    0,                         /*tp_itemsize*/
-    CLazyLinker_dealloc,       /*tp_dealloc*/
-    0,                         /*tp_print*/
-    0,                         /*tp_getattr*/
-    0,                         /*tp_setattr*/
-    0,                         /*tp_compare*/
-    0,                         /*tp_repr*/
-    0,                         /*tp_as_number*/
-    0,                         /*tp_as_sequence*/
-    0,                         /*tp_as_mapping*/
-    0,                         /*tp_hash */
-    CLazyLinker_call,          /*tp_call*/
-    0,                         /*tp_str*/
-    0,                         /*tp_getattro*/
-    0,                         /*tp_setattro*/
-    0,                         /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT|Py_TPFLAGS_BASETYPE,        /*tp_flags*/
-    "CLazyLinker object",      /* tp_doc */
-    0,                         /* tp_traverse */
-    0,                         /* tp_clear */
-    0,                         /* tp_richcompare */
-    0,                         /* tp_weaklistoffset */
-    0,                         /* tp_iter */
-    0,                         /* tp_iternext */
-    0,//CLazyLinker_methods,       /* tp_methods */
-    CLazyLinker_members,       /* tp_members */
-    CLazyLinker_getset,        /* tp_getset */
-    0,                         /* tp_base */
-    0,                         /* tp_dict */
-    0,                         /* tp_descr_get */
-    0,                         /* tp_descr_set */
-    0,                         /* tp_dictoffset */
-    (initproc)CLazyLinker_init,/* tp_init */
-    0,                         /* tp_alloc */
-    CLazyLinker_new,           /* tp_new */
+        "lazylinker_ext.CLazyLinker",         /*tp_name*/
+    sizeof(CLazyLinker),                      /*tp_basicsize*/
+    0,                                        /*tp_itemsize*/
+    CLazyLinker_dealloc,                      /*tp_dealloc*/
+    0,                                        /*tp_print*/
+    0,                                        /*tp_getattr*/
+    0,                                        /*tp_setattr*/
+    0,                                        /*tp_compare*/
+    0,                                        /*tp_repr*/
+    0,                                        /*tp_as_number*/
+    0,                                        /*tp_as_sequence*/
+    0,                                        /*tp_as_mapping*/
+    0,                                        /*tp_hash */
+    CLazyLinker_call,                         /*tp_call*/
+    0,                                        /*tp_str*/
+    0,                                        /*tp_getattro*/
+    0,                                        /*tp_setattro*/
+    0,                                        /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+    "CLazyLinker object",                     /* tp_doc */
+    0,                                        /* tp_traverse */
+    0,                                        /* tp_clear */
+    0,                                        /* tp_richcompare */
+    0,                                        /* tp_weaklistoffset */
+    0,                                        /* tp_iter */
+    0,                                        /* tp_iternext */
+    0,                          // CLazyLinker_methods,       /* tp_methods */
+    CLazyLinker_members,        /* tp_members */
+    CLazyLinker_getset,         /* tp_getset */
+    0,                          /* tp_base */
+    0,                          /* tp_dict */
+    0,                          /* tp_descr_get */
+    0,                          /* tp_descr_set */
+    0,                          /* tp_dictoffset */
+    (initproc)CLazyLinker_init, /* tp_init */
+    0,                          /* tp_alloc */
+    CLazyLinker_new,            /* tp_new */
 };
 
-static PyObject * get_version(PyObject *dummy, PyObject *args)
-{
-  PyObject *result = PyFloat_FromDouble(0.211);
+static PyObject *get_version(PyObject *dummy, PyObject *args) {
+  PyObject *result = PyFloat_FromDouble(0.212);
   return result;
 }
 
 static PyMethodDef lazylinker_ext_methods[] = {
-  {"get_version",  get_version, METH_VARARGS, "Get extension version."},
-  {NULL, NULL, 0, NULL}        /* Sentinel */
+    {"get_version", get_version, METH_VARARGS, "Get extension version."},
+    {NULL, NULL, 0, NULL} /* Sentinel */
 };
 
 #if defined(NPY_PY3K)
-static struct PyModuleDef moduledef = {
-        PyModuleDef_HEAD_INIT,
-        "lazylinker_ext",
-        NULL,
-        -1,
-        lazylinker_ext_methods,
-        NULL,
-        NULL,
-        NULL,
-        NULL
-};
+static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,
+                                       "lazylinker_ext",
+                                       NULL,
+                                       -1,
+                                       lazylinker_ext_methods,
+                                       NULL,
+                                       NULL,
+                                       NULL,
+                                       NULL};
 #endif
 #if defined(NPY_PY3K)
 #define RETVAL m
-PyMODINIT_FUNC
-PyInit_lazylinker_ext(void) {
+PyMODINIT_FUNC PyInit_lazylinker_ext(void) {
 #else
 #define RETVAL
-PyMODINIT_FUNC
-initlazylinker_ext(void)
-{
+PyMODINIT_FUNC initlazylinker_ext(void) {
 #endif
-    PyObject* m;
+  PyObject *m;
 
-    lazylinker_ext_CLazyLinkerType.tp_new = PyType_GenericNew;
-    if (PyType_Ready(&lazylinker_ext_CLazyLinkerType) < 0)
-        return RETVAL;
-#if defined(NPY_PY3K)
-    m = PyModule_Create(&moduledef);
-#else
-    m = Py_InitModule3("lazylinker_ext", lazylinker_ext_methods,
-                       "Example module that creates an extension type.");
-#endif
-    Py_INCREF(&lazylinker_ext_CLazyLinkerType);
-    PyModule_AddObject(m, "CLazyLinker", (PyObject *)&lazylinker_ext_CLazyLinkerType);
-
+  lazylinker_ext_CLazyLinkerType.tp_new = PyType_GenericNew;
+  if (PyType_Ready(&lazylinker_ext_CLazyLinkerType) < 0)
     return RETVAL;
+#if defined(NPY_PY3K)
+  m = PyModule_Create(&moduledef);
+#else
+  m = Py_InitModule3("lazylinker_ext", lazylinker_ext_methods,
+                     "Example module that creates an extension type.");
+#endif
+  Py_INCREF(&lazylinker_ext_CLazyLinkerType);
+  PyModule_AddObject(m, "CLazyLinker",
+                     (PyObject *)&lazylinker_ext_CLazyLinkerType);
+
+  return RETVAL;
 }

--- a/aesara/link/c/lazylinker_c.py
+++ b/aesara/link/c/lazylinker_c.py
@@ -16,7 +16,7 @@ from aesara.link.c.cmodule import GCC_compiler
 _logger = logging.getLogger(__file__)
 
 force_compile = False
-version = 0.211  # must match constant returned in function get_version()
+version = 0.212  # must match constant returned in function get_version()
 lazylinker_ext: Optional[ModuleType] = None
 
 

--- a/aesara/link/jax/dispatch.py
+++ b/aesara/link/jax/dispatch.py
@@ -418,7 +418,7 @@ def jax_funcify_Scan(op, **kwargs):
 
     def scan(*outer_inputs):
         scan_args = ScanArgs(
-            list(outer_inputs), [None] * op.n_outs, op.inputs, op.outputs, op.info
+            list(outer_inputs), [None] * op.info.n_outs, op.inputs, op.outputs, op.info
         )
 
         # `outer_inputs` is a list with the following composite form:

--- a/aesara/link/numba/dispatch/scan.py
+++ b/aesara/link/numba/dispatch/scan.py
@@ -34,7 +34,7 @@ def array0d_range(x):
 
 @numba_funcify.register(Scan)
 def numba_funcify_Scan(op, node, **kwargs):
-    inner_fg = FunctionGraph(op.inputs, op.outputs)
+    inner_fg = FunctionGraph(op.inner_inputs, op.inner_outputs)
     numba_at_inner_func = numba_basic.numba_njit(numba_funcify(inner_fg, **kwargs))
 
     n_seqs = op.info.n_seqs

--- a/aesara/link/numba/dispatch/scan.py
+++ b/aesara/link/numba/dispatch/scan.py
@@ -120,7 +120,7 @@ def numba_funcify_Scan(op, node, **kwargs):
     ]
 
     while_logic = ""
-    if op.as_while:
+    if op.info.as_while:
         # The inner function will be returning a boolean as last argument
         inner_out_indexed.append("while_flag")
         while_logic += """

--- a/aesara/link/utils.py
+++ b/aesara/link/utils.py
@@ -318,8 +318,6 @@ def raise_with_op(
         raise exc_value.with_traceback(exc_trace)
 
     trace = getattr(node.outputs[0].tag, "trace", ())
-    if not trace and hasattr(node.op, "tag"):
-        trace = getattr(node.op.tag, "trace", ())
 
     exc_value.__thunk_trace__ = trace
     exc_value.__op_instance__ = node
@@ -366,8 +364,6 @@ def raise_with_op(
             detailed_err_msg += "\nInputs type_num: %s" % str(
                 [getattr(getattr(i[0], "dtype", ""), "num", "") for i in thunk.inputs]
             )
-        if hasattr(node.op, "__input_name__"):
-            detailed_err_msg += f"\nInputs name: {node.op.__input_name__}\n"
 
         detailed_err_msg += f"\nOutputs clients: {clients}\n"
     else:

--- a/aesara/link/vm.py
+++ b/aesara/link/vm.py
@@ -1197,3 +1197,12 @@ class VMLinker(LocalLinker):
             self.allow_partial_eval = None
         if not hasattr(self, "callback_input"):
             self.callback_input = None
+
+    def __repr__(self):
+        args_str = ", ".join(
+            [
+                f"{name}={getattr(self, name)}"
+                for name in ("use_cloop", "lazy", "allow_partial_eval", "allow_gc")
+            ]
+        )
+        return f"{type(self).__name__}({args_str})"

--- a/aesara/misc/check_blas.py
+++ b/aesara/misc/check_blas.py
@@ -59,7 +59,7 @@ def execute(execute=True, verbose=True, M=2000, N=2000, K=2000, iters=10, order=
     if any(x.op.__class__.__name__ == "Gemm" for x in f.maker.fgraph.toposort()):
         c_impl = [
             hasattr(thunk, "cthunk")
-            for node, thunk in zip(f.fn.nodes, f.fn.thunks)
+            for node, thunk in zip(f.vm.nodes, f.vm.thunks)
             if node.op.__class__.__name__ == "Gemm"
         ]
         assert len(c_impl) == 1

--- a/aesara/printing.py
+++ b/aesara/printing.py
@@ -1537,7 +1537,7 @@ def pydotprint(
             if hasattr(scan_op.op, "_fn"):
                 to_print = scan_op.op.fn
             else:
-                to_print = scan_op.op.outputs
+                to_print = scan_op.op.inner_outputs
             pydotprint(
                 to_print,
                 new_name,

--- a/aesara/printing.py
+++ b/aesara/printing.py
@@ -1360,6 +1360,9 @@ def pydotprint(
     # it, we must copy it.
     outputs = list(outputs)
     if isinstance(fct, Function):
+
+        # TODO: Get rid of all this `expanded_inputs` nonsense and use
+        # `fgraph.update_mapping`
         function_inputs = zip(fct.maker.expanded_inputs, fgraph.inputs)
         for i, fg_ii in reversed(list(function_inputs)):
             if i.update is not None:

--- a/aesara/printing.py
+++ b/aesara/printing.py
@@ -375,6 +375,7 @@ N.B.:
                     print_op_info=print_op_info,
                     print_destroy_map=print_destroy_map,
                     print_view_map=print_view_map,
+                    inner_graph_node=s.owner,
                 )
 
     if file is _file:
@@ -407,6 +408,7 @@ def _debugprint(
     op_information: Optional[Dict[Apply, Dict[Variable, str]]] = None,
     parent_node: Optional[Apply] = None,
     print_op_info: bool = False,
+    inner_graph_node: Optional[Apply] = None,
 ) -> IOBase:
     r"""Print the graph leading to `r`.
 
@@ -459,6 +461,8 @@ def _debugprint(
     print_op_info
         Print extra information provided by the relevant `Op`\s.  For example,
         print the tap information for `Scan` inputs and outputs.
+    inner_graph_node
+        The inner-graph node in which `r` is contained.
     """
     if depth == 0:
         return file
@@ -615,6 +619,7 @@ def _debugprint(
                     print_op_info=print_op_info,
                     print_destroy_map=print_destroy_map,
                     print_view_map=print_view_map,
+                    inner_graph_node=inner_graph_node,
                 )
     else:
 
@@ -644,14 +649,9 @@ def _debugprint(
 
             var_output = f"{var_output} -> {outer_id_str}"
 
-            # This is an inner-graph input, so we need to find the outer node
-            # it belongs to and get the extra information from that
-            for inner_graph in inner_graph_ops:
-                if outer_r in inner_graph.owner.inputs:
-                    node_info = op_information.get(inner_graph.owner)
-                    if node_info and r in node_info:
-                        var_output = f"{var_output} ({node_info[r]})"
-                        break
+            node_info = op_information.get(inner_graph_node)
+            if node_info and r in node_info:
+                var_output = f"{var_output} ({node_info[r]})"
 
         node_info = op_information.get(parent_node) or op_information.get(r.owner)
         if node_info and r in node_info:

--- a/aesara/printing.py
+++ b/aesara/printing.py
@@ -222,7 +222,7 @@ def debugprint(
             results_to_print.extend(obj.maker.fgraph.outputs)
             profile_list.extend([obj.profile for item in obj.maker.fgraph.outputs])
             if print_storage:
-                smap.extend([obj.fn.storage_map for item in obj.maker.fgraph.outputs])
+                smap.extend([obj.vm.storage_map for item in obj.maker.fgraph.outputs])
             else:
                 smap.extend([None for item in obj.maker.fgraph.outputs])
             topo = obj.maker.fgraph.toposort()

--- a/aesara/sandbox/rng_mrg.py
+++ b/aesara/sandbox/rng_mrg.py
@@ -75,7 +75,7 @@ def multMatVect(v, A, m1, B, m2):
     f.input_storage[3].storage[0] = B
     f.input_storage[4].storage[0] = v[3:]
     f.input_storage[5].storage[0] = m2
-    f.fn()
+    f.vm()
     r = f.output_storage[0].storage[0]
 
     return r
@@ -829,7 +829,7 @@ class MRG_RandomStream:
             v = rval[i - 1]
             f.input_storage[1].storage[0] = v[:3]
             f.input_storage[4].storage[0] = v[3:]
-            f.fn()
+            f.vm()
             rval[i] = f.output_storage[0].storage[0]
 
         if inc_rstate:

--- a/aesara/scan/basic.py
+++ b/aesara/scan/basic.py
@@ -1139,6 +1139,7 @@ def scan(
         n_sit_sot=n_sit_sot,
         n_shared_outs=n_shared_outs,
         n_nit_sot=n_nit_sot,
+        n_non_seqs=len(other_shared_inner_args) + len(other_inner_args),
     )
 
     local_op = Scan(

--- a/aesara/scan/basic.py
+++ b/aesara/scan/basic.py
@@ -688,7 +688,6 @@ def scan(
 
     # MIT_MOT -- not provided by the user only by the grad function
     n_mit_mot = 0
-    n_mit_mot_outs = 0
     mit_mot_scan_inputs = []
     mit_mot_inner_inputs = []
     mit_mot_inner_outputs = []
@@ -1129,13 +1128,9 @@ def scan(
     info = ScanInfo(
         n_seqs=n_seqs,
         mit_mot_in_slices=(),
+        mit_mot_out_slices=tuple(tuple(v) for v in mit_mot_out_slices),
         mit_sot_in_slices=tuple(tuple(v) for v in mit_sot_tap_array),
         sit_sot_in_slices=tuple((-1,) for x in range(n_sit_sot)),
-        n_mit_mot=n_mit_mot,
-        n_mit_mot_outs=n_mit_mot_outs,
-        mit_mot_out_slices=tuple(tuple(v) for v in mit_mot_out_slices),
-        n_mit_sot=n_mit_sot,
-        n_sit_sot=n_sit_sot,
         n_shared_outs=n_shared_outs,
         n_nit_sot=n_nit_sot,
         n_non_seqs=len(other_shared_inner_args) + len(other_inner_args),

--- a/aesara/scan/basic.py
+++ b/aesara/scan/basic.py
@@ -1140,6 +1140,7 @@ def scan(
         n_shared_outs=n_shared_outs,
         n_nit_sot=n_nit_sot,
         n_non_seqs=len(other_shared_inner_args) + len(other_inner_args),
+        as_while=as_while,
     )
 
     local_op = Scan(
@@ -1149,7 +1150,6 @@ def scan(
         mode=mode,
         truncate_gradient=truncate_gradient,
         name=name,
-        as_while=as_while,
         profile=profile,
         allow_gc=allow_gc,
         strict=strict,

--- a/aesara/scan/basic.py
+++ b/aesara/scan/basic.py
@@ -1123,15 +1123,14 @@ def scan(
     # Step 7. Create the Scan Op
     ##
 
-    tap_array = tuple(tuple(v) for v in mit_sot_tap_array) + tuple(
-        (-1,) for x in range(n_sit_sot)
-    )
     if allow_gc is None:
         allow_gc = config.scan__allow_gc
 
     info = ScanInfo(
-        tap_array=tap_array,
         n_seqs=n_seqs,
+        mit_mot_in_slices=(),
+        mit_sot_in_slices=tuple(tuple(v) for v in mit_sot_tap_array),
+        sit_sot_in_slices=tuple((-1,) for x in range(n_sit_sot)),
         n_mit_mot=n_mit_mot,
         n_mit_mot_outs=n_mit_mot_outs,
         mit_mot_out_slices=tuple(tuple(v) for v in mit_mot_out_slices),

--- a/aesara/scan/c_code/scan_perform.c
+++ b/aesara/scan/c_code/scan_perform.c
@@ -1600,18 +1600,6 @@ static CYTHON_INLINE PyObject *__Pyx_PyObject_GetItem(PyObject *obj, PyObject* k
 #define __Pyx_PyObject_GetItem(obj, key)  PyObject_GetItem(obj, key)
 #endif
 
-/* RaiseTooManyValuesToUnpack.proto */
-static CYTHON_INLINE void __Pyx_RaiseTooManyValuesError(Py_ssize_t expected);
-
-/* RaiseNeedMoreValuesToUnpack.proto */
-static CYTHON_INLINE void __Pyx_RaiseNeedMoreValuesError(Py_ssize_t index);
-
-/* IterFinish.proto */
-static CYTHON_INLINE int __Pyx_IterFinish(void);
-
-/* UnpackItemEndCheck.proto */
-static int __Pyx_IternextUnpackEndCheck(PyObject *retval, Py_ssize_t expected);
-
 /* PyIntBinop.proto */
 #if !CYTHON_COMPILING_IN_PYPY
 static PyObject* __Pyx_PyInt_AddObjC(PyObject *op1, PyObject *op2, long intval, int inplace, int zerodivision_check);
@@ -1879,7 +1867,6 @@ static PyObject *__pyx_builtin_IndexError;
 static PyObject *__pyx_builtin_range;
 static PyObject *__pyx_builtin_ValueError;
 static PyObject *__pyx_builtin_xrange;
-static PyObject *__pyx_builtin_zip;
 static PyObject *__pyx_builtin_ImportError;
 static const char __pyx_k_e[] = "e";
 static const char __pyx_k_i[] = "i";
@@ -1900,7 +1887,6 @@ static const char __pyx_k_tap[] = "tap";
 static const char __pyx_k_tdx[] = "tdx";
 static const char __pyx_k_tmp[] = "tmp";
 static const char __pyx_k_var[] = "var";
-static const char __pyx_k_zip[] = "zip";
 static const char __pyx_k_cond[] = "cond";
 static const char __pyx_k_copy[] = "copy";
 static const char __pyx_k_data[] = "data";
@@ -1934,7 +1920,6 @@ static const char __pyx_k_new_var[] = "new_var";
 static const char __pyx_k_old_var[] = "old_var";
 static const char __pyx_k_perform[] = "perform";
 static const char __pyx_k_reshape[] = "reshape";
-static const char __pyx_k_storage[] = "storage";
 static const char __pyx_k_Sequence[] = "Sequence ";
 static const char __pyx_k_a_offset[] = "a_offset";
 static const char __pyx_k_as_while[] = "as_while";
@@ -1959,8 +1944,8 @@ static const char __pyx_k_store_steps[] = "store_steps";
 static const char __pyx_k_vector_outs[] = "vector_outs";
 static const char __pyx_k_vector_seqs[] = "vector_seqs";
 static const char __pyx_k_nb_mitmot_in[] = "nb_mitmot_in";
-static const char __pyx_k_needs_update[] = "needs_update";
 static const char __pyx_k_outer_inputs[] = "outer_inputs";
+static const char __pyx_k_inner_inp_idx[] = "inner_inp_idx";
 static const char __pyx_k_n_shared_outs[] = "n_shared_outs";
 static const char __pyx_k_outer_outputs[] = "outer_outputs";
 static const char __pyx_k_output_reused[] = "output_reused";
@@ -1979,7 +1964,6 @@ static const char __pyx_k_InnerFunctionError[] = "InnerFunctionError";
 static const char __pyx_k_cline_in_traceback[] = "cline_in_traceback";
 static const char __pyx_k_len_output_storage[] = "len_output_storage";
 static const char __pyx_k_mit_mot_out_slices[] = "mit_mot_out_slices";
-static const char __pyx_k_need_update_inputs[] = "need_update_inputs";
 static const char __pyx_k_nit_sot_arg_offset[] = "nit_sot_arg_offset";
 static const char __pyx_k_old_output_storage[] = "old_output_storage";
 static const char __pyx_k_outer_output_ndims[] = "outer_output_ndims";
@@ -1989,7 +1973,6 @@ static const char __pyx_k_inner_output_storage[] = "inner_output_storage";
 static const char __pyx_k_mitmots_preallocated[] = "mitmots_preallocated";
 static const char __pyx_k_old_mitmot_input_data[] = "old_mitmot_input_data";
 static const char __pyx_k_aesara_scan_scan_perform[] = "aesara.scan.scan_perform";
-static const char __pyx_k_inner_input_needs_update[] = "inner_input_needs_update";
 static const char __pyx_k_old_mitmot_input_storage[] = "old_mitmot_input_storage";
 static const char __pyx_k_but_the_Scan_s_required_number[] = " but the Scan's required number of steps is ";
 static const char __pyx_k_This_code_implements_the_operat[] = "\n This code implements the operations that scan has to carry on when called\n as a stand alone function.\n\n IF anything this is the entire code that needs to be transported to C.\n\n Short description of how this code works:\n     Scan divides its inputs ( Op's inputs) into different classes of inputs\n     as follows:\n         i) sequences : inputs over which scan loops to get data. Nothing is\n         written into them ( they are readonly, loop over)\n\n         ii) mit_mot : multiple input taps multiple output taps arguments.\n         These are inputs over which scan loops and gets data but into which\n         scan also writes data. The shorthand mit_mot describes how scan\n         deal with them at each step : at each step take several slices as\n         input and produce several slices as outputs\n\n         iii) mit_sot : multiple input taps single output tap arguments.\n         As before scan reads from these but also writes. At each step scan\n         uses several slices as input but produces only one as output\n\n         iv) sit_sot : single input tap single output tap arguments.\n         At each step use only the previous slice as input, produce only one\n         slice as output\n\n         v) nit_sot: no input tap single output tap arguments.\n         At each step don't use any previous values, only produce new onese\n\n         vi) shared_outs: arguments corresponding to shared variables with\n         updates.\n         At each step use its value as input, and afterwards replace it with\n         a new value.\n         vii) other_args: arguments that are passed to every call of the\n         inner function as they are ( no slicing is performed)\n\n    All these outputs are one after the other in the inputs list (named in\n    this code as outer_inputs) in a given order ( namely the one described above\n    with little discrepancies depending if we are talking about the outputs\n    of the Scan op or the inputs of the Scan op Node, and if w""e are talking\n    about the inputs of the inner function of scan or of the scan op).\n\n    Because of this, all we need to be able to separate and tell arguments\n    apart is how many of which we have as well as how many taps and which\n    ones (where applicable). All this information is described (more or less)\n    by describing the arguments of this function)\n";
@@ -2030,7 +2013,7 @@ static PyObject *__pyx_n_s_idx;
 static PyObject *__pyx_n_s_idx_2;
 static PyObject *__pyx_n_s_import;
 static PyObject *__pyx_n_s_index;
-static PyObject *__pyx_n_s_inner_input_needs_update;
+static PyObject *__pyx_n_s_inner_inp_idx;
 static PyObject *__pyx_n_s_inner_input_storage;
 static PyObject *__pyx_n_s_inner_output_storage;
 static PyObject *__pyx_n_s_inp_idx;
@@ -2060,8 +2043,6 @@ static PyObject *__pyx_n_s_n_sit_sot;
 static PyObject *__pyx_n_s_n_steps;
 static PyObject *__pyx_n_s_name;
 static PyObject *__pyx_n_s_nb_mitmot_in;
-static PyObject *__pyx_n_s_need_update_inputs;
-static PyObject *__pyx_n_s_needs_update;
 static PyObject *__pyx_n_s_new_var;
 static PyObject *__pyx_n_s_nit_sot_arg_offset;
 static PyObject *__pyx_n_s_numpy;
@@ -2095,7 +2076,6 @@ static PyObject *__pyx_n_s_seqs_arg_offset;
 static PyObject *__pyx_n_s_sh0;
 static PyObject *__pyx_n_s_shape;
 static PyObject *__pyx_n_s_shared_arg_offset;
-static PyObject *__pyx_n_s_storage;
 static PyObject *__pyx_n_s_store_steps;
 static PyObject *__pyx_n_s_sys;
 static PyObject *__pyx_n_s_t0_fn;
@@ -2111,32 +2091,29 @@ static PyObject *__pyx_n_s_var;
 static PyObject *__pyx_n_s_vector_outs;
 static PyObject *__pyx_n_s_vector_seqs;
 static PyObject *__pyx_n_s_xrange;
-static PyObject *__pyx_n_s_zip;
 static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_get_version(CYTHON_UNUSED PyObject *__pyx_self); /* proto */
-static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED PyObject *__pyx_self, unsigned int __pyx_v_n_shared_outs, unsigned int __pyx_v_n_mit_mot_outs, unsigned int __pyx_v_n_seqs, unsigned int __pyx_v_n_mit_mot, unsigned int __pyx_v_n_mit_sot, unsigned int __pyx_v_n_sit_sot, unsigned int __pyx_v_n_nit_sot, int __pyx_v_as_while, PyArrayObject *__pyx_v_mintaps, PyObject *__pyx_v_tap_array, PyObject *__pyx_v_tap_array_len, PyArrayObject *__pyx_v_vector_seqs, PyArrayObject *__pyx_v_vector_outs, PyObject *__pyx_v_mit_mot_out_slices, PyArrayObject *__pyx_v_mitmots_preallocated, PyArrayObject *__pyx_v_outs_is_tensor, PyObject *__pyx_v_inner_input_storage, PyObject *__pyx_v_inner_output_storage, int __pyx_v_need_update_inputs, PyObject *__pyx_v_inner_input_needs_update, PyArrayObject *__pyx_v_destroy_map, PyObject *__pyx_v_outer_inputs, PyObject *__pyx_v_outer_outputs, PyObject *__pyx_v_outer_output_dtypes, PyObject *__pyx_v_outer_output_ndims, PyObject *__pyx_v_fn); /* proto */
+static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED PyObject *__pyx_self, unsigned int __pyx_v_n_shared_outs, unsigned int __pyx_v_n_mit_mot_outs, unsigned int __pyx_v_n_seqs, unsigned int __pyx_v_n_mit_mot, unsigned int __pyx_v_n_mit_sot, unsigned int __pyx_v_n_sit_sot, unsigned int __pyx_v_n_nit_sot, int __pyx_v_as_while, PyArrayObject *__pyx_v_mintaps, PyObject *__pyx_v_tap_array, PyObject *__pyx_v_tap_array_len, PyArrayObject *__pyx_v_vector_seqs, PyArrayObject *__pyx_v_vector_outs, PyObject *__pyx_v_mit_mot_out_slices, PyArrayObject *__pyx_v_mitmots_preallocated, PyArrayObject *__pyx_v_outs_is_tensor, PyObject *__pyx_v_inner_input_storage, PyObject *__pyx_v_inner_output_storage, PyArrayObject *__pyx_v_destroy_map, PyObject *__pyx_v_outer_inputs, PyObject *__pyx_v_outer_outputs, PyObject *__pyx_v_outer_output_dtypes, PyObject *__pyx_v_outer_output_ndims, PyObject *__pyx_v_fn); /* proto */
 static PyObject *__pyx_float_0_0;
-static PyObject *__pyx_float_0_313;
+static PyObject *__pyx_float_0_314;
 static PyObject *__pyx_int_0;
 static PyObject *__pyx_int_1;
-static PyObject *__pyx_int_neg_1;
 static PyObject *__pyx_slice_;
 static PyObject *__pyx_slice__2;
-static PyObject *__pyx_slice__5;
 static PyObject *__pyx_tuple__3;
 static PyObject *__pyx_tuple__4;
+static PyObject *__pyx_tuple__5;
 static PyObject *__pyx_tuple__6;
 static PyObject *__pyx_tuple__7;
-static PyObject *__pyx_tuple__8;
-static PyObject *__pyx_tuple__10;
-static PyObject *__pyx_codeobj__9;
-static PyObject *__pyx_codeobj__11;
+static PyObject *__pyx_tuple__9;
+static PyObject *__pyx_codeobj__8;
+static PyObject *__pyx_codeobj__10;
 /* Late includes */
 
 /* "aesara/scan/scan_perform.pyx":61
  * 
  * 
  * def get_version():             # <<<<<<<<<<<<<<
- *     return 0.313
+ *     return 0.314
  * 
  */
 
@@ -2162,20 +2139,20 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_get_version(CYTHON_UNUSED
   /* "aesara/scan/scan_perform.pyx":62
  * 
  * def get_version():
- *     return 0.313             # <<<<<<<<<<<<<<
+ *     return 0.314             # <<<<<<<<<<<<<<
  * 
  * @cython.boundscheck(False)
  */
   __Pyx_XDECREF(__pyx_r);
-  __Pyx_INCREF(__pyx_float_0_313);
-  __pyx_r = __pyx_float_0_313;
+  __Pyx_INCREF(__pyx_float_0_314);
+  __pyx_r = __pyx_float_0_314;
   goto __pyx_L0;
 
   /* "aesara/scan/scan_perform.pyx":61
  * 
  * 
  * def get_version():             # <<<<<<<<<<<<<<
- *     return 0.313
+ *     return 0.314
  * 
  */
 
@@ -2196,7 +2173,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_get_version(CYTHON_UNUSED
 
 /* Python wrapper */
 static PyObject *__pyx_pw_6aesara_4scan_12scan_perform_3perform(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static char __pyx_doc_6aesara_4scan_12scan_perform_2perform[] = "\n    Parameters\n    ----------\n    n_shared_outs: unsigned int\n        Number of arguments that correspond to shared variables with\n        updates\n    n_mit_mot_outs: unsigned int\n        Sum over the number of output taps for each mit_mot sequence\n    n_seqs: unsigned int\n        Number of sequences provided as input\n    n_mit_mot : unsigned int\n        Number of mit_mot arguments\n    n_mit_sot: unsigned int\n        Number of mit_sot arguments\n    n_sit_sot: unsigned int\n        Number of sit sot arguments\n    n_nit_sot: unsigned int\n        Number of nit_sot arguments\n    mintaps: int32 ndarray (can also be a simple python list if that is better !)\n        For any of the mit_mot, mit_sot, sit_sot says which is the furtherst\n        away input tap from current position. For example, if the taps where [-2,\n        -5, -9], the mintap would be -9. For sit_sot this is always -1 since\n        is the only allowed tap.\n    tap_array\n        For each of the mit_mot, mit_sot, sit_sot (the first dimension) says\n        which are the corresponding input taps. While this is a matrix, not all\n        values in a row are needed and tap_array_len is there to say up to\n        which entry we are dealing with valid taps ( afterwards there are\n        just 0s to ensure the fix format)\n    tap_array_len\n        For each of the mit_mot, mit_sot, sit_sot says how many input taps\n        each has. For sit_sot this will always be 1.\n    vector_seqs: int32 ndarray (can be replaced by a list of bools if better)\n        For each sequence the corresponding entry is either a 1, is the\n        sequence is a vector or 0 if it has more than 1 dimension\n    vector_outs: int32 ndarray( can be replaced by list of bools if better)\n        For each output ( mit_mot, mit_sot, sit_sot, nit_sot in this order)\n        the entry is 1 if the corresponding argument is a 1 dimensional\n        tensor, 0 otherwise.\n    mit_mot_out_slices\n        Same as tap_array, but ""for the output taps of mit_mot sequences\n    outs_is_tensor : int32 ndarray (Can be replaced by a list)\n        Array of boolean indicating, for every output, whether it is a tensor\n        or not\n    inner_input_storage\n        The storage locations for the inner-function's inputs.\n    inner_output_storage\n        The storage locations for the inner-function's outputs.\n    need_update_inputs\n        A boolean indicating whether or not inner inputs need to be updated.\n    inner_input_needs_update\n        A tuple of booleans indicating which inner inputs need to be updated.\n    fnct: Function\n        The compiled Aesara inner-function object.\n    destroy_map\n        Array of boolean saying if an output is computed inplace\n    outer_inputs: list of ndarrays (and random states)\n        The inputs of scan in a given order ( n_steps, sequences, mit_mot,\n        mit_sot, sit_sot, nit_sot, shared_outs, other_args)\n    outer_outputs: list of 1 element list ( or storage objects?)\n        This is where we need to copy our outputs ( we don't return the\n        results, though we can change the code such that we return, and\n        figure things out on the outside - python)\n    outer_output_dtypes\n        The dtypes for each outer output.\n    outer_output_ndims\n        The number of dimensions for each outer output.\n    fn\n        The inner function thunk.\n\n    ";
+static char __pyx_doc_6aesara_4scan_12scan_perform_2perform[] = "\n    Parameters\n    ----------\n    n_shared_outs: unsigned int\n        Number of arguments that correspond to shared variables with\n        updates\n    n_mit_mot_outs: unsigned int\n        Sum over the number of output taps for each mit_mot sequence\n    n_seqs: unsigned int\n        Number of sequences provided as input\n    n_mit_mot : unsigned int\n        Number of mit_mot arguments\n    n_mit_sot: unsigned int\n        Number of mit_sot arguments\n    n_sit_sot: unsigned int\n        Number of sit sot arguments\n    n_nit_sot: unsigned int\n        Number of nit_sot arguments\n    mintaps: int32 ndarray (can also be a simple python list if that is better !)\n        For any of the mit_mot, mit_sot, sit_sot says which is the furtherst\n        away input tap from current position. For example, if the taps where [-2,\n        -5, -9], the mintap would be -9. For sit_sot this is always -1 since\n        is the only allowed tap.\n    tap_array\n        For each of the mit_mot, mit_sot, sit_sot (the first dimension) says\n        which are the corresponding input taps. While this is a matrix, not all\n        values in a row are needed and tap_array_len is there to say up to\n        which entry we are dealing with valid taps ( afterwards there are\n        just 0s to ensure the fix format)\n    tap_array_len\n        For each of the mit_mot, mit_sot, sit_sot says how many input taps\n        each has. For sit_sot this will always be 1.\n    vector_seqs: int32 ndarray (can be replaced by a list of bools if better)\n        For each sequence the corresponding entry is either a 1, is the\n        sequence is a vector or 0 if it has more than 1 dimension\n    vector_outs: int32 ndarray( can be replaced by list of bools if better)\n        For each output ( mit_mot, mit_sot, sit_sot, nit_sot in this order)\n        the entry is 1 if the corresponding argument is a 1 dimensional\n        tensor, 0 otherwise.\n    mit_mot_out_slices\n        Same as tap_array, but ""for the output taps of mit_mot sequences\n    outs_is_tensor : int32 ndarray (Can be replaced by a list)\n        Array of boolean indicating, for every output, whether it is a tensor\n        or not\n    inner_input_storage\n        The storage locations for the inner-function's inputs.\n    inner_output_storage\n        The storage locations for the inner-function's outputs.\n    fnct: Function\n        The compiled Aesara inner-function object.\n    destroy_map\n        Array of boolean saying if an output is computed inplace\n    outer_inputs: list of ndarrays (and random states)\n        The inputs of scan in a given order ( n_steps, sequences, mit_mot,\n        mit_sot, sit_sot, nit_sot, shared_outs, other_args)\n    outer_outputs: list of 1 element list ( or storage objects?)\n        This is where we need to copy our outputs ( we don't return the\n        results, though we can change the code such that we return, and\n        figure things out on the outside - python)\n    outer_output_dtypes\n        The dtypes for each outer output.\n    outer_output_ndims\n        The number of dimensions for each outer output.\n    fn\n        The inner function thunk.\n\n    ";
 static PyMethodDef __pyx_mdef_6aesara_4scan_12scan_perform_3perform = {"perform", (PyCFunction)(void*)(PyCFunctionWithKeywords)__pyx_pw_6aesara_4scan_12scan_perform_3perform, METH_VARARGS|METH_KEYWORDS, __pyx_doc_6aesara_4scan_12scan_perform_2perform};
 static PyObject *__pyx_pw_6aesara_4scan_12scan_perform_3perform(PyObject *__pyx_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   unsigned int __pyx_v_n_shared_outs;
@@ -2217,8 +2194,6 @@ static PyObject *__pyx_pw_6aesara_4scan_12scan_perform_3perform(PyObject *__pyx_
   PyArrayObject *__pyx_v_outs_is_tensor = 0;
   PyObject *__pyx_v_inner_input_storage = 0;
   PyObject *__pyx_v_inner_output_storage = 0;
-  int __pyx_v_need_update_inputs;
-  PyObject *__pyx_v_inner_input_needs_update = 0;
   PyArrayObject *__pyx_v_destroy_map = 0;
   PyObject *__pyx_v_outer_inputs = 0;
   PyObject *__pyx_v_outer_outputs = 0;
@@ -2232,16 +2207,12 @@ static PyObject *__pyx_pw_6aesara_4scan_12scan_perform_3perform(PyObject *__pyx_
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("perform (wrapper)", 0);
   {
-    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_n_shared_outs,&__pyx_n_s_n_mit_mot_outs,&__pyx_n_s_n_seqs,&__pyx_n_s_n_mit_mot,&__pyx_n_s_n_mit_sot,&__pyx_n_s_n_sit_sot,&__pyx_n_s_n_nit_sot,&__pyx_n_s_as_while,&__pyx_n_s_mintaps,&__pyx_n_s_tap_array,&__pyx_n_s_tap_array_len,&__pyx_n_s_vector_seqs,&__pyx_n_s_vector_outs,&__pyx_n_s_mit_mot_out_slices,&__pyx_n_s_mitmots_preallocated,&__pyx_n_s_outs_is_tensor,&__pyx_n_s_inner_input_storage,&__pyx_n_s_inner_output_storage,&__pyx_n_s_need_update_inputs,&__pyx_n_s_inner_input_needs_update,&__pyx_n_s_destroy_map,&__pyx_n_s_outer_inputs,&__pyx_n_s_outer_outputs,&__pyx_n_s_outer_output_dtypes,&__pyx_n_s_outer_output_ndims,&__pyx_n_s_fn,0};
-    PyObject* values[26] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+    static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_n_shared_outs,&__pyx_n_s_n_mit_mot_outs,&__pyx_n_s_n_seqs,&__pyx_n_s_n_mit_mot,&__pyx_n_s_n_mit_sot,&__pyx_n_s_n_sit_sot,&__pyx_n_s_n_nit_sot,&__pyx_n_s_as_while,&__pyx_n_s_mintaps,&__pyx_n_s_tap_array,&__pyx_n_s_tap_array_len,&__pyx_n_s_vector_seqs,&__pyx_n_s_vector_outs,&__pyx_n_s_mit_mot_out_slices,&__pyx_n_s_mitmots_preallocated,&__pyx_n_s_outs_is_tensor,&__pyx_n_s_inner_input_storage,&__pyx_n_s_inner_output_storage,&__pyx_n_s_destroy_map,&__pyx_n_s_outer_inputs,&__pyx_n_s_outer_outputs,&__pyx_n_s_outer_output_dtypes,&__pyx_n_s_outer_output_ndims,&__pyx_n_s_fn,0};
+    PyObject* values[24] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
     if (unlikely(__pyx_kwds)) {
       Py_ssize_t kw_args;
       const Py_ssize_t pos_args = PyTuple_GET_SIZE(__pyx_args);
       switch (pos_args) {
-        case 26: values[25] = PyTuple_GET_ITEM(__pyx_args, 25);
-        CYTHON_FALLTHROUGH;
-        case 25: values[24] = PyTuple_GET_ITEM(__pyx_args, 24);
-        CYTHON_FALLTHROUGH;
         case 24: values[23] = PyTuple_GET_ITEM(__pyx_args, 23);
         CYTHON_FALLTHROUGH;
         case 23: values[22] = PyTuple_GET_ITEM(__pyx_args, 22);
@@ -2302,157 +2273,145 @@ static PyObject *__pyx_pw_6aesara_4scan_12scan_perform_3perform(PyObject *__pyx_
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_n_mit_mot_outs)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 1); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 1); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_n_seqs)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 2); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 2); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
         if (likely((values[3] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_n_mit_mot)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 3); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 3); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  4:
         if (likely((values[4] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_n_mit_sot)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 4); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 4); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  5:
         if (likely((values[5] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_n_sit_sot)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 5); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 5); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  6:
         if (likely((values[6] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_n_nit_sot)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 6); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 6); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  7:
         if (likely((values[7] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_as_while)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 7); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 7); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  8:
         if (likely((values[8] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_mintaps)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 8); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 8); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  9:
         if (likely((values[9] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_tap_array)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 9); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 9); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 10:
         if (likely((values[10] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_tap_array_len)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 10); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 10); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 11:
         if (likely((values[11] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_vector_seqs)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 11); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 11); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 12:
         if (likely((values[12] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_vector_outs)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 12); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 12); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 13:
         if (likely((values[13] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_mit_mot_out_slices)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 13); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 13); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 14:
         if (likely((values[14] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_mitmots_preallocated)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 14); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 14); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 15:
         if (likely((values[15] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_outs_is_tensor)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 15); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 15); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 16:
         if (likely((values[16] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_inner_input_storage)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 16); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 16); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 17:
         if (likely((values[17] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_inner_output_storage)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 17); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 17); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 18:
-        if (likely((values[18] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_need_update_inputs)) != 0)) kw_args--;
+        if (likely((values[18] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_destroy_map)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 18); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 18); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 19:
-        if (likely((values[19] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_inner_input_needs_update)) != 0)) kw_args--;
+        if (likely((values[19] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_outer_inputs)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 19); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 19); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 20:
-        if (likely((values[20] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_destroy_map)) != 0)) kw_args--;
+        if (likely((values[20] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_outer_outputs)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 20); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 20); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 21:
-        if (likely((values[21] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_outer_inputs)) != 0)) kw_args--;
+        if (likely((values[21] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_outer_output_dtypes)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 21); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 21); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 22:
-        if (likely((values[22] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_outer_outputs)) != 0)) kw_args--;
+        if (likely((values[22] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_outer_output_ndims)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 22); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 22); __PYX_ERR(0, 65, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case 23:
-        if (likely((values[23] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_outer_output_dtypes)) != 0)) kw_args--;
+        if (likely((values[23] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_fn)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 23); __PYX_ERR(0, 65, __pyx_L3_error)
-        }
-        CYTHON_FALLTHROUGH;
-        case 24:
-        if (likely((values[24] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_outer_output_ndims)) != 0)) kw_args--;
-        else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 24); __PYX_ERR(0, 65, __pyx_L3_error)
-        }
-        CYTHON_FALLTHROUGH;
-        case 25:
-        if (likely((values[25] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_fn)) != 0)) kw_args--;
-        else {
-          __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, 25); __PYX_ERR(0, 65, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, 23); __PYX_ERR(0, 65, __pyx_L3_error)
         }
       }
       if (unlikely(kw_args > 0)) {
         if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "perform") < 0)) __PYX_ERR(0, 65, __pyx_L3_error)
       }
-    } else if (PyTuple_GET_SIZE(__pyx_args) != 26) {
+    } else if (PyTuple_GET_SIZE(__pyx_args) != 24) {
       goto __pyx_L5_argtuple_error;
     } else {
       values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
@@ -2479,8 +2438,6 @@ static PyObject *__pyx_pw_6aesara_4scan_12scan_perform_3perform(PyObject *__pyx_
       values[21] = PyTuple_GET_ITEM(__pyx_args, 21);
       values[22] = PyTuple_GET_ITEM(__pyx_args, 22);
       values[23] = PyTuple_GET_ITEM(__pyx_args, 23);
-      values[24] = PyTuple_GET_ITEM(__pyx_args, 24);
-      values[25] = PyTuple_GET_ITEM(__pyx_args, 25);
     }
     __pyx_v_n_shared_outs = __Pyx_PyInt_As_unsigned_int(values[0]); if (unlikely((__pyx_v_n_shared_outs == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 66, __pyx_L3_error)
     __pyx_v_n_mit_mot_outs = __Pyx_PyInt_As_unsigned_int(values[1]); if (unlikely((__pyx_v_n_mit_mot_outs == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 67, __pyx_L3_error)
@@ -2500,18 +2457,16 @@ static PyObject *__pyx_pw_6aesara_4scan_12scan_perform_3perform(PyObject *__pyx_
     __pyx_v_outs_is_tensor = ((PyArrayObject *)values[15]);
     __pyx_v_inner_input_storage = ((PyObject*)values[16]);
     __pyx_v_inner_output_storage = ((PyObject*)values[17]);
-    __pyx_v_need_update_inputs = __Pyx_PyObject_IsTrue(values[18]); if (unlikely((__pyx_v_need_update_inputs == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 84, __pyx_L3_error)
-    __pyx_v_inner_input_needs_update = ((PyObject*)values[19]);
-    __pyx_v_destroy_map = ((PyArrayObject *)values[20]);
-    __pyx_v_outer_inputs = ((PyObject*)values[21]);
-    __pyx_v_outer_outputs = ((PyObject*)values[22]);
-    __pyx_v_outer_output_dtypes = ((PyObject*)values[23]);
-    __pyx_v_outer_output_ndims = ((PyObject*)values[24]);
-    __pyx_v_fn = values[25];
+    __pyx_v_destroy_map = ((PyArrayObject *)values[18]);
+    __pyx_v_outer_inputs = ((PyObject*)values[19]);
+    __pyx_v_outer_outputs = ((PyObject*)values[20]);
+    __pyx_v_outer_output_dtypes = ((PyObject*)values[21]);
+    __pyx_v_outer_output_ndims = ((PyObject*)values[22]);
+    __pyx_v_fn = values[23];
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("perform", 1, 26, 26, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 65, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("perform", 1, 24, 24, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 65, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("aesara.scan.scan_perform.perform", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -2527,13 +2482,12 @@ static PyObject *__pyx_pw_6aesara_4scan_12scan_perform_3perform(PyObject *__pyx_
   if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_outs_is_tensor), __pyx_ptype_5numpy_ndarray, 1, "outs_is_tensor", 0))) __PYX_ERR(0, 81, __pyx_L1_error)
   if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_inner_input_storage), (&PyList_Type), 1, "inner_input_storage", 1))) __PYX_ERR(0, 82, __pyx_L1_error)
   if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_inner_output_storage), (&PyList_Type), 1, "inner_output_storage", 1))) __PYX_ERR(0, 83, __pyx_L1_error)
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_inner_input_needs_update), (&PyTuple_Type), 1, "inner_input_needs_update", 1))) __PYX_ERR(0, 85, __pyx_L1_error)
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_destroy_map), __pyx_ptype_5numpy_ndarray, 1, "destroy_map", 0))) __PYX_ERR(0, 86, __pyx_L1_error)
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_outer_inputs), (&PyList_Type), 1, "outer_inputs", 1))) __PYX_ERR(0, 87, __pyx_L1_error)
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_outer_outputs), (&PyList_Type), 1, "outer_outputs", 1))) __PYX_ERR(0, 88, __pyx_L1_error)
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_outer_output_dtypes), (&PyTuple_Type), 1, "outer_output_dtypes", 1))) __PYX_ERR(0, 89, __pyx_L1_error)
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_outer_output_ndims), (&PyTuple_Type), 1, "outer_output_ndims", 1))) __PYX_ERR(0, 90, __pyx_L1_error)
-  __pyx_r = __pyx_pf_6aesara_4scan_12scan_perform_2perform(__pyx_self, __pyx_v_n_shared_outs, __pyx_v_n_mit_mot_outs, __pyx_v_n_seqs, __pyx_v_n_mit_mot, __pyx_v_n_mit_sot, __pyx_v_n_sit_sot, __pyx_v_n_nit_sot, __pyx_v_as_while, __pyx_v_mintaps, __pyx_v_tap_array, __pyx_v_tap_array_len, __pyx_v_vector_seqs, __pyx_v_vector_outs, __pyx_v_mit_mot_out_slices, __pyx_v_mitmots_preallocated, __pyx_v_outs_is_tensor, __pyx_v_inner_input_storage, __pyx_v_inner_output_storage, __pyx_v_need_update_inputs, __pyx_v_inner_input_needs_update, __pyx_v_destroy_map, __pyx_v_outer_inputs, __pyx_v_outer_outputs, __pyx_v_outer_output_dtypes, __pyx_v_outer_output_ndims, __pyx_v_fn);
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_destroy_map), __pyx_ptype_5numpy_ndarray, 1, "destroy_map", 0))) __PYX_ERR(0, 84, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_outer_inputs), (&PyList_Type), 1, "outer_inputs", 1))) __PYX_ERR(0, 85, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_outer_outputs), (&PyList_Type), 1, "outer_outputs", 1))) __PYX_ERR(0, 86, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_outer_output_dtypes), (&PyTuple_Type), 1, "outer_output_dtypes", 1))) __PYX_ERR(0, 87, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_outer_output_ndims), (&PyTuple_Type), 1, "outer_output_ndims", 1))) __PYX_ERR(0, 88, __pyx_L1_error)
+  __pyx_r = __pyx_pf_6aesara_4scan_12scan_perform_2perform(__pyx_self, __pyx_v_n_shared_outs, __pyx_v_n_mit_mot_outs, __pyx_v_n_seqs, __pyx_v_n_mit_mot, __pyx_v_n_mit_sot, __pyx_v_n_sit_sot, __pyx_v_n_nit_sot, __pyx_v_as_while, __pyx_v_mintaps, __pyx_v_tap_array, __pyx_v_tap_array_len, __pyx_v_vector_seqs, __pyx_v_vector_outs, __pyx_v_mit_mot_out_slices, __pyx_v_mitmots_preallocated, __pyx_v_outs_is_tensor, __pyx_v_inner_input_storage, __pyx_v_inner_output_storage, __pyx_v_destroy_map, __pyx_v_outer_inputs, __pyx_v_outer_outputs, __pyx_v_outer_output_dtypes, __pyx_v_outer_output_ndims, __pyx_v_fn);
 
   /* function exit code */
   goto __pyx_L0;
@@ -2544,7 +2498,7 @@ static PyObject *__pyx_pw_6aesara_4scan_12scan_perform_3perform(PyObject *__pyx_
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED PyObject *__pyx_self, unsigned int __pyx_v_n_shared_outs, unsigned int __pyx_v_n_mit_mot_outs, unsigned int __pyx_v_n_seqs, unsigned int __pyx_v_n_mit_mot, unsigned int __pyx_v_n_mit_sot, unsigned int __pyx_v_n_sit_sot, unsigned int __pyx_v_n_nit_sot, int __pyx_v_as_while, PyArrayObject *__pyx_v_mintaps, PyObject *__pyx_v_tap_array, PyObject *__pyx_v_tap_array_len, PyArrayObject *__pyx_v_vector_seqs, PyArrayObject *__pyx_v_vector_outs, PyObject *__pyx_v_mit_mot_out_slices, PyArrayObject *__pyx_v_mitmots_preallocated, PyArrayObject *__pyx_v_outs_is_tensor, PyObject *__pyx_v_inner_input_storage, PyObject *__pyx_v_inner_output_storage, int __pyx_v_need_update_inputs, PyObject *__pyx_v_inner_input_needs_update, PyArrayObject *__pyx_v_destroy_map, PyObject *__pyx_v_outer_inputs, PyObject *__pyx_v_outer_outputs, PyObject *__pyx_v_outer_output_dtypes, PyObject *__pyx_v_outer_output_ndims, PyObject *__pyx_v_fn) {
+static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED PyObject *__pyx_self, unsigned int __pyx_v_n_shared_outs, unsigned int __pyx_v_n_mit_mot_outs, unsigned int __pyx_v_n_seqs, unsigned int __pyx_v_n_mit_mot, unsigned int __pyx_v_n_mit_sot, unsigned int __pyx_v_n_sit_sot, unsigned int __pyx_v_n_nit_sot, int __pyx_v_as_while, PyArrayObject *__pyx_v_mintaps, PyObject *__pyx_v_tap_array, PyObject *__pyx_v_tap_array_len, PyArrayObject *__pyx_v_vector_seqs, PyArrayObject *__pyx_v_vector_outs, PyObject *__pyx_v_mit_mot_out_slices, PyArrayObject *__pyx_v_mitmots_preallocated, PyArrayObject *__pyx_v_outs_is_tensor, PyObject *__pyx_v_inner_input_storage, PyObject *__pyx_v_inner_output_storage, PyArrayObject *__pyx_v_destroy_map, PyObject *__pyx_v_outer_inputs, PyObject *__pyx_v_outer_outputs, PyObject *__pyx_v_outer_output_dtypes, PyObject *__pyx_v_outer_output_ndims, PyObject *__pyx_v_fn) {
   unsigned int __pyx_v_t_fn;
   unsigned int __pyx_v_n_steps;
   unsigned int __pyx_v_n_outs;
@@ -2582,11 +2536,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   PyObject *__pyx_v_t0_fn = NULL;
   PyObject *__pyx_v_exc = NULL;
   PyObject *__pyx_v_dt_fn = NULL;
-  PyObject *__pyx_v_needs_update = NULL;
-  PyObject *__pyx_v_storage = NULL;
   PyObject *__pyx_v_mitmot_inp_offset = NULL;
   PyObject *__pyx_v_mitmot_out_idx = NULL;
   PyObject *__pyx_v_inp_idx = NULL;
+  PyObject *__pyx_v_inner_inp_idx = NULL;
   PyObject *__pyx_v_old_var = NULL;
   PyObject *__pyx_v_new_var = NULL;
   PyObject *__pyx_v_old_data = NULL;
@@ -2647,8 +2600,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   PyObject *__pyx_t_33 = NULL;
   PyObject *__pyx_t_34 = NULL;
   PyObject *__pyx_t_35 = NULL;
-  PyObject *(*__pyx_t_36)(PyObject *);
-  char const *__pyx_t_37;
+  char const *__pyx_t_36;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
@@ -2708,7 +2660,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   }
   __pyx_pybuffernd_destroy_map.diminfo[0].strides = __pyx_pybuffernd_destroy_map.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_destroy_map.diminfo[0].shape = __pyx_pybuffernd_destroy_map.rcbuffer->pybuffer.shape[0];
 
-  /* "aesara/scan/scan_perform.pyx":166
+  /* "aesara/scan/scan_perform.pyx":160
  *     # 1. Unzip the number of steps and sequences. If number of steps is
  *     # negative flip sequences around, and make n_steps positive
  *     cdef unsigned int t_fn = 0             # <<<<<<<<<<<<<<
@@ -2717,7 +2669,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_t_fn = 0;
 
-  /* "aesara/scan/scan_perform.pyx":167
+  /* "aesara/scan/scan_perform.pyx":161
  *     # negative flip sequences around, and make n_steps positive
  *     cdef unsigned int t_fn = 0
  *     cdef unsigned int n_steps = outer_inputs[0].item()             # <<<<<<<<<<<<<<
@@ -2726,9 +2678,9 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   if (unlikely(__pyx_v_outer_inputs == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 167, __pyx_L1_error)
+    __PYX_ERR(0, 161, __pyx_L1_error)
   }
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(PyList_GET_ITEM(__pyx_v_outer_inputs, 0), __pyx_n_s_item); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 167, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(PyList_GET_ITEM(__pyx_v_outer_inputs, 0), __pyx_n_s_item); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 161, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_3 = NULL;
   if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_2))) {
@@ -2742,14 +2694,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   }
   __pyx_t_1 = (__pyx_t_3) ? __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_3) : __Pyx_PyObject_CallNoArg(__pyx_t_2);
   __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 167, __pyx_L1_error)
+  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 161, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_4 = __Pyx_PyInt_As_unsigned_int(__pyx_t_1); if (unlikely((__pyx_t_4 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 167, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_As_unsigned_int(__pyx_t_1); if (unlikely((__pyx_t_4 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 161, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_n_steps = __pyx_t_4;
 
-  /* "aesara/scan/scan_perform.pyx":168
+  /* "aesara/scan/scan_perform.pyx":162
  *     cdef unsigned int t_fn = 0
  *     cdef unsigned int n_steps = outer_inputs[0].item()
  *     cdef unsigned int n_outs = n_mit_mot + n_mit_sot + n_sit_sot             # <<<<<<<<<<<<<<
@@ -2758,7 +2710,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_n_outs = ((__pyx_v_n_mit_mot + __pyx_v_n_mit_sot) + __pyx_v_n_sit_sot);
 
-  /* "aesara/scan/scan_perform.pyx":169
+  /* "aesara/scan/scan_perform.pyx":163
  *     cdef unsigned int n_steps = outer_inputs[0].item()
  *     cdef unsigned int n_outs = n_mit_mot + n_mit_sot + n_sit_sot
  *     cdef unsigned int seqs_arg_offset = n_seqs + 1             # <<<<<<<<<<<<<<
@@ -2767,7 +2719,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_seqs_arg_offset = (__pyx_v_n_seqs + 1);
 
-  /* "aesara/scan/scan_perform.pyx":171
+  /* "aesara/scan/scan_perform.pyx":165
  *     cdef unsigned int seqs_arg_offset = n_seqs + 1
  *     cdef unsigned int shared_arg_offset = ( 1 + n_seqs + n_mit_mot +
  *                                            n_mit_sot + n_sit_sot)             # <<<<<<<<<<<<<<
@@ -2776,7 +2728,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_shared_arg_offset = ((((1 + __pyx_v_n_seqs) + __pyx_v_n_mit_mot) + __pyx_v_n_mit_sot) + __pyx_v_n_sit_sot);
 
-  /* "aesara/scan/scan_perform.pyx":172
+  /* "aesara/scan/scan_perform.pyx":166
  *     cdef unsigned int shared_arg_offset = ( 1 + n_seqs + n_mit_mot +
  *                                            n_mit_sot + n_sit_sot)
  *     cdef unsigned int nit_sot_arg_offset = ( shared_arg_offset +             # <<<<<<<<<<<<<<
@@ -2785,25 +2737,25 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_nit_sot_arg_offset = (__pyx_v_shared_arg_offset + __pyx_v_n_shared_outs);
 
-  /* "aesara/scan/scan_perform.pyx":175
+  /* "aesara/scan/scan_perform.pyx":169
  *                                             n_shared_outs)
  *     cdef unsigned int offset_out
  *     cdef unsigned int lenpos = n_outs + n_nit_sot             # <<<<<<<<<<<<<<
- *     cdef int pos[500] # put a maximum of 500 outputs
- *     cdef unsigned int len_store_steps = n_mit_mot + n_mit_sot + n_sit_sot + n_nit_sot
+ *     # TODO: See how this is being converted and whether or not we can remove
+ *     # fixed allocations caused by this.
  */
   __pyx_v_lenpos = (__pyx_v_n_outs + __pyx_v_n_nit_sot);
 
-  /* "aesara/scan/scan_perform.pyx":177
- *     cdef unsigned int lenpos = n_outs + n_nit_sot
+  /* "aesara/scan/scan_perform.pyx":173
+ *     # fixed allocations caused by this.
  *     cdef int pos[500] # put a maximum of 500 outputs
  *     cdef unsigned int len_store_steps = n_mit_mot + n_mit_sot + n_sit_sot + n_nit_sot             # <<<<<<<<<<<<<<
- *     cdef int store_steps[500]
- *     cdef unsigned int l
+ *     # The length of each output
+ *     # TODO: See how this is being converted and whether or not we can remove
  */
   __pyx_v_len_store_steps = (((__pyx_v_n_mit_mot + __pyx_v_n_mit_sot) + __pyx_v_n_sit_sot) + __pyx_v_n_nit_sot);
 
-  /* "aesara/scan/scan_perform.pyx":197
+  /* "aesara/scan/scan_perform.pyx":196
  *     cdef int cond
  *     cdef unsigned int len_output_storage = (n_mit_mot_outs + n_mit_sot +
  *                                             n_sit_sot + n_nit_sot +             # <<<<<<<<<<<<<<
@@ -2812,7 +2764,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_len_output_storage = ((((__pyx_v_n_mit_mot_outs + __pyx_v_n_mit_sot) + __pyx_v_n_sit_sot) + __pyx_v_n_nit_sot) + __pyx_v_n_shared_outs);
 
-  /* "aesara/scan/scan_perform.pyx":200
+  /* "aesara/scan/scan_perform.pyx":199
  *                                             n_shared_outs)
  * 
  *     if n_steps < 0:             # <<<<<<<<<<<<<<
@@ -2822,42 +2774,42 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __pyx_t_5 = ((__pyx_v_n_steps < 0) != 0);
   if (unlikely(__pyx_t_5)) {
 
-    /* "aesara/scan/scan_perform.pyx":205
+    /* "aesara/scan/scan_perform.pyx":204
  *         raise IndexError(
  *             "Scan was asked to run for negative number of step %d" %
  *             n_steps)             # <<<<<<<<<<<<<<
  *     else:
  *         for idx in range(n_seqs):
  */
-    __pyx_t_1 = __Pyx_PyInt_From_unsigned_int(__pyx_v_n_steps); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 205, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyInt_From_unsigned_int(__pyx_v_n_steps); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 204, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
 
-    /* "aesara/scan/scan_perform.pyx":204
+    /* "aesara/scan/scan_perform.pyx":203
  *         # scan. Now we reverse the inputs outside of scan.
  *         raise IndexError(
  *             "Scan was asked to run for negative number of step %d" %             # <<<<<<<<<<<<<<
  *             n_steps)
  *     else:
  */
-    __pyx_t_2 = PyUnicode_Format(__pyx_kp_u_Scan_was_asked_to_run_for_negati, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 204, __pyx_L1_error)
+    __pyx_t_2 = PyUnicode_Format(__pyx_kp_u_Scan_was_asked_to_run_for_negati, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 203, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "aesara/scan/scan_perform.pyx":203
+    /* "aesara/scan/scan_perform.pyx":202
  *         # History, in the past, this was used for backward
  *         # scan. Now we reverse the inputs outside of scan.
  *         raise IndexError(             # <<<<<<<<<<<<<<
  *             "Scan was asked to run for negative number of step %d" %
  *             n_steps)
  */
-    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_builtin_IndexError, __pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 203, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_builtin_IndexError, __pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 202, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_Raise(__pyx_t_1, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __PYX_ERR(0, 203, __pyx_L1_error)
+    __PYX_ERR(0, 202, __pyx_L1_error)
 
-    /* "aesara/scan/scan_perform.pyx":200
+    /* "aesara/scan/scan_perform.pyx":199
  *                                             n_shared_outs)
  * 
  *     if n_steps < 0:             # <<<<<<<<<<<<<<
@@ -2866,7 +2818,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   }
 
-  /* "aesara/scan/scan_perform.pyx":207
+  /* "aesara/scan/scan_perform.pyx":206
  *             n_steps)
  *     else:
  *         for idx in range(n_seqs):             # <<<<<<<<<<<<<<
@@ -2879,7 +2831,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":208
+      /* "aesara/scan/scan_perform.pyx":207
  *     else:
  *         for idx in range(n_seqs):
  *             if outer_inputs[<unsigned int>(1+idx)].shape[0] < n_steps:             # <<<<<<<<<<<<<<
@@ -2888,31 +2840,31 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       if (unlikely(__pyx_v_outer_inputs == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 208, __pyx_L1_error)
+        __PYX_ERR(0, 207, __pyx_L1_error)
       }
       __pyx_t_8 = ((unsigned int)(1 + __pyx_v_idx));
-      __pyx_t_1 = __Pyx_PyObject_GetAttrStr(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), __pyx_n_s_shape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 208, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyObject_GetAttrStr(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), __pyx_n_s_shape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 207, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_1, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 208, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_1, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 207, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-      __pyx_t_1 = __Pyx_PyInt_From_unsigned_int(__pyx_v_n_steps); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 208, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyInt_From_unsigned_int(__pyx_v_n_steps); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 207, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_3 = PyObject_RichCompare(__pyx_t_2, __pyx_t_1, Py_LT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 208, __pyx_L1_error)
+      __pyx_t_3 = PyObject_RichCompare(__pyx_t_2, __pyx_t_1, Py_LT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 207, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-      __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 208, __pyx_L1_error)
+      __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 207, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       if (unlikely(__pyx_t_5)) {
 
-        /* "aesara/scan/scan_perform.pyx":210
+        /* "aesara/scan/scan_perform.pyx":209
  *             if outer_inputs[<unsigned int>(1+idx)].shape[0] < n_steps:
  *                 raise ValueError((
  *                     "Sequence %s has shape %s "             # <<<<<<<<<<<<<<
  *                     "but the Scan's required number of steps is %s"
  *                 ) % (
  */
-        __pyx_t_3 = PyTuple_New(6); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 210, __pyx_L1_error)
+        __pyx_t_3 = PyTuple_New(6); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 209, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __pyx_t_9 = 0;
         __pyx_t_10 = 127;
@@ -2921,14 +2873,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __Pyx_GIVEREF(__pyx_kp_u_Sequence);
         PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_kp_u_Sequence);
 
-        /* "aesara/scan/scan_perform.pyx":213
+        /* "aesara/scan/scan_perform.pyx":212
  *                     "but the Scan's required number of steps is %s"
  *                 ) % (
  *                     idx,             # <<<<<<<<<<<<<<
  *                     outer_inputs[1+idx].shape,
  *                     n_steps,
  */
-        __pyx_t_1 = __Pyx_PyUnicode_From_unsigned_int(__pyx_v_idx, 0, ' ', 'd'); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 213, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyUnicode_From_unsigned_int(__pyx_v_idx, 0, ' ', 'd'); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 212, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __pyx_t_9 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_1);
         __Pyx_GIVEREF(__pyx_t_1);
@@ -2939,7 +2891,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __Pyx_GIVEREF(__pyx_kp_u_has_shape);
         PyTuple_SET_ITEM(__pyx_t_3, 2, __pyx_kp_u_has_shape);
 
-        /* "aesara/scan/scan_perform.pyx":214
+        /* "aesara/scan/scan_perform.pyx":213
  *                 ) % (
  *                     idx,
  *                     outer_inputs[1+idx].shape,             # <<<<<<<<<<<<<<
@@ -2948,15 +2900,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_inputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 214, __pyx_L1_error)
+          __PYX_ERR(0, 213, __pyx_L1_error)
         }
         __pyx_t_11 = (1 + __pyx_v_idx);
-        __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_outer_inputs, __pyx_t_11, long, 1, __Pyx_PyInt_From_long, 1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 214, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_outer_inputs, __pyx_t_11, long, 1, __Pyx_PyInt_From_long, 1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 213, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 214, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 213, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_1 = __Pyx_PyObject_FormatSimpleAndDecref(PyObject_Unicode(__pyx_t_2), __pyx_empty_unicode); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 214, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_FormatSimpleAndDecref(PyObject_Unicode(__pyx_t_2), __pyx_empty_unicode); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 213, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
         __pyx_t_10 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_1) > __pyx_t_10) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_1) : __pyx_t_10;
@@ -2969,46 +2921,46 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __Pyx_GIVEREF(__pyx_kp_u_but_the_Scan_s_required_number);
         PyTuple_SET_ITEM(__pyx_t_3, 4, __pyx_kp_u_but_the_Scan_s_required_number);
 
-        /* "aesara/scan/scan_perform.pyx":215
+        /* "aesara/scan/scan_perform.pyx":214
  *                     idx,
  *                     outer_inputs[1+idx].shape,
  *                     n_steps,             # <<<<<<<<<<<<<<
  *                 ))
- *     # 2. Allocate memory for the outputs. Construct the list:
+ * 
  */
-        __pyx_t_1 = __Pyx_PyUnicode_From_unsigned_int(__pyx_v_n_steps, 0, ' ', 'd'); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 215, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyUnicode_From_unsigned_int(__pyx_v_n_steps, 0, ' ', 'd'); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 214, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __pyx_t_9 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_1);
         __Pyx_GIVEREF(__pyx_t_1);
         PyTuple_SET_ITEM(__pyx_t_3, 5, __pyx_t_1);
         __pyx_t_1 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":210
+        /* "aesara/scan/scan_perform.pyx":209
  *             if outer_inputs[<unsigned int>(1+idx)].shape[0] < n_steps:
  *                 raise ValueError((
  *                     "Sequence %s has shape %s "             # <<<<<<<<<<<<<<
  *                     "but the Scan's required number of steps is %s"
  *                 ) % (
  */
-        __pyx_t_1 = __Pyx_PyUnicode_Join(__pyx_t_3, 6, __pyx_t_9, __pyx_t_10); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 210, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyUnicode_Join(__pyx_t_3, 6, __pyx_t_9, __pyx_t_10); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 209, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":209
+        /* "aesara/scan/scan_perform.pyx":208
  *         for idx in range(n_seqs):
  *             if outer_inputs[<unsigned int>(1+idx)].shape[0] < n_steps:
  *                 raise ValueError((             # <<<<<<<<<<<<<<
  *                     "Sequence %s has shape %s "
  *                     "but the Scan's required number of steps is %s"
  */
-        __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_builtin_ValueError, __pyx_t_1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 209, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_builtin_ValueError, __pyx_t_1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 208, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __Pyx_Raise(__pyx_t_3, 0, 0, 0);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-        __PYX_ERR(0, 209, __pyx_L1_error)
+        __PYX_ERR(0, 208, __pyx_L1_error)
 
-        /* "aesara/scan/scan_perform.pyx":208
+        /* "aesara/scan/scan_perform.pyx":207
  *     else:
  *         for idx in range(n_seqs):
  *             if outer_inputs[<unsigned int>(1+idx)].shape[0] < n_steps:             # <<<<<<<<<<<<<<
@@ -3019,8 +2971,8 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     }
   }
 
-  /* "aesara/scan/scan_perform.pyx":221
- *     #       pos          -- map containing the current position of each output
+  /* "aesara/scan/scan_perform.pyx":219
+ *     # 2. Allocate memory for the outputs. Construct the list:
  * 
  *     for idx in range(n_mit_mot + n_mit_sot + n_sit_sot):             # <<<<<<<<<<<<<<
  *         store_steps[<unsigned int>idx] = outer_inputs[<unsigned int>(idx+n_seqs+1)].shape[0]
@@ -3031,7 +2983,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
     __pyx_v_idx = __pyx_t_7;
 
-    /* "aesara/scan/scan_perform.pyx":222
+    /* "aesara/scan/scan_perform.pyx":220
  * 
  *     for idx in range(n_mit_mot + n_mit_sot + n_sit_sot):
  *         store_steps[<unsigned int>idx] = outer_inputs[<unsigned int>(idx+n_seqs+1)].shape[0]             # <<<<<<<<<<<<<<
@@ -3040,20 +2992,20 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     if (unlikely(__pyx_v_outer_inputs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 222, __pyx_L1_error)
+      __PYX_ERR(0, 220, __pyx_L1_error)
     }
     __pyx_t_8 = ((unsigned int)((__pyx_v_idx + __pyx_v_n_seqs) + 1));
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), __pyx_n_s_shape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 222, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), __pyx_n_s_shape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 220, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 222, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 220, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __pyx_t_12 = __Pyx_PyInt_As_int(__pyx_t_1); if (unlikely((__pyx_t_12 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 222, __pyx_L1_error)
+    __pyx_t_12 = __Pyx_PyInt_As_int(__pyx_t_1); if (unlikely((__pyx_t_12 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 220, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     (__pyx_v_store_steps[((unsigned int)__pyx_v_idx)]) = __pyx_t_12;
   }
 
-  /* "aesara/scan/scan_perform.pyx":224
+  /* "aesara/scan/scan_perform.pyx":222
  *         store_steps[<unsigned int>idx] = outer_inputs[<unsigned int>(idx+n_seqs+1)].shape[0]
  * 
  *     for idx in range(n_nit_sot):             # <<<<<<<<<<<<<<
@@ -3065,7 +3017,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
     __pyx_v_idx = __pyx_t_7;
 
-    /* "aesara/scan/scan_perform.pyx":226
+    /* "aesara/scan/scan_perform.pyx":224
  *     for idx in range(n_nit_sot):
  *         store_steps[<unsigned int>(idx + n_mit_mot + n_mit_sot + n_sit_sot)]=\
  *                 outer_inputs[<unsigned int>(idx + n_mit_mot + n_mit_sot + n_sit_sot             # <<<<<<<<<<<<<<
@@ -3074,10 +3026,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     if (unlikely(__pyx_v_outer_inputs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 226, __pyx_L1_error)
+      __PYX_ERR(0, 224, __pyx_L1_error)
     }
 
-    /* "aesara/scan/scan_perform.pyx":227
+    /* "aesara/scan/scan_perform.pyx":225
  *         store_steps[<unsigned int>(idx + n_mit_mot + n_mit_sot + n_sit_sot)]=\
  *                 outer_inputs[<unsigned int>(idx + n_mit_mot + n_mit_sot + n_sit_sot
  *                                     + n_shared_outs + n_seqs+1)]             # <<<<<<<<<<<<<<
@@ -3086,16 +3038,16 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_t_8 = ((unsigned int)((((((__pyx_v_idx + __pyx_v_n_mit_mot) + __pyx_v_n_mit_sot) + __pyx_v_n_sit_sot) + __pyx_v_n_shared_outs) + __pyx_v_n_seqs) + 1));
 
-    /* "aesara/scan/scan_perform.pyx":226
+    /* "aesara/scan/scan_perform.pyx":224
  *     for idx in range(n_nit_sot):
  *         store_steps[<unsigned int>(idx + n_mit_mot + n_mit_sot + n_sit_sot)]=\
  *                 outer_inputs[<unsigned int>(idx + n_mit_mot + n_mit_sot + n_sit_sot             # <<<<<<<<<<<<<<
  *                                     + n_shared_outs + n_seqs+1)]
  * 
  */
-    __pyx_t_12 = __Pyx_PyInt_As_int(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8)); if (unlikely((__pyx_t_12 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 226, __pyx_L1_error)
+    __pyx_t_12 = __Pyx_PyInt_As_int(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8)); if (unlikely((__pyx_t_12 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 224, __pyx_L1_error)
 
-    /* "aesara/scan/scan_perform.pyx":225
+    /* "aesara/scan/scan_perform.pyx":223
  * 
  *     for idx in range(n_nit_sot):
  *         store_steps[<unsigned int>(idx + n_mit_mot + n_mit_sot + n_sit_sot)]=\             # <<<<<<<<<<<<<<
@@ -3105,7 +3057,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     (__pyx_v_store_steps[((unsigned int)(((__pyx_v_idx + __pyx_v_n_mit_mot) + __pyx_v_n_mit_sot) + __pyx_v_n_sit_sot))]) = __pyx_t_12;
   }
 
-  /* "aesara/scan/scan_perform.pyx":230
+  /* "aesara/scan/scan_perform.pyx":228
  * 
  *     # 2.1 Create storage space for outputs
  *     for idx in range(n_outs):             # <<<<<<<<<<<<<<
@@ -3117,7 +3069,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
     __pyx_v_idx = __pyx_t_7;
 
-    /* "aesara/scan/scan_perform.pyx":231
+    /* "aesara/scan/scan_perform.pyx":229
  *     # 2.1 Create storage space for outputs
  *     for idx in range(n_outs):
  *         if destroy_map[idx] != 0:             # <<<<<<<<<<<<<<
@@ -3128,7 +3080,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_5 = (((*__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_destroy_map.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_destroy_map.diminfo[0].strides)) != 0) != 0);
     if (__pyx_t_5) {
 
-      /* "aesara/scan/scan_perform.pyx":234
+      /* "aesara/scan/scan_perform.pyx":232
  *             # ^ Case 1. Outputs should be computed inplace of their
  *             # initial state
  *             outer_outputs[idx][0] = outer_inputs[ <unsigned int>(1+ n_seqs + idx)]             # <<<<<<<<<<<<<<
@@ -3137,19 +3089,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       if (unlikely(__pyx_v_outer_inputs == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 234, __pyx_L1_error)
+        __PYX_ERR(0, 232, __pyx_L1_error)
       }
       __pyx_t_8 = ((unsigned int)((1 + __pyx_v_n_seqs) + __pyx_v_idx));
       __pyx_t_1 = PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8);
       __Pyx_INCREF(__pyx_t_1);
       if (unlikely(__pyx_v_outer_outputs == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 234, __pyx_L1_error)
+        __PYX_ERR(0, 232, __pyx_L1_error)
       }
-      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, __pyx_t_1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 234, __pyx_L1_error)
+      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, __pyx_t_1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 232, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":231
+      /* "aesara/scan/scan_perform.pyx":229
  *     # 2.1 Create storage space for outputs
  *     for idx in range(n_outs):
  *         if destroy_map[idx] != 0:             # <<<<<<<<<<<<<<
@@ -3159,7 +3111,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       goto __pyx_L13;
     }
 
-    /* "aesara/scan/scan_perform.pyx":235
+    /* "aesara/scan/scan_perform.pyx":233
  *             # initial state
  *             outer_outputs[idx][0] = outer_inputs[ <unsigned int>(1+ n_seqs + idx)]
  *         elif ( outer_outputs[idx][0] is not None and             # <<<<<<<<<<<<<<
@@ -3168,9 +3120,9 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     if (unlikely(__pyx_v_outer_outputs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 235, __pyx_L1_error)
+      __PYX_ERR(0, 233, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 233, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_t_14 = (__pyx_t_1 != Py_None);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
@@ -3181,7 +3133,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       goto __pyx_L14_bool_binop_done;
     }
 
-    /* "aesara/scan/scan_perform.pyx":236
+    /* "aesara/scan/scan_perform.pyx":234
  *             outer_outputs[idx][0] = outer_inputs[ <unsigned int>(1+ n_seqs + idx)]
  *         elif ( outer_outputs[idx][0] is not None and
  *               outer_outputs[idx][0].shape[1:] == outer_inputs[<unsigned int>(1+ n_seqs + idx)].shape[1:]             # <<<<<<<<<<<<<<
@@ -3190,30 +3142,30 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     if (unlikely(__pyx_v_outer_outputs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 236, __pyx_L1_error)
+      __PYX_ERR(0, 234, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 236, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 234, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_shape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 236, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_shape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 234, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_t_3, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 236, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_t_3, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 234, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     if (unlikely(__pyx_v_outer_inputs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 236, __pyx_L1_error)
+      __PYX_ERR(0, 234, __pyx_L1_error)
     }
     __pyx_t_8 = ((unsigned int)((1 + __pyx_v_n_seqs) + __pyx_v_idx));
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), __pyx_n_s_shape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 236, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), __pyx_n_s_shape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 234, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_t_3, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 236, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_t_3, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 234, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __pyx_t_3 = PyObject_RichCompare(__pyx_t_1, __pyx_t_2, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 236, __pyx_L1_error)
+    __pyx_t_3 = PyObject_RichCompare(__pyx_t_1, __pyx_t_2, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 234, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 236, __pyx_L1_error)
+    __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 234, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     if (__pyx_t_15) {
     } else {
@@ -3221,7 +3173,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       goto __pyx_L14_bool_binop_done;
     }
 
-    /* "aesara/scan/scan_perform.pyx":237
+    /* "aesara/scan/scan_perform.pyx":235
  *         elif ( outer_outputs[idx][0] is not None and
  *               outer_outputs[idx][0].shape[1:] == outer_inputs[<unsigned int>(1+ n_seqs + idx)].shape[1:]
  *               and outer_outputs[idx][0].shape[0] >= store_steps[idx] ):             # <<<<<<<<<<<<<<
@@ -3230,27 +3182,27 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     if (unlikely(__pyx_v_outer_outputs == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 237, __pyx_L1_error)
+      __PYX_ERR(0, 235, __pyx_L1_error)
     }
-    __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 237, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 235, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 237, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_2, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 237, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_2, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 235, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    __pyx_t_2 = __Pyx_PyInt_From_int((__pyx_v_store_steps[__pyx_v_idx])); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 237, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyInt_From_int((__pyx_v_store_steps[__pyx_v_idx])); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 235, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_1 = PyObject_RichCompare(__pyx_t_3, __pyx_t_2, Py_GE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 237, __pyx_L1_error)
+    __pyx_t_1 = PyObject_RichCompare(__pyx_t_3, __pyx_t_2, Py_GE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 235, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 237, __pyx_L1_error)
+    __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 235, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_5 = __pyx_t_15;
     __pyx_L14_bool_binop_done:;
 
-    /* "aesara/scan/scan_perform.pyx":235
+    /* "aesara/scan/scan_perform.pyx":233
  *             # initial state
  *             outer_outputs[idx][0] = outer_inputs[ <unsigned int>(1+ n_seqs + idx)]
  *         elif ( outer_outputs[idx][0] is not None and             # <<<<<<<<<<<<<<
@@ -3259,7 +3211,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     if (__pyx_t_5) {
 
-      /* "aesara/scan/scan_perform.pyx":239
+      /* "aesara/scan/scan_perform.pyx":237
  *               and outer_outputs[idx][0].shape[0] >= store_steps[idx] ):
  *             # Put in the values of the initial state
  *             outer_outputs[idx][0] = outer_outputs[idx][0][:store_steps[idx]]             # <<<<<<<<<<<<<<
@@ -3268,21 +3220,21 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       if (unlikely(__pyx_v_outer_outputs == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 239, __pyx_L1_error)
+        __PYX_ERR(0, 237, __pyx_L1_error)
       }
-      __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 239, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 237, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_t_1, 0, (__pyx_v_store_steps[__pyx_v_idx]), NULL, NULL, NULL, 0, 1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 239, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_t_1, 0, (__pyx_v_store_steps[__pyx_v_idx]), NULL, NULL, NULL, 0, 1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 237, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       if (unlikely(__pyx_v_outer_outputs == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 239, __pyx_L1_error)
+        __PYX_ERR(0, 237, __pyx_L1_error)
       }
-      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 239, __pyx_L1_error)
+      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 237, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":240
+      /* "aesara/scan/scan_perform.pyx":238
  *             # Put in the values of the initial state
  *             outer_outputs[idx][0] = outer_outputs[idx][0][:store_steps[idx]]
  *             if idx > n_mit_mot:             # <<<<<<<<<<<<<<
@@ -3292,7 +3244,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_5 = ((__pyx_v_idx > __pyx_v_n_mit_mot) != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":241
+        /* "aesara/scan/scan_perform.pyx":239
  *             outer_outputs[idx][0] = outer_outputs[idx][0][:store_steps[idx]]
  *             if idx > n_mit_mot:
  *                 l = - mintaps[idx]             # <<<<<<<<<<<<<<
@@ -3302,7 +3254,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_t_13 = __pyx_v_idx;
         __pyx_v_l = (-(*__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_mintaps.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_mintaps.diminfo[0].strides)));
 
-        /* "aesara/scan/scan_perform.pyx":242
+        /* "aesara/scan/scan_perform.pyx":240
  *             if idx > n_mit_mot:
  *                 l = - mintaps[idx]
  *                 outer_outputs[idx][0][:l] = outer_inputs[<unsigned int>(seqs_arg_offset +             # <<<<<<<<<<<<<<
@@ -3311,10 +3263,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_inputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 242, __pyx_L1_error)
+          __PYX_ERR(0, 240, __pyx_L1_error)
         }
 
-        /* "aesara/scan/scan_perform.pyx":243
+        /* "aesara/scan/scan_perform.pyx":241
  *                 l = - mintaps[idx]
  *                 outer_outputs[idx][0][:l] = outer_inputs[<unsigned int>(seqs_arg_offset +
  *                                                        idx)][:l]             # <<<<<<<<<<<<<<
@@ -3323,26 +3275,26 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         __pyx_t_8 = ((unsigned int)(__pyx_v_seqs_arg_offset + __pyx_v_idx));
 
-        /* "aesara/scan/scan_perform.pyx":242
+        /* "aesara/scan/scan_perform.pyx":240
  *             if idx > n_mit_mot:
  *                 l = - mintaps[idx]
  *                 outer_outputs[idx][0][:l] = outer_inputs[<unsigned int>(seqs_arg_offset +             # <<<<<<<<<<<<<<
  *                                                        idx)][:l]
  *             else:
  */
-        __pyx_t_2 = __Pyx_PyObject_GetSlice(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), 0, __pyx_v_l, NULL, NULL, NULL, 0, 1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 243, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_GetSlice(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), 0, __pyx_v_l, NULL, NULL, NULL, 0, 1, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 241, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 242, __pyx_L1_error)
+          __PYX_ERR(0, 240, __pyx_L1_error)
         }
-        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 242, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 240, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        if (__Pyx_PyObject_SetSlice(__pyx_t_1, __pyx_t_2, 0, __pyx_v_l, NULL, NULL, NULL, 0, 1, 1) < 0) __PYX_ERR(0, 242, __pyx_L1_error)
+        if (__Pyx_PyObject_SetSlice(__pyx_t_1, __pyx_t_2, 0, __pyx_v_l, NULL, NULL, NULL, 0, 1, 1) < 0) __PYX_ERR(0, 240, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":240
+        /* "aesara/scan/scan_perform.pyx":238
  *             # Put in the values of the initial state
  *             outer_outputs[idx][0] = outer_outputs[idx][0][:store_steps[idx]]
  *             if idx > n_mit_mot:             # <<<<<<<<<<<<<<
@@ -3352,7 +3304,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L17;
       }
 
-      /* "aesara/scan/scan_perform.pyx":245
+      /* "aesara/scan/scan_perform.pyx":243
  *                                                        idx)][:l]
  *             else:
  *                 outer_outputs[idx][0][:] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)]             # <<<<<<<<<<<<<<
@@ -3362,24 +3314,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       /*else*/ {
         if (unlikely(__pyx_v_outer_inputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 245, __pyx_L1_error)
+          __PYX_ERR(0, 243, __pyx_L1_error)
         }
         __pyx_t_8 = ((unsigned int)(__pyx_v_seqs_arg_offset + __pyx_v_idx));
         __pyx_t_2 = PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8);
         __Pyx_INCREF(__pyx_t_2);
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 245, __pyx_L1_error)
+          __PYX_ERR(0, 243, __pyx_L1_error)
         }
-        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 245, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 243, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        if (__Pyx_PyObject_SetSlice(__pyx_t_1, __pyx_t_2, 0, 0, NULL, NULL, &__pyx_slice__2, 0, 0, 1) < 0) __PYX_ERR(0, 245, __pyx_L1_error)
+        if (__Pyx_PyObject_SetSlice(__pyx_t_1, __pyx_t_2, 0, 0, NULL, NULL, &__pyx_slice__2, 0, 0, 1) < 0) __PYX_ERR(0, 243, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       }
       __pyx_L17:;
 
-      /* "aesara/scan/scan_perform.pyx":235
+      /* "aesara/scan/scan_perform.pyx":233
  *             # initial state
  *             outer_outputs[idx][0] = outer_inputs[ <unsigned int>(1+ n_seqs + idx)]
  *         elif ( outer_outputs[idx][0] is not None and             # <<<<<<<<<<<<<<
@@ -3389,7 +3341,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       goto __pyx_L13;
     }
 
-    /* "aesara/scan/scan_perform.pyx":247
+    /* "aesara/scan/scan_perform.pyx":245
  *                 outer_outputs[idx][0][:] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)]
  *         else:
  *             outer_outputs[idx][0] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)].copy()             # <<<<<<<<<<<<<<
@@ -3399,10 +3351,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     /*else*/ {
       if (unlikely(__pyx_v_outer_inputs == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 247, __pyx_L1_error)
+        __PYX_ERR(0, 245, __pyx_L1_error)
       }
       __pyx_t_8 = ((unsigned int)(__pyx_v_seqs_arg_offset + __pyx_v_idx));
-      __pyx_t_1 = __Pyx_PyObject_GetAttrStr(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), __pyx_n_s_copy); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 247, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyObject_GetAttrStr(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), __pyx_n_s_copy); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 245, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __pyx_t_3 = NULL;
       if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_1))) {
@@ -3416,20 +3368,20 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       }
       __pyx_t_2 = (__pyx_t_3) ? __Pyx_PyObject_CallOneArg(__pyx_t_1, __pyx_t_3) : __Pyx_PyObject_CallNoArg(__pyx_t_1);
       __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
-      if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 247, __pyx_L1_error)
+      if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 245, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       if (unlikely(__pyx_v_outer_outputs == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 247, __pyx_L1_error)
+        __PYX_ERR(0, 245, __pyx_L1_error)
       }
-      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 247, __pyx_L1_error)
+      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 245, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     }
     __pyx_L13:;
   }
 
-  /* "aesara/scan/scan_perform.pyx":249
+  /* "aesara/scan/scan_perform.pyx":247
  *             outer_outputs[idx][0] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)].copy()
  * 
  *     if n_steps == 0:             # <<<<<<<<<<<<<<
@@ -3439,7 +3391,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __pyx_t_5 = ((__pyx_v_n_steps == 0) != 0);
   if (__pyx_t_5) {
 
-    /* "aesara/scan/scan_perform.pyx":250
+    /* "aesara/scan/scan_perform.pyx":248
  * 
  *     if n_steps == 0:
  *         for idx in range(n_outs, n_outs + n_nit_sot):             # <<<<<<<<<<<<<<
@@ -3451,7 +3403,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = __pyx_v_n_outs; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":251
+      /* "aesara/scan/scan_perform.pyx":249
  *     if n_steps == 0:
  *         for idx in range(n_outs, n_outs + n_nit_sot):
  *             if outs_is_tensor[idx]:             # <<<<<<<<<<<<<<
@@ -3462,49 +3414,49 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_5 = ((*__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_outs_is_tensor.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_outs_is_tensor.diminfo[0].strides)) != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":257
+        /* "aesara/scan/scan_perform.pyx":255
  *                 # access, because it's not going to produce a very efficient
  *                 # Cython function!)
  *                 outer_outputs[idx][0] = numpy.empty((0,) * outer_output_ndims[idx], dtype=outer_output_dtypes[idx])             # <<<<<<<<<<<<<<
  *             else:
  *                 outer_outputs[idx][0] = None
  */
-        __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 257, __pyx_L1_error)
+        __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_numpy); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 255, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_empty); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 257, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_empty); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 255, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
         if (unlikely(__pyx_v_outer_output_ndims == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 257, __pyx_L1_error)
+          __PYX_ERR(0, 255, __pyx_L1_error)
         }
-        __pyx_t_2 = PyNumber_Multiply(__pyx_tuple__3, PyTuple_GET_ITEM(__pyx_v_outer_output_ndims, __pyx_v_idx)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 257, __pyx_L1_error)
+        __pyx_t_2 = PyNumber_Multiply(__pyx_tuple__3, PyTuple_GET_ITEM(__pyx_v_outer_output_ndims, __pyx_v_idx)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 255, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 257, __pyx_L1_error)
+        __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 255, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_GIVEREF(__pyx_t_2);
         PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_2);
         __pyx_t_2 = 0;
-        __pyx_t_2 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 257, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 255, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
         if (unlikely(__pyx_v_outer_output_dtypes == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 257, __pyx_L1_error)
+          __PYX_ERR(0, 255, __pyx_L1_error)
         }
-        if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_dtype, PyTuple_GET_ITEM(__pyx_v_outer_output_dtypes, __pyx_v_idx)) < 0) __PYX_ERR(0, 257, __pyx_L1_error)
-        __pyx_t_16 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 257, __pyx_L1_error)
+        if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_dtype, PyTuple_GET_ITEM(__pyx_v_outer_output_dtypes, __pyx_v_idx)) < 0) __PYX_ERR(0, 255, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 255, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 257, __pyx_L1_error)
+          __PYX_ERR(0, 255, __pyx_L1_error)
         }
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 257, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 255, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":251
+        /* "aesara/scan/scan_perform.pyx":249
  *     if n_steps == 0:
  *         for idx in range(n_outs, n_outs + n_nit_sot):
  *             if outs_is_tensor[idx]:             # <<<<<<<<<<<<<<
@@ -3514,7 +3466,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L21;
       }
 
-      /* "aesara/scan/scan_perform.pyx":259
+      /* "aesara/scan/scan_perform.pyx":257
  *                 outer_outputs[idx][0] = numpy.empty((0,) * outer_output_ndims[idx], dtype=outer_output_dtypes[idx])
  *             else:
  *                 outer_outputs[idx][0] = None             # <<<<<<<<<<<<<<
@@ -3524,14 +3476,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       /*else*/ {
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 259, __pyx_L1_error)
+          __PYX_ERR(0, 257, __pyx_L1_error)
         }
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 259, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 257, __pyx_L1_error)
       }
       __pyx_L21:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":260
+    /* "aesara/scan/scan_perform.pyx":258
  *             else:
  *                 outer_outputs[idx][0] = None
  *         return 0.0, 0             # <<<<<<<<<<<<<<
@@ -3543,7 +3495,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_r = __pyx_tuple__4;
     goto __pyx_L0;
 
-    /* "aesara/scan/scan_perform.pyx":249
+    /* "aesara/scan/scan_perform.pyx":247
  *             outer_outputs[idx][0] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)].copy()
  * 
  *     if n_steps == 0:             # <<<<<<<<<<<<<<
@@ -3552,7 +3504,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   }
 
-  /* "aesara/scan/scan_perform.pyx":262
+  /* "aesara/scan/scan_perform.pyx":260
  *         return 0.0, 0
  * 
  *     for idx in range(n_outs + n_nit_sot):             # <<<<<<<<<<<<<<
@@ -3564,7 +3516,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
     __pyx_v_idx = __pyx_t_7;
 
-    /* "aesara/scan/scan_perform.pyx":263
+    /* "aesara/scan/scan_perform.pyx":261
  * 
  *     for idx in range(n_outs + n_nit_sot):
  *         pos[idx] = -mintaps[idx] % store_steps[idx]             # <<<<<<<<<<<<<<
@@ -3575,12 +3527,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_17 = (-(*__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_mintaps.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_mintaps.diminfo[0].strides)));
     if (unlikely((__pyx_v_store_steps[__pyx_v_idx]) == 0)) {
       PyErr_SetString(PyExc_ZeroDivisionError, "integer division or modulo by zero");
-      __PYX_ERR(0, 263, __pyx_L1_error)
+      __PYX_ERR(0, 261, __pyx_L1_error)
     }
     (__pyx_v_pos[__pyx_v_idx]) = __Pyx_mod___pyx_t_5numpy_int32_t(__pyx_t_17, (__pyx_v_store_steps[__pyx_v_idx]));
   }
 
-  /* "aesara/scan/scan_perform.pyx":265
+  /* "aesara/scan/scan_perform.pyx":263
  *         pos[idx] = -mintaps[idx] % store_steps[idx]
  * 
  *     offset = nit_sot_arg_offset + n_nit_sot             # <<<<<<<<<<<<<<
@@ -3589,7 +3541,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_offset = (__pyx_v_nit_sot_arg_offset + __pyx_v_n_nit_sot);
 
-  /* "aesara/scan/scan_perform.pyx":266
+  /* "aesara/scan/scan_perform.pyx":264
  * 
  *     offset = nit_sot_arg_offset + n_nit_sot
  *     other_args = outer_inputs[offset:]             # <<<<<<<<<<<<<<
@@ -3598,14 +3550,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   if (unlikely(__pyx_v_outer_inputs == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 266, __pyx_L1_error)
+    __PYX_ERR(0, 264, __pyx_L1_error)
   }
-  __pyx_t_16 = __Pyx_PyList_GetSlice(__pyx_v_outer_inputs, __pyx_v_offset, PY_SSIZE_T_MAX); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 266, __pyx_L1_error)
+  __pyx_t_16 = __Pyx_PyList_GetSlice(__pyx_v_outer_inputs, __pyx_v_offset, PY_SSIZE_T_MAX); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 264, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_16);
   __pyx_v_other_args = ((PyObject*)__pyx_t_16);
   __pyx_t_16 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":268
+  /* "aesara/scan/scan_perform.pyx":266
  *     other_args = outer_inputs[offset:]
  * 
  *     nb_mitmot_in = 0             # <<<<<<<<<<<<<<
@@ -3615,7 +3567,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __Pyx_INCREF(__pyx_int_0);
   __pyx_v_nb_mitmot_in = __pyx_int_0;
 
-  /* "aesara/scan/scan_perform.pyx":269
+  /* "aesara/scan/scan_perform.pyx":267
  * 
  *     nb_mitmot_in = 0
  *     for idx in range(n_mit_mot):             # <<<<<<<<<<<<<<
@@ -3627,7 +3579,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
     __pyx_v_idx = __pyx_t_7;
 
-    /* "aesara/scan/scan_perform.pyx":270
+    /* "aesara/scan/scan_perform.pyx":268
  *     nb_mitmot_in = 0
  *     for idx in range(n_mit_mot):
  *         nb_mitmot_in += tap_array_len[idx]             # <<<<<<<<<<<<<<
@@ -3636,27 +3588,27 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     if (unlikely(__pyx_v_tap_array_len == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 270, __pyx_L1_error)
+      __PYX_ERR(0, 268, __pyx_L1_error)
     }
-    __pyx_t_16 = PyNumber_InPlaceAdd(__pyx_v_nb_mitmot_in, PyTuple_GET_ITEM(__pyx_v_tap_array_len, __pyx_v_idx)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 270, __pyx_L1_error)
+    __pyx_t_16 = PyNumber_InPlaceAdd(__pyx_v_nb_mitmot_in, PyTuple_GET_ITEM(__pyx_v_tap_array_len, __pyx_v_idx)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 268, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
     __Pyx_DECREF_SET(__pyx_v_nb_mitmot_in, __pyx_t_16);
     __pyx_t_16 = 0;
   }
 
-  /* "aesara/scan/scan_perform.pyx":272
+  /* "aesara/scan/scan_perform.pyx":270
  *         nb_mitmot_in += tap_array_len[idx]
  * 
  *     old_mitmot_input_storage = [None] * nb_mitmot_in             # <<<<<<<<<<<<<<
  *     old_mitmot_input_data = [None] * nb_mitmot_in
  *     old_output_storage = [None] * len_output_storage
  */
-  __pyx_t_16 = PyList_New(1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 272, __pyx_L1_error)
+  __pyx_t_16 = PyList_New(1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 270, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_16);
   __Pyx_INCREF(Py_None);
   __Pyx_GIVEREF(Py_None);
   PyList_SET_ITEM(__pyx_t_16, 0, Py_None);
-  { PyObject* __pyx_temp = PyNumber_InPlaceMultiply(__pyx_t_16, __pyx_v_nb_mitmot_in); if (unlikely(!__pyx_temp)) __PYX_ERR(0, 272, __pyx_L1_error)
+  { PyObject* __pyx_temp = PyNumber_InPlaceMultiply(__pyx_t_16, __pyx_v_nb_mitmot_in); if (unlikely(!__pyx_temp)) __PYX_ERR(0, 270, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_temp);
     __Pyx_DECREF(__pyx_t_16);
     __pyx_t_16 = __pyx_temp;
@@ -3664,19 +3616,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __pyx_v_old_mitmot_input_storage = ((PyObject*)__pyx_t_16);
   __pyx_t_16 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":273
+  /* "aesara/scan/scan_perform.pyx":271
  * 
  *     old_mitmot_input_storage = [None] * nb_mitmot_in
  *     old_mitmot_input_data = [None] * nb_mitmot_in             # <<<<<<<<<<<<<<
  *     old_output_storage = [None] * len_output_storage
  *     old_output_data = [None] * len_output_storage
  */
-  __pyx_t_16 = PyList_New(1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 273, __pyx_L1_error)
+  __pyx_t_16 = PyList_New(1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 271, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_16);
   __Pyx_INCREF(Py_None);
   __Pyx_GIVEREF(Py_None);
   PyList_SET_ITEM(__pyx_t_16, 0, Py_None);
-  { PyObject* __pyx_temp = PyNumber_InPlaceMultiply(__pyx_t_16, __pyx_v_nb_mitmot_in); if (unlikely(!__pyx_temp)) __PYX_ERR(0, 273, __pyx_L1_error)
+  { PyObject* __pyx_temp = PyNumber_InPlaceMultiply(__pyx_t_16, __pyx_v_nb_mitmot_in); if (unlikely(!__pyx_temp)) __PYX_ERR(0, 271, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_temp);
     __Pyx_DECREF(__pyx_t_16);
     __pyx_t_16 = __pyx_temp;
@@ -3684,14 +3636,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __pyx_v_old_mitmot_input_data = ((PyObject*)__pyx_t_16);
   __pyx_t_16 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":274
+  /* "aesara/scan/scan_perform.pyx":272
  *     old_mitmot_input_storage = [None] * nb_mitmot_in
  *     old_mitmot_input_data = [None] * nb_mitmot_in
  *     old_output_storage = [None] * len_output_storage             # <<<<<<<<<<<<<<
  *     old_output_data = [None] * len_output_storage
  *     offset = n_seqs
  */
-  __pyx_t_16 = PyList_New(1 * (__pyx_v_len_output_storage)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 274, __pyx_L1_error)
+  __pyx_t_16 = PyList_New(1 * (__pyx_v_len_output_storage)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 272, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_16);
   { Py_ssize_t __pyx_temp;
     for (__pyx_temp=0; __pyx_temp < __pyx_v_len_output_storage; __pyx_temp++) {
@@ -3703,14 +3655,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __pyx_v_old_output_storage = ((PyObject*)__pyx_t_16);
   __pyx_t_16 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":275
+  /* "aesara/scan/scan_perform.pyx":273
  *     old_mitmot_input_data = [None] * nb_mitmot_in
  *     old_output_storage = [None] * len_output_storage
  *     old_output_data = [None] * len_output_storage             # <<<<<<<<<<<<<<
  *     offset = n_seqs
  *     for idx in range(n_outs):
  */
-  __pyx_t_16 = PyList_New(1 * (__pyx_v_len_output_storage)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 275, __pyx_L1_error)
+  __pyx_t_16 = PyList_New(1 * (__pyx_v_len_output_storage)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 273, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_16);
   { Py_ssize_t __pyx_temp;
     for (__pyx_temp=0; __pyx_temp < __pyx_v_len_output_storage; __pyx_temp++) {
@@ -3722,7 +3674,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __pyx_v_old_output_data = ((PyObject*)__pyx_t_16);
   __pyx_t_16 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":276
+  /* "aesara/scan/scan_perform.pyx":274
  *     old_output_storage = [None] * len_output_storage
  *     old_output_data = [None] * len_output_storage
  *     offset = n_seqs             # <<<<<<<<<<<<<<
@@ -3731,7 +3683,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_offset = __pyx_v_n_seqs;
 
-  /* "aesara/scan/scan_perform.pyx":277
+  /* "aesara/scan/scan_perform.pyx":275
  *     old_output_data = [None] * len_output_storage
  *     offset = n_seqs
  *     for idx in range(n_outs):             # <<<<<<<<<<<<<<
@@ -3743,28 +3695,28 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
     __pyx_v_idx = __pyx_t_7;
 
-    /* "aesara/scan/scan_perform.pyx":278
+    /* "aesara/scan/scan_perform.pyx":276
  *     offset = n_seqs
  *     for idx in range(n_outs):
  *         offset += tap_array_len[idx]             # <<<<<<<<<<<<<<
  *     offset += n_shared_outs
  * 
  */
-    __pyx_t_16 = __Pyx_PyInt_From_unsigned_int(__pyx_v_offset); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 278, __pyx_L1_error)
+    __pyx_t_16 = __Pyx_PyInt_From_unsigned_int(__pyx_v_offset); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 276, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
     if (unlikely(__pyx_v_tap_array_len == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 278, __pyx_L1_error)
+      __PYX_ERR(0, 276, __pyx_L1_error)
     }
-    __pyx_t_2 = PyNumber_InPlaceAdd(__pyx_t_16, PyTuple_GET_ITEM(__pyx_v_tap_array_len, __pyx_v_idx)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 278, __pyx_L1_error)
+    __pyx_t_2 = PyNumber_InPlaceAdd(__pyx_t_16, PyTuple_GET_ITEM(__pyx_v_tap_array_len, __pyx_v_idx)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 276, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-    __pyx_t_8 = __Pyx_PyInt_As_unsigned_int(__pyx_t_2); if (unlikely((__pyx_t_8 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 278, __pyx_L1_error)
+    __pyx_t_8 = __Pyx_PyInt_As_unsigned_int(__pyx_t_2); if (unlikely((__pyx_t_8 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 276, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_v_offset = __pyx_t_8;
   }
 
-  /* "aesara/scan/scan_perform.pyx":279
+  /* "aesara/scan/scan_perform.pyx":277
  *     for idx in range(n_outs):
  *         offset += tap_array_len[idx]
  *     offset += n_shared_outs             # <<<<<<<<<<<<<<
@@ -3773,19 +3725,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_offset = (__pyx_v_offset + __pyx_v_n_shared_outs);
 
-  /* "aesara/scan/scan_perform.pyx":281
+  /* "aesara/scan/scan_perform.pyx":279
  *     offset += n_shared_outs
  * 
  *     for idx in range(len(other_args)):             # <<<<<<<<<<<<<<
  *         inner_input_storage[<unsigned int>(idx+offset)][0] = other_args[idx]
  * 
  */
-  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_other_args); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 281, __pyx_L1_error)
+  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_other_args); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 279, __pyx_L1_error)
   __pyx_t_18 = __pyx_t_9;
   for (__pyx_t_4 = 0; __pyx_t_4 < __pyx_t_18; __pyx_t_4+=1) {
     __pyx_v_idx = __pyx_t_4;
 
-    /* "aesara/scan/scan_perform.pyx":282
+    /* "aesara/scan/scan_perform.pyx":280
  * 
  *     for idx in range(len(other_args)):
  *         inner_input_storage[<unsigned int>(idx+offset)][0] = other_args[idx]             # <<<<<<<<<<<<<<
@@ -3796,14 +3748,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __Pyx_INCREF(__pyx_t_2);
     if (unlikely(__pyx_v_inner_input_storage == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 282, __pyx_L1_error)
+      __PYX_ERR(0, 280, __pyx_L1_error)
     }
     __pyx_t_6 = ((unsigned int)(__pyx_v_idx + __pyx_v_offset));
-    if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_t_6), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 282, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_t_6), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 280, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   }
 
-  /* "aesara/scan/scan_perform.pyx":284
+  /* "aesara/scan/scan_perform.pyx":282
  *         inner_input_storage[<unsigned int>(idx+offset)][0] = other_args[idx]
  * 
  *     i = 0             # <<<<<<<<<<<<<<
@@ -3812,7 +3764,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_i = 0;
 
-  /* "aesara/scan/scan_perform.pyx":285
+  /* "aesara/scan/scan_perform.pyx":283
  * 
  *     i = 0
  *     cond = 1             # <<<<<<<<<<<<<<
@@ -3821,7 +3773,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_cond = 1;
 
-  /* "aesara/scan/scan_perform.pyx":288
+  /* "aesara/scan/scan_perform.pyx":286
  *     ############## THE MAIN LOOP #########################
  *     #for i in range(n_steps):
  *     while (i < n_steps) and cond == 1:             # <<<<<<<<<<<<<<
@@ -3840,7 +3792,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_L32_bool_binop_done:;
     if (!__pyx_t_5) break;
 
-    /* "aesara/scan/scan_perform.pyx":291
+    /* "aesara/scan/scan_perform.pyx":289
  *         # sequences over which scan iterates
  *         # 3. collect input slices
  *         for idx in range(n_seqs):             # <<<<<<<<<<<<<<
@@ -3852,7 +3804,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":292
+      /* "aesara/scan/scan_perform.pyx":290
  *         # 3. collect input slices
  *         for idx in range(n_seqs):
  *             if vector_seqs[idx] == 1:             # <<<<<<<<<<<<<<
@@ -3863,7 +3815,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_5 = (((*__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_vector_seqs.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_vector_seqs.diminfo[0].strides)) == 1) != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":293
+        /* "aesara/scan/scan_perform.pyx":291
  *         for idx in range(n_seqs):
  *             if vector_seqs[idx] == 1:
  *                 inner_input_storage[idx][0] = outer_inputs[\             # <<<<<<<<<<<<<<
@@ -3872,10 +3824,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_inputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 293, __pyx_L1_error)
+          __PYX_ERR(0, 291, __pyx_L1_error)
         }
 
-        /* "aesara/scan/scan_perform.pyx":294
+        /* "aesara/scan/scan_perform.pyx":292
  *             if vector_seqs[idx] == 1:
  *                 inner_input_storage[idx][0] = outer_inputs[\
  *                             <unsigned int>(1+idx)][i:<unsigned int>(i+1)].reshape(())             # <<<<<<<<<<<<<<
@@ -3884,24 +3836,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         __pyx_t_8 = ((unsigned int)(1 + __pyx_v_idx));
 
-        /* "aesara/scan/scan_perform.pyx":293
+        /* "aesara/scan/scan_perform.pyx":291
  *         for idx in range(n_seqs):
  *             if vector_seqs[idx] == 1:
  *                 inner_input_storage[idx][0] = outer_inputs[\             # <<<<<<<<<<<<<<
  *                             <unsigned int>(1+idx)][i:<unsigned int>(i+1)].reshape(())
  *             else:
  */
-        __pyx_t_16 = __Pyx_PyObject_GetSlice(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), __pyx_v_i, ((unsigned int)(__pyx_v_i + 1)), NULL, NULL, NULL, 1, 1, 1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 294, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_PyObject_GetSlice(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), __pyx_v_i, ((unsigned int)(__pyx_v_i + 1)), NULL, NULL, NULL, 1, 1, 1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 292, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
 
-        /* "aesara/scan/scan_perform.pyx":294
+        /* "aesara/scan/scan_perform.pyx":292
  *             if vector_seqs[idx] == 1:
  *                 inner_input_storage[idx][0] = outer_inputs[\
  *                             <unsigned int>(1+idx)][i:<unsigned int>(i+1)].reshape(())             # <<<<<<<<<<<<<<
  *             else:
  *                 inner_input_storage[idx][0] = \
  */
-        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_16, __pyx_n_s_reshape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 294, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_16, __pyx_n_s_reshape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 292, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         __pyx_t_16 = NULL;
@@ -3916,11 +3868,11 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         }
         __pyx_t_2 = (__pyx_t_16) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_16, __pyx_empty_tuple) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_empty_tuple);
         __Pyx_XDECREF(__pyx_t_16); __pyx_t_16 = 0;
-        if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 294, __pyx_L1_error)
+        if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 292, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":293
+        /* "aesara/scan/scan_perform.pyx":291
  *         for idx in range(n_seqs):
  *             if vector_seqs[idx] == 1:
  *                 inner_input_storage[idx][0] = outer_inputs[\             # <<<<<<<<<<<<<<
@@ -3929,12 +3881,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_inner_input_storage == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 293, __pyx_L1_error)
+          __PYX_ERR(0, 291, __pyx_L1_error)
         }
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_idx), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 293, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_idx), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 291, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":292
+        /* "aesara/scan/scan_perform.pyx":290
  *         # 3. collect input slices
  *         for idx in range(n_seqs):
  *             if vector_seqs[idx] == 1:             # <<<<<<<<<<<<<<
@@ -3944,7 +3896,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L36;
       }
 
-      /* "aesara/scan/scan_perform.pyx":297
+      /* "aesara/scan/scan_perform.pyx":295
  *             else:
  *                 inner_input_storage[idx][0] = \
  *                         outer_inputs[<unsigned int>(idx+1)][i]             # <<<<<<<<<<<<<<
@@ -3954,13 +3906,13 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       /*else*/ {
         if (unlikely(__pyx_v_outer_inputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 297, __pyx_L1_error)
+          __PYX_ERR(0, 295, __pyx_L1_error)
         }
         __pyx_t_8 = ((unsigned int)(__pyx_v_idx + 1));
-        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), __pyx_v_i, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 297, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8), __pyx_v_i, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 295, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
 
-        /* "aesara/scan/scan_perform.pyx":296
+        /* "aesara/scan/scan_perform.pyx":294
  *                             <unsigned int>(1+idx)][i:<unsigned int>(i+1)].reshape(())
  *             else:
  *                 inner_input_storage[idx][0] = \             # <<<<<<<<<<<<<<
@@ -3969,15 +3921,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_inner_input_storage == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 296, __pyx_L1_error)
+          __PYX_ERR(0, 294, __pyx_L1_error)
         }
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_idx), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 296, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_idx), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 294, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       }
       __pyx_L36:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":299
+    /* "aesara/scan/scan_perform.pyx":297
  *                         outer_inputs[<unsigned int>(idx+1)][i]
  * 
  *         offset = n_seqs             # <<<<<<<<<<<<<<
@@ -3986,7 +3938,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_offset = __pyx_v_n_seqs;
 
-    /* "aesara/scan/scan_perform.pyx":300
+    /* "aesara/scan/scan_perform.pyx":298
  * 
  *         offset = n_seqs
  *         for idx in range(n_outs):             # <<<<<<<<<<<<<<
@@ -3998,7 +3950,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":301
+      /* "aesara/scan/scan_perform.pyx":299
  *         offset = n_seqs
  *         for idx in range(n_outs):
  *             if vector_outs[idx] == 1:             # <<<<<<<<<<<<<<
@@ -4009,7 +3961,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_5 = (((*__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_vector_outs.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_vector_outs.diminfo[0].strides)) == 1) != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":302
+        /* "aesara/scan/scan_perform.pyx":300
  *         for idx in range(n_outs):
  *             if vector_outs[idx] == 1:
  *                 for tap in tap_array[idx]:             # <<<<<<<<<<<<<<
@@ -4018,32 +3970,32 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_tap_array == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 302, __pyx_L1_error)
+          __PYX_ERR(0, 300, __pyx_L1_error)
         }
         if (likely(PyList_CheckExact(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx))) || PyTuple_CheckExact(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx))) {
           __pyx_t_2 = PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx); __Pyx_INCREF(__pyx_t_2); __pyx_t_9 = 0;
           __pyx_t_19 = NULL;
         } else {
-          __pyx_t_9 = -1; __pyx_t_2 = PyObject_GetIter(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 302, __pyx_L1_error)
+          __pyx_t_9 = -1; __pyx_t_2 = PyObject_GetIter(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 300, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_2);
-          __pyx_t_19 = Py_TYPE(__pyx_t_2)->tp_iternext; if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 302, __pyx_L1_error)
+          __pyx_t_19 = Py_TYPE(__pyx_t_2)->tp_iternext; if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 300, __pyx_L1_error)
         }
         for (;;) {
           if (likely(!__pyx_t_19)) {
             if (likely(PyList_CheckExact(__pyx_t_2))) {
               if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_2)) break;
               #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-              __pyx_t_3 = PyList_GET_ITEM(__pyx_t_2, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 302, __pyx_L1_error)
+              __pyx_t_3 = PyList_GET_ITEM(__pyx_t_2, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 300, __pyx_L1_error)
               #else
-              __pyx_t_3 = PySequence_ITEM(__pyx_t_2, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 302, __pyx_L1_error)
+              __pyx_t_3 = PySequence_ITEM(__pyx_t_2, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 300, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_3);
               #endif
             } else {
               if (__pyx_t_9 >= PyTuple_GET_SIZE(__pyx_t_2)) break;
               #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-              __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_2, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 302, __pyx_L1_error)
+              __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_2, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 300, __pyx_L1_error)
               #else
-              __pyx_t_3 = PySequence_ITEM(__pyx_t_2, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 302, __pyx_L1_error)
+              __pyx_t_3 = PySequence_ITEM(__pyx_t_2, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 300, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_3);
               #endif
             }
@@ -4053,17 +4005,17 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
               PyObject* exc_type = PyErr_Occurred();
               if (exc_type) {
                 if (likely(__Pyx_PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-                else __PYX_ERR(0, 302, __pyx_L1_error)
+                else __PYX_ERR(0, 300, __pyx_L1_error)
               }
               break;
             }
             __Pyx_GOTREF(__pyx_t_3);
           }
-          __pyx_t_12 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_12 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 302, __pyx_L1_error)
+          __pyx_t_12 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_12 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 300, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
           __pyx_v_tap = __pyx_t_12;
 
-          /* "aesara/scan/scan_perform.pyx":303
+          /* "aesara/scan/scan_perform.pyx":301
  *             if vector_outs[idx] == 1:
  *                 for tap in tap_array[idx]:
  *                     _idx = (pos[idx]+tap)%store_steps[idx]             # <<<<<<<<<<<<<<
@@ -4073,11 +4025,11 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           __pyx_t_12 = ((__pyx_v_pos[__pyx_v_idx]) + __pyx_v_tap);
           if (unlikely((__pyx_v_store_steps[__pyx_v_idx]) == 0)) {
             PyErr_SetString(PyExc_ZeroDivisionError, "integer division or modulo by zero");
-            __PYX_ERR(0, 303, __pyx_L1_error)
+            __PYX_ERR(0, 301, __pyx_L1_error)
           }
           __pyx_v__idx = __Pyx_mod_int(__pyx_t_12, (__pyx_v_store_steps[__pyx_v_idx]));
 
-          /* "aesara/scan/scan_perform.pyx":305
+          /* "aesara/scan/scan_perform.pyx":303
  *                     _idx = (pos[idx]+tap)%store_steps[idx]
  *                     inner_input_storage[offset][0] =\
  *                             outer_outputs[idx][0][_idx:<unsigned int>(_idx+1)].reshape(())             # <<<<<<<<<<<<<<
@@ -4086,14 +4038,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           if (unlikely(__pyx_v_outer_outputs == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 305, __pyx_L1_error)
+            __PYX_ERR(0, 303, __pyx_L1_error)
           }
-          __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 305, __pyx_L1_error)
+          __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 303, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_16);
-          __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_t_16, __pyx_v__idx, ((unsigned int)(__pyx_v__idx + 1)), NULL, NULL, NULL, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 305, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_t_16, __pyx_v__idx, ((unsigned int)(__pyx_v__idx + 1)), NULL, NULL, NULL, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 303, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-          __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_reshape); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 305, __pyx_L1_error)
+          __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_reshape); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 303, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_16);
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
           __pyx_t_1 = NULL;
@@ -4108,11 +4060,11 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           }
           __pyx_t_3 = (__pyx_t_1) ? __Pyx_PyObject_Call2Args(__pyx_t_16, __pyx_t_1, __pyx_empty_tuple) : __Pyx_PyObject_CallOneArg(__pyx_t_16, __pyx_empty_tuple);
           __Pyx_XDECREF(__pyx_t_1); __pyx_t_1 = 0;
-          if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 305, __pyx_L1_error)
+          if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 303, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_3);
           __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":304
+          /* "aesara/scan/scan_perform.pyx":302
  *                 for tap in tap_array[idx]:
  *                     _idx = (pos[idx]+tap)%store_steps[idx]
  *                     inner_input_storage[offset][0] =\             # <<<<<<<<<<<<<<
@@ -4121,12 +4073,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           if (unlikely(__pyx_v_inner_input_storage == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 304, __pyx_L1_error)
+            __PYX_ERR(0, 302, __pyx_L1_error)
           }
-          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_3, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 304, __pyx_L1_error)
+          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_3, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 302, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":306
+          /* "aesara/scan/scan_perform.pyx":304
  *                     inner_input_storage[offset][0] =\
  *                             outer_outputs[idx][0][_idx:<unsigned int>(_idx+1)].reshape(())
  *                     offset += 1             # <<<<<<<<<<<<<<
@@ -4135,7 +4087,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           __pyx_v_offset = (__pyx_v_offset + 1);
 
-          /* "aesara/scan/scan_perform.pyx":302
+          /* "aesara/scan/scan_perform.pyx":300
  *         for idx in range(n_outs):
  *             if vector_outs[idx] == 1:
  *                 for tap in tap_array[idx]:             # <<<<<<<<<<<<<<
@@ -4145,7 +4097,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         }
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":301
+        /* "aesara/scan/scan_perform.pyx":299
  *         offset = n_seqs
  *         for idx in range(n_outs):
  *             if vector_outs[idx] == 1:             # <<<<<<<<<<<<<<
@@ -4155,7 +4107,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L39;
       }
 
-      /* "aesara/scan/scan_perform.pyx":308
+      /* "aesara/scan/scan_perform.pyx":306
  *                     offset += 1
  *             else:
  *                 for tap in tap_array[idx]:             # <<<<<<<<<<<<<<
@@ -4165,32 +4117,32 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       /*else*/ {
         if (unlikely(__pyx_v_tap_array == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 308, __pyx_L1_error)
+          __PYX_ERR(0, 306, __pyx_L1_error)
         }
         if (likely(PyList_CheckExact(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx))) || PyTuple_CheckExact(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx))) {
           __pyx_t_2 = PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx); __Pyx_INCREF(__pyx_t_2); __pyx_t_9 = 0;
           __pyx_t_19 = NULL;
         } else {
-          __pyx_t_9 = -1; __pyx_t_2 = PyObject_GetIter(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 308, __pyx_L1_error)
+          __pyx_t_9 = -1; __pyx_t_2 = PyObject_GetIter(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 306, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_2);
-          __pyx_t_19 = Py_TYPE(__pyx_t_2)->tp_iternext; if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 308, __pyx_L1_error)
+          __pyx_t_19 = Py_TYPE(__pyx_t_2)->tp_iternext; if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 306, __pyx_L1_error)
         }
         for (;;) {
           if (likely(!__pyx_t_19)) {
             if (likely(PyList_CheckExact(__pyx_t_2))) {
               if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_2)) break;
               #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-              __pyx_t_3 = PyList_GET_ITEM(__pyx_t_2, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 308, __pyx_L1_error)
+              __pyx_t_3 = PyList_GET_ITEM(__pyx_t_2, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 306, __pyx_L1_error)
               #else
-              __pyx_t_3 = PySequence_ITEM(__pyx_t_2, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 308, __pyx_L1_error)
+              __pyx_t_3 = PySequence_ITEM(__pyx_t_2, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 306, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_3);
               #endif
             } else {
               if (__pyx_t_9 >= PyTuple_GET_SIZE(__pyx_t_2)) break;
               #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-              __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_2, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 308, __pyx_L1_error)
+              __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_2, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 306, __pyx_L1_error)
               #else
-              __pyx_t_3 = PySequence_ITEM(__pyx_t_2, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 308, __pyx_L1_error)
+              __pyx_t_3 = PySequence_ITEM(__pyx_t_2, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 306, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_3);
               #endif
             }
@@ -4200,17 +4152,17 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
               PyObject* exc_type = PyErr_Occurred();
               if (exc_type) {
                 if (likely(__Pyx_PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-                else __PYX_ERR(0, 308, __pyx_L1_error)
+                else __PYX_ERR(0, 306, __pyx_L1_error)
               }
               break;
             }
             __Pyx_GOTREF(__pyx_t_3);
           }
-          __pyx_t_12 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_12 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 308, __pyx_L1_error)
+          __pyx_t_12 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_12 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 306, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
           __pyx_v_tap = __pyx_t_12;
 
-          /* "aesara/scan/scan_perform.pyx":309
+          /* "aesara/scan/scan_perform.pyx":307
  *             else:
  *                 for tap in tap_array[idx]:
  *                     _idx = (pos[idx]+tap)%store_steps[idx]             # <<<<<<<<<<<<<<
@@ -4220,11 +4172,11 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           __pyx_t_12 = ((__pyx_v_pos[__pyx_v_idx]) + __pyx_v_tap);
           if (unlikely((__pyx_v_store_steps[__pyx_v_idx]) == 0)) {
             PyErr_SetString(PyExc_ZeroDivisionError, "integer division or modulo by zero");
-            __PYX_ERR(0, 309, __pyx_L1_error)
+            __PYX_ERR(0, 307, __pyx_L1_error)
           }
           __pyx_v__idx = __Pyx_mod_int(__pyx_t_12, (__pyx_v_store_steps[__pyx_v_idx]));
 
-          /* "aesara/scan/scan_perform.pyx":310
+          /* "aesara/scan/scan_perform.pyx":308
  *                 for tap in tap_array[idx]:
  *                     _idx = (pos[idx]+tap)%store_steps[idx]
  *                     inner_input_storage[offset][0] = outer_outputs[idx][0][_idx]             # <<<<<<<<<<<<<<
@@ -4233,21 +4185,21 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           if (unlikely(__pyx_v_outer_outputs == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 310, __pyx_L1_error)
+            __PYX_ERR(0, 308, __pyx_L1_error)
           }
-          __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 310, __pyx_L1_error)
+          __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 308, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_3);
-          __pyx_t_16 = __Pyx_GetItemInt(__pyx_t_3, __pyx_v__idx, int, 1, __Pyx_PyInt_From_int, 0, 1, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 310, __pyx_L1_error)
+          __pyx_t_16 = __Pyx_GetItemInt(__pyx_t_3, __pyx_v__idx, int, 1, __Pyx_PyInt_From_int, 0, 1, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 308, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_16);
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
           if (unlikely(__pyx_v_inner_input_storage == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 310, __pyx_L1_error)
+            __PYX_ERR(0, 308, __pyx_L1_error)
           }
-          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 310, __pyx_L1_error)
+          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 308, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":311
+          /* "aesara/scan/scan_perform.pyx":309
  *                     _idx = (pos[idx]+tap)%store_steps[idx]
  *                     inner_input_storage[offset][0] = outer_outputs[idx][0][_idx]
  *                     offset += 1             # <<<<<<<<<<<<<<
@@ -4256,7 +4208,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           __pyx_v_offset = (__pyx_v_offset + 1);
 
-          /* "aesara/scan/scan_perform.pyx":308
+          /* "aesara/scan/scan_perform.pyx":306
  *                     offset += 1
  *             else:
  *                 for tap in tap_array[idx]:             # <<<<<<<<<<<<<<
@@ -4269,7 +4221,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_L39:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":314
+    /* "aesara/scan/scan_perform.pyx":312
  * 
  * 
  *         a_offset = shared_arg_offset             # <<<<<<<<<<<<<<
@@ -4278,7 +4230,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_a_offset = __pyx_v_shared_arg_offset;
 
-    /* "aesara/scan/scan_perform.pyx":315
+    /* "aesara/scan/scan_perform.pyx":313
  * 
  *         a_offset = shared_arg_offset
  *         o_offset = n_outs + n_nit_sot             # <<<<<<<<<<<<<<
@@ -4287,7 +4239,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_o_offset = (__pyx_v_n_outs + __pyx_v_n_nit_sot);
 
-    /* "aesara/scan/scan_perform.pyx":316
+    /* "aesara/scan/scan_perform.pyx":314
  *         a_offset = shared_arg_offset
  *         o_offset = n_outs + n_nit_sot
  *         if i == 0:             # <<<<<<<<<<<<<<
@@ -4297,7 +4249,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_5 = ((__pyx_v_i == 0) != 0);
     if (__pyx_t_5) {
 
-      /* "aesara/scan/scan_perform.pyx":317
+      /* "aesara/scan/scan_perform.pyx":315
  *         o_offset = n_outs + n_nit_sot
  *         if i == 0:
  *             for j in range(n_shared_outs):             # <<<<<<<<<<<<<<
@@ -4309,7 +4261,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
         __pyx_v_j = __pyx_t_7;
 
-        /* "aesara/scan/scan_perform.pyx":318
+        /* "aesara/scan/scan_perform.pyx":316
  *         if i == 0:
  *             for j in range(n_shared_outs):
  *                 inner_input_storage[offset][0] = outer_inputs[<unsigned int>(a_offset+j)]             # <<<<<<<<<<<<<<
@@ -4318,19 +4270,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_inputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 318, __pyx_L1_error)
+          __PYX_ERR(0, 316, __pyx_L1_error)
         }
         __pyx_t_8 = ((unsigned int)(__pyx_v_a_offset + __pyx_v_j));
         __pyx_t_2 = PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_8);
         __Pyx_INCREF(__pyx_t_2);
         if (unlikely(__pyx_v_inner_input_storage == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 318, __pyx_L1_error)
+          __PYX_ERR(0, 316, __pyx_L1_error)
         }
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 318, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 316, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":319
+        /* "aesara/scan/scan_perform.pyx":317
  *             for j in range(n_shared_outs):
  *                 inner_input_storage[offset][0] = outer_inputs[<unsigned int>(a_offset+j)]
  *                 offset += 1             # <<<<<<<<<<<<<<
@@ -4340,7 +4292,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_v_offset = (__pyx_v_offset + 1);
       }
 
-      /* "aesara/scan/scan_perform.pyx":316
+      /* "aesara/scan/scan_perform.pyx":314
  *         a_offset = shared_arg_offset
  *         o_offset = n_outs + n_nit_sot
  *         if i == 0:             # <<<<<<<<<<<<<<
@@ -4350,7 +4302,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       goto __pyx_L44;
     }
 
-    /* "aesara/scan/scan_perform.pyx":321
+    /* "aesara/scan/scan_perform.pyx":319
  *                 offset += 1
  *         else:
  *             for j in range(n_shared_outs):             # <<<<<<<<<<<<<<
@@ -4363,7 +4315,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
         __pyx_v_j = __pyx_t_7;
 
-        /* "aesara/scan/scan_perform.pyx":322
+        /* "aesara/scan/scan_perform.pyx":320
  *         else:
  *             for j in range(n_shared_outs):
  *                 inner_input_storage[offset][0] = outer_outputs[<unsigned int>(o_offset+j)][0]             # <<<<<<<<<<<<<<
@@ -4372,19 +4324,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 322, __pyx_L1_error)
+          __PYX_ERR(0, 320, __pyx_L1_error)
         }
         __pyx_t_8 = ((unsigned int)(__pyx_v_o_offset + __pyx_v_j));
-        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 322, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 320, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
         if (unlikely(__pyx_v_inner_input_storage == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 322, __pyx_L1_error)
+          __PYX_ERR(0, 320, __pyx_L1_error)
         }
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 322, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 320, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":323
+        /* "aesara/scan/scan_perform.pyx":321
  *             for j in range(n_shared_outs):
  *                 inner_input_storage[offset][0] = outer_outputs[<unsigned int>(o_offset+j)][0]
  *                 offset += 1             # <<<<<<<<<<<<<<
@@ -4396,7 +4348,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     }
     __pyx_L44:;
 
-    /* "aesara/scan/scan_perform.pyx":328
+    /* "aesara/scan/scan_perform.pyx":326
  * 
  *         # 4.1. Collect slices for mitmots
  *         offset = 0             # <<<<<<<<<<<<<<
@@ -4405,7 +4357,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_offset = 0;
 
-    /* "aesara/scan/scan_perform.pyx":329
+    /* "aesara/scan/scan_perform.pyx":327
  *         # 4.1. Collect slices for mitmots
  *         offset = 0
  *         for idx in range(n_mit_mot_outs):             # <<<<<<<<<<<<<<
@@ -4417,50 +4369,50 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":330
+      /* "aesara/scan/scan_perform.pyx":328
  *         offset = 0
  *         for idx in range(n_mit_mot_outs):
  *             if not mitmots_preallocated[<unsigned int>idx]:             # <<<<<<<<<<<<<<
  *                 inner_output_storage[<unsigned int>offset][0] = None
- *                 offset += 1
+ *             offset += 1
  */
       __pyx_t_13 = ((unsigned int)__pyx_v_idx);
       __pyx_t_5 = ((!((*__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_mitmots_preallocated.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_mitmots_preallocated.diminfo[0].strides)) != 0)) != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":331
+        /* "aesara/scan/scan_perform.pyx":329
  *         for idx in range(n_mit_mot_outs):
  *             if not mitmots_preallocated[<unsigned int>idx]:
  *                 inner_output_storage[<unsigned int>offset][0] = None             # <<<<<<<<<<<<<<
- *                 offset += 1
+ *             offset += 1
  * 
  */
         if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 331, __pyx_L1_error)
+          __PYX_ERR(0, 329, __pyx_L1_error)
         }
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, ((unsigned int)__pyx_v_offset)), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 331, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, ((unsigned int)__pyx_v_offset)), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 329, __pyx_L1_error)
 
-        /* "aesara/scan/scan_perform.pyx":332
- *             if not mitmots_preallocated[<unsigned int>idx]:
- *                 inner_output_storage[<unsigned int>offset][0] = None
- *                 offset += 1             # <<<<<<<<<<<<<<
- * 
- *         # 4.2. Collect slices for mitsots, sitsots and nitsots
- */
-        __pyx_v_offset = (__pyx_v_offset + 1);
-
-        /* "aesara/scan/scan_perform.pyx":330
+        /* "aesara/scan/scan_perform.pyx":328
  *         offset = 0
  *         for idx in range(n_mit_mot_outs):
  *             if not mitmots_preallocated[<unsigned int>idx]:             # <<<<<<<<<<<<<<
  *                 inner_output_storage[<unsigned int>offset][0] = None
- *                 offset += 1
+ *             offset += 1
  */
       }
+
+      /* "aesara/scan/scan_perform.pyx":330
+ *             if not mitmots_preallocated[<unsigned int>idx]:
+ *                 inner_output_storage[<unsigned int>offset][0] = None
+ *             offset += 1             # <<<<<<<<<<<<<<
+ * 
+ *         # 4.2. Collect slices for mitsots, sitsots and nitsots
+ */
+      __pyx_v_offset = (__pyx_v_offset + 1);
     }
 
-    /* "aesara/scan/scan_perform.pyx":335
+    /* "aesara/scan/scan_perform.pyx":333
  * 
  *         # 4.2. Collect slices for mitsots, sitsots and nitsots
  *         if i != 0:             # <<<<<<<<<<<<<<
@@ -4470,7 +4422,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_5 = ((__pyx_v_i != 0) != 0);
     if (__pyx_t_5) {
 
-      /* "aesara/scan/scan_perform.pyx":336
+      /* "aesara/scan/scan_perform.pyx":334
  *         # 4.2. Collect slices for mitsots, sitsots and nitsots
  *         if i != 0:
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):             # <<<<<<<<<<<<<<
@@ -4482,7 +4434,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
         __pyx_v_idx = __pyx_t_7;
 
-        /* "aesara/scan/scan_perform.pyx":337
+        /* "aesara/scan/scan_perform.pyx":335
  *         if i != 0:
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):
  *                 if ( store_steps[<unsigned int>(idx+n_mit_mot)] == 1 or             # <<<<<<<<<<<<<<
@@ -4496,7 +4448,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           goto __pyx_L56_bool_binop_done;
         }
 
-        /* "aesara/scan/scan_perform.pyx":338
+        /* "aesara/scan/scan_perform.pyx":336
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):
  *                 if ( store_steps[<unsigned int>(idx+n_mit_mot)] == 1 or
  *                     vector_outs[<unsigned int>(idx+n_mit_mot)] == 1):             # <<<<<<<<<<<<<<
@@ -4508,7 +4460,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_t_5 = __pyx_t_15;
         __pyx_L56_bool_binop_done:;
 
-        /* "aesara/scan/scan_perform.pyx":337
+        /* "aesara/scan/scan_perform.pyx":335
  *         if i != 0:
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):
  *                 if ( store_steps[<unsigned int>(idx+n_mit_mot)] == 1 or             # <<<<<<<<<<<<<<
@@ -4517,7 +4469,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (__pyx_t_5) {
 
-          /* "aesara/scan/scan_perform.pyx":339
+          /* "aesara/scan/scan_perform.pyx":337
  *                 if ( store_steps[<unsigned int>(idx+n_mit_mot)] == 1 or
  *                     vector_outs[<unsigned int>(idx+n_mit_mot)] == 1):
  *                     inner_output_storage[<unsigned int>(idx+offset)][0] = None             # <<<<<<<<<<<<<<
@@ -4526,12 +4478,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 339, __pyx_L1_error)
+            __PYX_ERR(0, 337, __pyx_L1_error)
           }
           __pyx_t_8 = ((unsigned int)(__pyx_v_idx + __pyx_v_offset));
-          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 339, __pyx_L1_error)
+          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 337, __pyx_L1_error)
 
-          /* "aesara/scan/scan_perform.pyx":337
+          /* "aesara/scan/scan_perform.pyx":335
  *         if i != 0:
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):
  *                 if ( store_steps[<unsigned int>(idx+n_mit_mot)] == 1 or             # <<<<<<<<<<<<<<
@@ -4541,7 +4493,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           goto __pyx_L55;
         }
 
-        /* "aesara/scan/scan_perform.pyx":342
+        /* "aesara/scan/scan_perform.pyx":340
  *                 else:
  *                     inner_output_storage[<unsigned int>(idx+offset)][0] =\
  *                         outer_outputs[<unsigned int>(idx+n_mit_mot)][0][pos[\             # <<<<<<<<<<<<<<
@@ -4551,13 +4503,13 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         /*else*/ {
           if (unlikely(__pyx_v_outer_outputs == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 342, __pyx_L1_error)
+            __PYX_ERR(0, 340, __pyx_L1_error)
           }
           __pyx_t_8 = ((unsigned int)(__pyx_v_idx + __pyx_v_n_mit_mot));
-          __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 342, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 340, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_2);
 
-          /* "aesara/scan/scan_perform.pyx":343
+          /* "aesara/scan/scan_perform.pyx":341
  *                     inner_output_storage[<unsigned int>(idx+offset)][0] =\
  *                         outer_outputs[<unsigned int>(idx+n_mit_mot)][0][pos[\
  *                                             <unsigned int>(idx+n_mit_mot)]]             # <<<<<<<<<<<<<<
@@ -4566,18 +4518,18 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           __pyx_t_12 = (__pyx_v_pos[((unsigned int)(__pyx_v_idx + __pyx_v_n_mit_mot))]);
 
-          /* "aesara/scan/scan_perform.pyx":342
+          /* "aesara/scan/scan_perform.pyx":340
  *                 else:
  *                     inner_output_storage[<unsigned int>(idx+offset)][0] =\
  *                         outer_outputs[<unsigned int>(idx+n_mit_mot)][0][pos[\             # <<<<<<<<<<<<<<
  *                                             <unsigned int>(idx+n_mit_mot)]]
  *         else:
  */
-          __pyx_t_16 = __Pyx_GetItemInt(__pyx_t_2, __pyx_t_12, int, 1, __Pyx_PyInt_From_int, 0, 1, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 342, __pyx_L1_error)
+          __pyx_t_16 = __Pyx_GetItemInt(__pyx_t_2, __pyx_t_12, int, 1, __Pyx_PyInt_From_int, 0, 1, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 340, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_16);
           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":341
+          /* "aesara/scan/scan_perform.pyx":339
  *                     inner_output_storage[<unsigned int>(idx+offset)][0] = None
  *                 else:
  *                     inner_output_storage[<unsigned int>(idx+offset)][0] =\             # <<<<<<<<<<<<<<
@@ -4586,16 +4538,16 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 341, __pyx_L1_error)
+            __PYX_ERR(0, 339, __pyx_L1_error)
           }
           __pyx_t_8 = ((unsigned int)(__pyx_v_idx + __pyx_v_offset));
-          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 341, __pyx_L1_error)
+          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 339, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         }
         __pyx_L55:;
       }
 
-      /* "aesara/scan/scan_perform.pyx":335
+      /* "aesara/scan/scan_perform.pyx":333
  * 
  *         # 4.2. Collect slices for mitsots, sitsots and nitsots
  *         if i != 0:             # <<<<<<<<<<<<<<
@@ -4605,7 +4557,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       goto __pyx_L52;
     }
 
-    /* "aesara/scan/scan_perform.pyx":345
+    /* "aesara/scan/scan_perform.pyx":343
  *                                             <unsigned int>(idx+n_mit_mot)]]
  *         else:
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):             # <<<<<<<<<<<<<<
@@ -4618,7 +4570,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
         __pyx_v_idx = __pyx_t_7;
 
-        /* "aesara/scan/scan_perform.pyx":346
+        /* "aesara/scan/scan_perform.pyx":344
  *         else:
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):
  *                 inner_output_storage[<unsigned int>(idx+offset)][0] = None             # <<<<<<<<<<<<<<
@@ -4627,15 +4579,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 346, __pyx_L1_error)
+          __PYX_ERR(0, 344, __pyx_L1_error)
         }
         __pyx_t_8 = ((unsigned int)(__pyx_v_idx + __pyx_v_offset));
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 346, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 344, __pyx_L1_error)
       }
     }
     __pyx_L52:;
 
-    /* "aesara/scan/scan_perform.pyx":349
+    /* "aesara/scan/scan_perform.pyx":347
  * 
  *         # 4.3. Collect slices for shared outputs
  *         offset += n_outs+n_nit_sot - n_mit_mot             # <<<<<<<<<<<<<<
@@ -4644,7 +4596,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_offset = (__pyx_v_offset + ((__pyx_v_n_outs + __pyx_v_n_nit_sot) - __pyx_v_n_mit_mot));
 
-    /* "aesara/scan/scan_perform.pyx":350
+    /* "aesara/scan/scan_perform.pyx":348
  *         # 4.3. Collect slices for shared outputs
  *         offset += n_outs+n_nit_sot - n_mit_mot
  *         for idx in range(n_shared_outs):             # <<<<<<<<<<<<<<
@@ -4656,7 +4608,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":351
+      /* "aesara/scan/scan_perform.pyx":349
  *         offset += n_outs+n_nit_sot - n_mit_mot
  *         for idx in range(n_shared_outs):
  *             inner_output_storage[<unsigned int>(idx+offset)][0] = None             # <<<<<<<<<<<<<<
@@ -4665,13 +4617,13 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 351, __pyx_L1_error)
+        __PYX_ERR(0, 349, __pyx_L1_error)
       }
       __pyx_t_8 = ((unsigned int)(__pyx_v_idx + __pyx_v_offset));
-      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 351, __pyx_L1_error)
+      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 349, __pyx_L1_error)
     }
 
-    /* "aesara/scan/scan_perform.pyx":354
+    /* "aesara/scan/scan_perform.pyx":352
  * 
  *         # 4.4. If there is a condition add it to the mix
  *         if as_while:             # <<<<<<<<<<<<<<
@@ -4681,7 +4633,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_5 = (__pyx_v_as_while != 0);
     if (__pyx_t_5) {
 
-      /* "aesara/scan/scan_perform.pyx":355
+      /* "aesara/scan/scan_perform.pyx":353
  *         # 4.4. If there is a condition add it to the mix
  *         if as_while:
  *             pdx = offset + n_shared_outs             # <<<<<<<<<<<<<<
@@ -4690,7 +4642,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       __pyx_v_pdx = (__pyx_v_offset + __pyx_v_n_shared_outs);
 
-      /* "aesara/scan/scan_perform.pyx":356
+      /* "aesara/scan/scan_perform.pyx":354
  *         if as_while:
  *             pdx = offset + n_shared_outs
  *             inner_output_storage[<unsigned int>pdx][0] = None             # <<<<<<<<<<<<<<
@@ -4699,11 +4651,11 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 356, __pyx_L1_error)
+        __PYX_ERR(0, 354, __pyx_L1_error)
       }
-      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, ((unsigned int)__pyx_v_pdx)), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 356, __pyx_L1_error)
+      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, ((unsigned int)__pyx_v_pdx)), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 354, __pyx_L1_error)
 
-      /* "aesara/scan/scan_perform.pyx":354
+      /* "aesara/scan/scan_perform.pyx":352
  * 
  *         # 4.4. If there is a condition add it to the mix
  *         if as_while:             # <<<<<<<<<<<<<<
@@ -4712,7 +4664,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     }
 
-    /* "aesara/scan/scan_perform.pyx":364
+    /* "aesara/scan/scan_perform.pyx":362
  *         # cases where outputs reused the allocated object but alter the
  *         # memory region they refer to.
  *         for idx in range(len_output_storage):             # <<<<<<<<<<<<<<
@@ -4724,7 +4676,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":366
+      /* "aesara/scan/scan_perform.pyx":364
  *         for idx in range(len_output_storage):
  * 
  *             var = inner_output_storage[idx][0]             # <<<<<<<<<<<<<<
@@ -4733,23 +4685,23 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 366, __pyx_L1_error)
+        __PYX_ERR(0, 364, __pyx_L1_error)
       }
-      __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 366, __pyx_L1_error)
+      __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 364, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_16);
       __Pyx_XDECREF_SET(__pyx_v_var, __pyx_t_16);
       __pyx_t_16 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":367
+      /* "aesara/scan/scan_perform.pyx":365
  * 
  *             var = inner_output_storage[idx][0]
  *             old_output_storage[idx] = var             # <<<<<<<<<<<<<<
  * 
  *             if var is None:
  */
-      if (unlikely(__Pyx_SetItemInt(__pyx_v_old_output_storage, __pyx_v_idx, __pyx_v_var, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 367, __pyx_L1_error)
+      if (unlikely(__Pyx_SetItemInt(__pyx_v_old_output_storage, __pyx_v_idx, __pyx_v_var, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 365, __pyx_L1_error)
 
-      /* "aesara/scan/scan_perform.pyx":369
+      /* "aesara/scan/scan_perform.pyx":367
  *             old_output_storage[idx] = var
  * 
  *             if var is None:             # <<<<<<<<<<<<<<
@@ -4760,16 +4712,16 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_15 = (__pyx_t_5 != 0);
       if (__pyx_t_15) {
 
-        /* "aesara/scan/scan_perform.pyx":370
+        /* "aesara/scan/scan_perform.pyx":368
  * 
  *             if var is None:
  *                 old_output_data[idx] = None             # <<<<<<<<<<<<<<
  *             else:
  *                 old_output_data[idx] = var.data
  */
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_output_data, __pyx_v_idx, Py_None, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 370, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_output_data, __pyx_v_idx, Py_None, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 368, __pyx_L1_error)
 
-        /* "aesara/scan/scan_perform.pyx":369
+        /* "aesara/scan/scan_perform.pyx":367
  *             old_output_storage[idx] = var
  * 
  *             if var is None:             # <<<<<<<<<<<<<<
@@ -4779,7 +4731,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L65;
       }
 
-      /* "aesara/scan/scan_perform.pyx":372
+      /* "aesara/scan/scan_perform.pyx":370
  *                 old_output_data[idx] = None
  *             else:
  *                 old_output_data[idx] = var.data             # <<<<<<<<<<<<<<
@@ -4787,27 +4739,27 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *         # 4.6. Keep a reference to the variables (ndarrays,
  */
       /*else*/ {
-        __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_v_var, __pyx_n_s_data); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 372, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_v_var, __pyx_n_s_data); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 370, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_output_data, __pyx_v_idx, __pyx_t_16, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 372, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_output_data, __pyx_v_idx, __pyx_t_16, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 370, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
       }
       __pyx_L65:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":380
+    /* "aesara/scan/scan_perform.pyx":378
  *         # be able to detect cases where outputs reused the allocated object
  *         # but alter the memory region they refer to.
  *         for idx in xrange(nb_mitmot_in):             # <<<<<<<<<<<<<<
  *             var = inner_input_storage[idx + n_seqs][0]
  *             old_mitmot_input_storage[idx] = var
  */
-    __pyx_t_11 = __Pyx_PyInt_As_long(__pyx_v_nb_mitmot_in); if (unlikely((__pyx_t_11 == (long)-1) && PyErr_Occurred())) __PYX_ERR(0, 380, __pyx_L1_error)
+    __pyx_t_11 = __Pyx_PyInt_As_long(__pyx_v_nb_mitmot_in); if (unlikely((__pyx_t_11 == (long)-1) && PyErr_Occurred())) __PYX_ERR(0, 378, __pyx_L1_error)
     __pyx_t_20 = __pyx_t_11;
     for (__pyx_t_4 = 0; __pyx_t_4 < __pyx_t_20; __pyx_t_4+=1) {
       __pyx_v_idx = __pyx_t_4;
 
-      /* "aesara/scan/scan_perform.pyx":381
+      /* "aesara/scan/scan_perform.pyx":379
  *         # but alter the memory region they refer to.
  *         for idx in xrange(nb_mitmot_in):
  *             var = inner_input_storage[idx + n_seqs][0]             # <<<<<<<<<<<<<<
@@ -4816,24 +4768,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       if (unlikely(__pyx_v_inner_input_storage == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 381, __pyx_L1_error)
+        __PYX_ERR(0, 379, __pyx_L1_error)
       }
       __pyx_t_6 = (__pyx_v_idx + __pyx_v_n_seqs);
-      __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_t_6), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 381, __pyx_L1_error)
+      __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_t_6), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 379, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_16);
       __Pyx_XDECREF_SET(__pyx_v_var, __pyx_t_16);
       __pyx_t_16 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":382
+      /* "aesara/scan/scan_perform.pyx":380
  *         for idx in xrange(nb_mitmot_in):
  *             var = inner_input_storage[idx + n_seqs][0]
  *             old_mitmot_input_storage[idx] = var             # <<<<<<<<<<<<<<
  * 
  *             if var is None:
  */
-      if (unlikely(__Pyx_SetItemInt(__pyx_v_old_mitmot_input_storage, __pyx_v_idx, __pyx_v_var, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 382, __pyx_L1_error)
+      if (unlikely(__Pyx_SetItemInt(__pyx_v_old_mitmot_input_storage, __pyx_v_idx, __pyx_v_var, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 380, __pyx_L1_error)
 
-      /* "aesara/scan/scan_perform.pyx":384
+      /* "aesara/scan/scan_perform.pyx":382
  *             old_mitmot_input_storage[idx] = var
  * 
  *             if var is None:             # <<<<<<<<<<<<<<
@@ -4844,16 +4796,16 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_5 = (__pyx_t_15 != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":385
+        /* "aesara/scan/scan_perform.pyx":383
  * 
  *             if var is None:
  *                 old_mitmot_input_data[idx] = None             # <<<<<<<<<<<<<<
  *             else:
  *                 old_mitmot_input_data[idx] = var.data
  */
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_mitmot_input_data, __pyx_v_idx, Py_None, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 385, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_mitmot_input_data, __pyx_v_idx, Py_None, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 383, __pyx_L1_error)
 
-        /* "aesara/scan/scan_perform.pyx":384
+        /* "aesara/scan/scan_perform.pyx":382
  *             old_mitmot_input_storage[idx] = var
  * 
  *             if var is None:             # <<<<<<<<<<<<<<
@@ -4863,7 +4815,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L68;
       }
 
-      /* "aesara/scan/scan_perform.pyx":387
+      /* "aesara/scan/scan_perform.pyx":385
  *                 old_mitmot_input_data[idx] = None
  *             else:
  *                 old_mitmot_input_data[idx] = var.data             # <<<<<<<<<<<<<<
@@ -4871,24 +4823,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *         # 5.1 compute outputs
  */
       /*else*/ {
-        __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_v_var, __pyx_n_s_data); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 387, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_v_var, __pyx_n_s_data); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 385, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_mitmot_input_data, __pyx_v_idx, __pyx_t_16, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 387, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_mitmot_input_data, __pyx_v_idx, __pyx_t_16, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 385, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
       }
       __pyx_L68:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":390
+    /* "aesara/scan/scan_perform.pyx":388
  * 
  *         # 5.1 compute outputs
  *         t0_fn = time.time()             # <<<<<<<<<<<<<<
  * 
  *         try:
  */
-    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_time); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 390, __pyx_L1_error)
+    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_time); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 388, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_time); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 390, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_time); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 388, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_2 = NULL;
@@ -4903,13 +4855,13 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     }
     __pyx_t_16 = (__pyx_t_2) ? __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2) : __Pyx_PyObject_CallNoArg(__pyx_t_3);
     __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-    if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 390, __pyx_L1_error)
+    if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 388, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_XDECREF_SET(__pyx_v_t0_fn, __pyx_t_16);
     __pyx_t_16 = 0;
 
-    /* "aesara/scan/scan_perform.pyx":392
+    /* "aesara/scan/scan_perform.pyx":390
  *         t0_fn = time.time()
  * 
  *         try:             # <<<<<<<<<<<<<<
@@ -4925,7 +4877,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __Pyx_XGOTREF(__pyx_t_23);
       /*try:*/ {
 
-        /* "aesara/scan/scan_perform.pyx":393
+        /* "aesara/scan/scan_perform.pyx":391
  * 
  *         try:
  *             fn()             # <<<<<<<<<<<<<<
@@ -4945,12 +4897,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         }
         __pyx_t_16 = (__pyx_t_2) ? __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2) : __Pyx_PyObject_CallNoArg(__pyx_t_3);
         __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-        if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 393, __pyx_L69_error)
+        if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 391, __pyx_L69_error)
         __Pyx_GOTREF(__pyx_t_16);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":392
+        /* "aesara/scan/scan_perform.pyx":390
  *         t0_fn = time.time()
  * 
  *         try:             # <<<<<<<<<<<<<<
@@ -4968,7 +4920,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
       __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":394
+      /* "aesara/scan/scan_perform.pyx":392
  *         try:
  *             fn()
  *         except Exception as exc:             # <<<<<<<<<<<<<<
@@ -4978,7 +4930,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_12 = __Pyx_PyErr_ExceptionMatches(((PyObject *)(&((PyTypeObject*)PyExc_Exception)[0])));
       if (__pyx_t_12) {
         __Pyx_AddTraceback("aesara.scan.scan_perform.perform", __pyx_clineno, __pyx_lineno, __pyx_filename);
-        if (__Pyx_GetException(&__pyx_t_16, &__pyx_t_3, &__pyx_t_2) < 0) __PYX_ERR(0, 394, __pyx_L71_except_error)
+        if (__Pyx_GetException(&__pyx_t_16, &__pyx_t_3, &__pyx_t_2) < 0) __PYX_ERR(0, 392, __pyx_L71_except_error)
         __Pyx_GOTREF(__pyx_t_16);
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_GOTREF(__pyx_t_2);
@@ -4986,18 +4938,18 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_v_exc = __pyx_t_3;
         /*try:*/ {
 
-          /* "aesara/scan/scan_perform.pyx":395
+          /* "aesara/scan/scan_perform.pyx":393
  *             fn()
  *         except Exception as exc:
  *             raise InnerFunctionError(exc, sys.exc_info()[-1])             # <<<<<<<<<<<<<<
  * 
  *         dt_fn = time.time() - t0_fn
  */
-          __Pyx_GetModuleGlobalName(__pyx_t_24, __pyx_n_s_InnerFunctionError); if (unlikely(!__pyx_t_24)) __PYX_ERR(0, 395, __pyx_L82_error)
+          __Pyx_GetModuleGlobalName(__pyx_t_24, __pyx_n_s_InnerFunctionError); if (unlikely(!__pyx_t_24)) __PYX_ERR(0, 393, __pyx_L82_error)
           __Pyx_GOTREF(__pyx_t_24);
-          __Pyx_GetModuleGlobalName(__pyx_t_26, __pyx_n_s_sys); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 395, __pyx_L82_error)
+          __Pyx_GetModuleGlobalName(__pyx_t_26, __pyx_n_s_sys); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 393, __pyx_L82_error)
           __Pyx_GOTREF(__pyx_t_26);
-          __pyx_t_27 = __Pyx_PyObject_GetAttrStr(__pyx_t_26, __pyx_n_s_exc_info); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 395, __pyx_L82_error)
+          __pyx_t_27 = __Pyx_PyObject_GetAttrStr(__pyx_t_26, __pyx_n_s_exc_info); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 393, __pyx_L82_error)
           __Pyx_GOTREF(__pyx_t_27);
           __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
           __pyx_t_26 = NULL;
@@ -5012,10 +4964,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           }
           __pyx_t_25 = (__pyx_t_26) ? __Pyx_PyObject_CallOneArg(__pyx_t_27, __pyx_t_26) : __Pyx_PyObject_CallNoArg(__pyx_t_27);
           __Pyx_XDECREF(__pyx_t_26); __pyx_t_26 = 0;
-          if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 395, __pyx_L82_error)
+          if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 393, __pyx_L82_error)
           __Pyx_GOTREF(__pyx_t_25);
           __Pyx_DECREF(__pyx_t_27); __pyx_t_27 = 0;
-          __pyx_t_27 = __Pyx_GetItemInt(__pyx_t_25, -1L, long, 1, __Pyx_PyInt_From_long, 0, 1, 0); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 395, __pyx_L82_error)
+          __pyx_t_27 = __Pyx_GetItemInt(__pyx_t_25, -1L, long, 1, __Pyx_PyInt_From_long, 0, 1, 0); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 393, __pyx_L82_error)
           __Pyx_GOTREF(__pyx_t_27);
           __Pyx_DECREF(__pyx_t_25); __pyx_t_25 = 0;
           __pyx_t_25 = NULL;
@@ -5033,7 +4985,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           #if CYTHON_FAST_PYCALL
           if (PyFunction_Check(__pyx_t_24)) {
             PyObject *__pyx_temp[3] = {__pyx_t_25, __pyx_v_exc, __pyx_t_27};
-            __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_24, __pyx_temp+1-__pyx_t_12, 2+__pyx_t_12); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 395, __pyx_L82_error)
+            __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_24, __pyx_temp+1-__pyx_t_12, 2+__pyx_t_12); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 393, __pyx_L82_error)
             __Pyx_XDECREF(__pyx_t_25); __pyx_t_25 = 0;
             __Pyx_GOTREF(__pyx_t_1);
             __Pyx_DECREF(__pyx_t_27); __pyx_t_27 = 0;
@@ -5042,14 +4994,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           #if CYTHON_FAST_PYCCALL
           if (__Pyx_PyFastCFunction_Check(__pyx_t_24)) {
             PyObject *__pyx_temp[3] = {__pyx_t_25, __pyx_v_exc, __pyx_t_27};
-            __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_24, __pyx_temp+1-__pyx_t_12, 2+__pyx_t_12); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 395, __pyx_L82_error)
+            __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_24, __pyx_temp+1-__pyx_t_12, 2+__pyx_t_12); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 393, __pyx_L82_error)
             __Pyx_XDECREF(__pyx_t_25); __pyx_t_25 = 0;
             __Pyx_GOTREF(__pyx_t_1);
             __Pyx_DECREF(__pyx_t_27); __pyx_t_27 = 0;
           } else
           #endif
           {
-            __pyx_t_26 = PyTuple_New(2+__pyx_t_12); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 395, __pyx_L82_error)
+            __pyx_t_26 = PyTuple_New(2+__pyx_t_12); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 393, __pyx_L82_error)
             __Pyx_GOTREF(__pyx_t_26);
             if (__pyx_t_25) {
               __Pyx_GIVEREF(__pyx_t_25); PyTuple_SET_ITEM(__pyx_t_26, 0, __pyx_t_25); __pyx_t_25 = NULL;
@@ -5060,17 +5012,17 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
             __Pyx_GIVEREF(__pyx_t_27);
             PyTuple_SET_ITEM(__pyx_t_26, 1+__pyx_t_12, __pyx_t_27);
             __pyx_t_27 = 0;
-            __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_24, __pyx_t_26, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 395, __pyx_L82_error)
+            __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_24, __pyx_t_26, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 393, __pyx_L82_error)
             __Pyx_GOTREF(__pyx_t_1);
             __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
           }
           __Pyx_DECREF(__pyx_t_24); __pyx_t_24 = 0;
           __Pyx_Raise(__pyx_t_1, 0, 0, 0);
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-          __PYX_ERR(0, 395, __pyx_L82_error)
+          __PYX_ERR(0, 393, __pyx_L82_error)
         }
 
-        /* "aesara/scan/scan_perform.pyx":394
+        /* "aesara/scan/scan_perform.pyx":392
  *         try:
  *             fn()
  *         except Exception as exc:             # <<<<<<<<<<<<<<
@@ -5120,7 +5072,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       goto __pyx_L71_except_error;
       __pyx_L71_except_error:;
 
-      /* "aesara/scan/scan_perform.pyx":392
+      /* "aesara/scan/scan_perform.pyx":390
  *         t0_fn = time.time()
  * 
  *         try:             # <<<<<<<<<<<<<<
@@ -5135,16 +5087,16 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_L76_try_end:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":397
+    /* "aesara/scan/scan_perform.pyx":395
  *             raise InnerFunctionError(exc, sys.exc_info()[-1])
  * 
  *         dt_fn = time.time() - t0_fn             # <<<<<<<<<<<<<<
  *         t_fn += dt_fn
  *         if as_while:
  */
-    __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_time); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 397, __pyx_L1_error)
+    __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_time); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 395, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_time); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 397, __pyx_L1_error)
+    __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_time); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 395, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_3 = NULL;
@@ -5159,32 +5111,32 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     }
     __pyx_t_2 = (__pyx_t_3) ? __Pyx_PyObject_CallOneArg(__pyx_t_16, __pyx_t_3) : __Pyx_PyObject_CallNoArg(__pyx_t_16);
     __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
-    if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 397, __pyx_L1_error)
+    if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 395, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-    __pyx_t_16 = PyNumber_Subtract(__pyx_t_2, __pyx_v_t0_fn); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 397, __pyx_L1_error)
+    __pyx_t_16 = PyNumber_Subtract(__pyx_t_2, __pyx_v_t0_fn); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 395, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_XDECREF_SET(__pyx_v_dt_fn, __pyx_t_16);
     __pyx_t_16 = 0;
 
-    /* "aesara/scan/scan_perform.pyx":398
+    /* "aesara/scan/scan_perform.pyx":396
  * 
  *         dt_fn = time.time() - t0_fn
  *         t_fn += dt_fn             # <<<<<<<<<<<<<<
  *         if as_while:
  *             pdx = offset + n_shared_outs
  */
-    __pyx_t_16 = __Pyx_PyInt_From_unsigned_int(__pyx_v_t_fn); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 398, __pyx_L1_error)
+    __pyx_t_16 = __Pyx_PyInt_From_unsigned_int(__pyx_v_t_fn); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 396, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
-    __pyx_t_2 = PyNumber_InPlaceAdd(__pyx_t_16, __pyx_v_dt_fn); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 398, __pyx_L1_error)
+    __pyx_t_2 = PyNumber_InPlaceAdd(__pyx_t_16, __pyx_v_dt_fn); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 396, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-    __pyx_t_4 = __Pyx_PyInt_As_unsigned_int(__pyx_t_2); if (unlikely((__pyx_t_4 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 398, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyInt_As_unsigned_int(__pyx_t_2); if (unlikely((__pyx_t_4 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 396, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_v_t_fn = __pyx_t_4;
 
-    /* "aesara/scan/scan_perform.pyx":399
+    /* "aesara/scan/scan_perform.pyx":397
  *         dt_fn = time.time() - t0_fn
  *         t_fn += dt_fn
  *         if as_while:             # <<<<<<<<<<<<<<
@@ -5194,7 +5146,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_5 = (__pyx_v_as_while != 0);
     if (__pyx_t_5) {
 
-      /* "aesara/scan/scan_perform.pyx":400
+      /* "aesara/scan/scan_perform.pyx":398
  *         t_fn += dt_fn
  *         if as_while:
  *             pdx = offset + n_shared_outs             # <<<<<<<<<<<<<<
@@ -5203,27 +5155,27 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       __pyx_v_pdx = (__pyx_v_offset + __pyx_v_n_shared_outs);
 
-      /* "aesara/scan/scan_perform.pyx":401
+      /* "aesara/scan/scan_perform.pyx":399
  *         if as_while:
  *             pdx = offset + n_shared_outs
  *             cond = inner_output_storage[pdx][0] == 0             # <<<<<<<<<<<<<<
  * 
- *         # 5.2. By calling fn() directly instead of calling the aesara
+ *         offset_out = 0
  */
       if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 401, __pyx_L1_error)
+        __PYX_ERR(0, 399, __pyx_L1_error)
       }
-      __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_pdx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 401, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_pdx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 399, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
-      __pyx_t_16 = __Pyx_PyInt_EqObjC(__pyx_t_2, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 401, __pyx_L1_error)
+      __pyx_t_16 = __Pyx_PyInt_EqObjC(__pyx_t_2, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 399, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_16);
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-      __pyx_t_28 = __Pyx_PyInt_As_int(__pyx_t_16); if (unlikely((__pyx_t_28 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 401, __pyx_L1_error)
+      __pyx_t_28 = __Pyx_PyInt_As_int(__pyx_t_16); if (unlikely((__pyx_t_28 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 399, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
       __pyx_v_cond = __pyx_t_28;
 
-      /* "aesara/scan/scan_perform.pyx":399
+      /* "aesara/scan/scan_perform.pyx":397
  *         dt_fn = time.time() - t0_fn
  *         t_fn += dt_fn
  *         if as_while:             # <<<<<<<<<<<<<<
@@ -5232,224 +5184,8 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     }
 
-    /* "aesara/scan/scan_perform.pyx":406
- *         # function, it is possible that the updates have not been
- *         # performed. Perform the updates if needed.
- *         if need_update_inputs:             # <<<<<<<<<<<<<<
- *             offset_out = len(inner_output_storage) - 1
- *             for needs_update, storage in zip(inner_input_needs_update[::-1],
- */
-    __pyx_t_5 = (__pyx_v_need_update_inputs != 0);
-    if (__pyx_t_5) {
-
-      /* "aesara/scan/scan_perform.pyx":407
- *         # performed. Perform the updates if needed.
- *         if need_update_inputs:
- *             offset_out = len(inner_output_storage) - 1             # <<<<<<<<<<<<<<
- *             for needs_update, storage in zip(inner_input_needs_update[::-1],
- *                                              inner_input_storage[::-1]):
- */
-      if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
-        PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-        __PYX_ERR(0, 407, __pyx_L1_error)
-      }
-      __pyx_t_9 = PyList_GET_SIZE(__pyx_v_inner_output_storage); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 407, __pyx_L1_error)
-      __pyx_v_offset_out = (__pyx_t_9 - 1);
-
-      /* "aesara/scan/scan_perform.pyx":408
- *         if need_update_inputs:
- *             offset_out = len(inner_output_storage) - 1
- *             for needs_update, storage in zip(inner_input_needs_update[::-1],             # <<<<<<<<<<<<<<
- *                                              inner_input_storage[::-1]):
- *                 if needs_update:
- */
-      __pyx_t_16 = __Pyx_PyObject_GetItem(__pyx_v_inner_input_needs_update, __pyx_slice__5); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 408, __pyx_L1_error)
-      __Pyx_GOTREF(__pyx_t_16);
-
-      /* "aesara/scan/scan_perform.pyx":409
- *             offset_out = len(inner_output_storage) - 1
- *             for needs_update, storage in zip(inner_input_needs_update[::-1],
- *                                              inner_input_storage[::-1]):             # <<<<<<<<<<<<<<
- *                 if needs_update:
- *                     storage[0] = inner_output_storage[offset_out][0]
- */
-      __pyx_t_2 = __Pyx_PyObject_GetItem(__pyx_v_inner_input_storage, __pyx_slice__5); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 409, __pyx_L1_error)
-      __Pyx_GOTREF(__pyx_t_2);
-
-      /* "aesara/scan/scan_perform.pyx":408
- *         if need_update_inputs:
- *             offset_out = len(inner_output_storage) - 1
- *             for needs_update, storage in zip(inner_input_needs_update[::-1],             # <<<<<<<<<<<<<<
- *                                              inner_input_storage[::-1]):
- *                 if needs_update:
- */
-      __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 408, __pyx_L1_error)
-      __Pyx_GOTREF(__pyx_t_3);
-      __Pyx_GIVEREF(__pyx_t_16);
-      PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_16);
-      __Pyx_GIVEREF(__pyx_t_2);
-      PyTuple_SET_ITEM(__pyx_t_3, 1, __pyx_t_2);
-      __pyx_t_16 = 0;
-      __pyx_t_2 = 0;
-      __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_zip, __pyx_t_3, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 408, __pyx_L1_error)
-      __Pyx_GOTREF(__pyx_t_2);
-      __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-      if (likely(PyList_CheckExact(__pyx_t_2)) || PyTuple_CheckExact(__pyx_t_2)) {
-        __pyx_t_3 = __pyx_t_2; __Pyx_INCREF(__pyx_t_3); __pyx_t_9 = 0;
-        __pyx_t_19 = NULL;
-      } else {
-        __pyx_t_9 = -1; __pyx_t_3 = PyObject_GetIter(__pyx_t_2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 408, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_19 = Py_TYPE(__pyx_t_3)->tp_iternext; if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 408, __pyx_L1_error)
-      }
-      __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-      for (;;) {
-        if (likely(!__pyx_t_19)) {
-          if (likely(PyList_CheckExact(__pyx_t_3))) {
-            if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_3)) break;
-            #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-            __pyx_t_2 = PyList_GET_ITEM(__pyx_t_3, __pyx_t_9); __Pyx_INCREF(__pyx_t_2); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 408, __pyx_L1_error)
-            #else
-            __pyx_t_2 = PySequence_ITEM(__pyx_t_3, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 408, __pyx_L1_error)
-            __Pyx_GOTREF(__pyx_t_2);
-            #endif
-          } else {
-            if (__pyx_t_9 >= PyTuple_GET_SIZE(__pyx_t_3)) break;
-            #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-            __pyx_t_2 = PyTuple_GET_ITEM(__pyx_t_3, __pyx_t_9); __Pyx_INCREF(__pyx_t_2); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 408, __pyx_L1_error)
-            #else
-            __pyx_t_2 = PySequence_ITEM(__pyx_t_3, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 408, __pyx_L1_error)
-            __Pyx_GOTREF(__pyx_t_2);
-            #endif
-          }
-        } else {
-          __pyx_t_2 = __pyx_t_19(__pyx_t_3);
-          if (unlikely(!__pyx_t_2)) {
-            PyObject* exc_type = PyErr_Occurred();
-            if (exc_type) {
-              if (likely(__Pyx_PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-              else __PYX_ERR(0, 408, __pyx_L1_error)
-            }
-            break;
-          }
-          __Pyx_GOTREF(__pyx_t_2);
-        }
-        if ((likely(PyTuple_CheckExact(__pyx_t_2))) || (PyList_CheckExact(__pyx_t_2))) {
-          PyObject* sequence = __pyx_t_2;
-          Py_ssize_t size = __Pyx_PySequence_SIZE(sequence);
-          if (unlikely(size != 2)) {
-            if (size > 2) __Pyx_RaiseTooManyValuesError(2);
-            else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-            __PYX_ERR(0, 408, __pyx_L1_error)
-          }
-          #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-          if (likely(PyTuple_CheckExact(sequence))) {
-            __pyx_t_16 = PyTuple_GET_ITEM(sequence, 0); 
-            __pyx_t_1 = PyTuple_GET_ITEM(sequence, 1); 
-          } else {
-            __pyx_t_16 = PyList_GET_ITEM(sequence, 0); 
-            __pyx_t_1 = PyList_GET_ITEM(sequence, 1); 
-          }
-          __Pyx_INCREF(__pyx_t_16);
-          __Pyx_INCREF(__pyx_t_1);
-          #else
-          __pyx_t_16 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 408, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_16);
-          __pyx_t_1 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 408, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_1);
-          #endif
-          __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        } else {
-          Py_ssize_t index = -1;
-          __pyx_t_24 = PyObject_GetIter(__pyx_t_2); if (unlikely(!__pyx_t_24)) __PYX_ERR(0, 408, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_24);
-          __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-          __pyx_t_36 = Py_TYPE(__pyx_t_24)->tp_iternext;
-          index = 0; __pyx_t_16 = __pyx_t_36(__pyx_t_24); if (unlikely(!__pyx_t_16)) goto __pyx_L92_unpacking_failed;
-          __Pyx_GOTREF(__pyx_t_16);
-          index = 1; __pyx_t_1 = __pyx_t_36(__pyx_t_24); if (unlikely(!__pyx_t_1)) goto __pyx_L92_unpacking_failed;
-          __Pyx_GOTREF(__pyx_t_1);
-          if (__Pyx_IternextUnpackEndCheck(__pyx_t_36(__pyx_t_24), 2) < 0) __PYX_ERR(0, 408, __pyx_L1_error)
-          __pyx_t_36 = NULL;
-          __Pyx_DECREF(__pyx_t_24); __pyx_t_24 = 0;
-          goto __pyx_L93_unpacking_done;
-          __pyx_L92_unpacking_failed:;
-          __Pyx_DECREF(__pyx_t_24); __pyx_t_24 = 0;
-          __pyx_t_36 = NULL;
-          if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-          __PYX_ERR(0, 408, __pyx_L1_error)
-          __pyx_L93_unpacking_done:;
-        }
-        __Pyx_XDECREF_SET(__pyx_v_needs_update, __pyx_t_16);
-        __pyx_t_16 = 0;
-        __Pyx_XDECREF_SET(__pyx_v_storage, __pyx_t_1);
-        __pyx_t_1 = 0;
-
-        /* "aesara/scan/scan_perform.pyx":410
- *             for needs_update, storage in zip(inner_input_needs_update[::-1],
- *                                              inner_input_storage[::-1]):
- *                 if needs_update:             # <<<<<<<<<<<<<<
- *                     storage[0] = inner_output_storage[offset_out][0]
- *                     offset_out -= 1
- */
-        __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_needs_update); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 410, __pyx_L1_error)
-        if (__pyx_t_5) {
-
-          /* "aesara/scan/scan_perform.pyx":411
- *                                              inner_input_storage[::-1]):
- *                 if needs_update:
- *                     storage[0] = inner_output_storage[offset_out][0]             # <<<<<<<<<<<<<<
- *                     offset_out -= 1
- * 
- */
-          if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
-            PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 411, __pyx_L1_error)
-          }
-          __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_offset_out), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 411, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_2);
-          if (unlikely(__Pyx_SetItemInt(__pyx_v_storage, 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 411, __pyx_L1_error)
-          __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-
-          /* "aesara/scan/scan_perform.pyx":412
- *                 if needs_update:
- *                     storage[0] = inner_output_storage[offset_out][0]
- *                     offset_out -= 1             # <<<<<<<<<<<<<<
- * 
- *         offset_out = 0
- */
-          __pyx_v_offset_out = (__pyx_v_offset_out - 1);
-
-          /* "aesara/scan/scan_perform.pyx":410
- *             for needs_update, storage in zip(inner_input_needs_update[::-1],
- *                                              inner_input_storage[::-1]):
- *                 if needs_update:             # <<<<<<<<<<<<<<
- *                     storage[0] = inner_output_storage[offset_out][0]
- *                     offset_out -= 1
- */
-        }
-
-        /* "aesara/scan/scan_perform.pyx":408
- *         if need_update_inputs:
- *             offset_out = len(inner_output_storage) - 1
- *             for needs_update, storage in zip(inner_input_needs_update[::-1],             # <<<<<<<<<<<<<<
- *                                              inner_input_storage[::-1]):
- *                 if needs_update:
- */
-      }
-      __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-
-      /* "aesara/scan/scan_perform.pyx":406
- *         # function, it is possible that the updates have not been
- *         # performed. Perform the updates if needed.
- *         if need_update_inputs:             # <<<<<<<<<<<<<<
- *             offset_out = len(inner_output_storage) - 1
- *             for needs_update, storage in zip(inner_input_needs_update[::-1],
- */
-    }
-
-    /* "aesara/scan/scan_perform.pyx":414
- *                     offset_out -= 1
+    /* "aesara/scan/scan_perform.pyx":401
+ *             cond = inner_output_storage[pdx][0] == 0
  * 
  *         offset_out = 0             # <<<<<<<<<<<<<<
  * 
@@ -5457,7 +5193,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_offset_out = 0;
 
-    /* "aesara/scan/scan_perform.pyx":417
+    /* "aesara/scan/scan_perform.pyx":404
  * 
  *         # 5.3 Copy over the values for mit_mot outputs
  *         mitmot_inp_offset = 0             # <<<<<<<<<<<<<<
@@ -5467,7 +5203,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __Pyx_INCREF(__pyx_int_0);
     __Pyx_XDECREF_SET(__pyx_v_mitmot_inp_offset, __pyx_int_0);
 
-    /* "aesara/scan/scan_perform.pyx":418
+    /* "aesara/scan/scan_perform.pyx":405
  *         # 5.3 Copy over the values for mit_mot outputs
  *         mitmot_inp_offset = 0
  *         mitmot_out_idx = 0             # <<<<<<<<<<<<<<
@@ -5477,7 +5213,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __Pyx_INCREF(__pyx_int_0);
     __Pyx_XDECREF_SET(__pyx_v_mitmot_out_idx, __pyx_int_0);
 
-    /* "aesara/scan/scan_perform.pyx":419
+    /* "aesara/scan/scan_perform.pyx":406
  *         mitmot_inp_offset = 0
  *         mitmot_out_idx = 0
  *         for j in xrange(n_mit_mot):             # <<<<<<<<<<<<<<
@@ -5489,7 +5225,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_j = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":420
+      /* "aesara/scan/scan_perform.pyx":407
  *         mitmot_out_idx = 0
  *         for j in xrange(n_mit_mot):
  *             for k in mit_mot_out_slices[j]:             # <<<<<<<<<<<<<<
@@ -5498,140 +5234,149 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       if (unlikely(__pyx_v_mit_mot_out_slices == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 420, __pyx_L1_error)
+        __PYX_ERR(0, 407, __pyx_L1_error)
       }
       if (likely(PyList_CheckExact(PyTuple_GET_ITEM(__pyx_v_mit_mot_out_slices, __pyx_v_j))) || PyTuple_CheckExact(PyTuple_GET_ITEM(__pyx_v_mit_mot_out_slices, __pyx_v_j))) {
-        __pyx_t_3 = PyTuple_GET_ITEM(__pyx_v_mit_mot_out_slices, __pyx_v_j); __Pyx_INCREF(__pyx_t_3); __pyx_t_9 = 0;
+        __pyx_t_16 = PyTuple_GET_ITEM(__pyx_v_mit_mot_out_slices, __pyx_v_j); __Pyx_INCREF(__pyx_t_16); __pyx_t_9 = 0;
         __pyx_t_19 = NULL;
       } else {
-        __pyx_t_9 = -1; __pyx_t_3 = PyObject_GetIter(PyTuple_GET_ITEM(__pyx_v_mit_mot_out_slices, __pyx_v_j)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 420, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_19 = Py_TYPE(__pyx_t_3)->tp_iternext; if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 420, __pyx_L1_error)
+        __pyx_t_9 = -1; __pyx_t_16 = PyObject_GetIter(PyTuple_GET_ITEM(__pyx_v_mit_mot_out_slices, __pyx_v_j)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 407, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
+        __pyx_t_19 = Py_TYPE(__pyx_t_16)->tp_iternext; if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 407, __pyx_L1_error)
       }
       for (;;) {
         if (likely(!__pyx_t_19)) {
-          if (likely(PyList_CheckExact(__pyx_t_3))) {
-            if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_3)) break;
+          if (likely(PyList_CheckExact(__pyx_t_16))) {
+            if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_16)) break;
             #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-            __pyx_t_2 = PyList_GET_ITEM(__pyx_t_3, __pyx_t_9); __Pyx_INCREF(__pyx_t_2); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 420, __pyx_L1_error)
+            __pyx_t_2 = PyList_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_2); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 407, __pyx_L1_error)
             #else
-            __pyx_t_2 = PySequence_ITEM(__pyx_t_3, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 420, __pyx_L1_error)
+            __pyx_t_2 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 407, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_2);
             #endif
           } else {
-            if (__pyx_t_9 >= PyTuple_GET_SIZE(__pyx_t_3)) break;
+            if (__pyx_t_9 >= PyTuple_GET_SIZE(__pyx_t_16)) break;
             #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-            __pyx_t_2 = PyTuple_GET_ITEM(__pyx_t_3, __pyx_t_9); __Pyx_INCREF(__pyx_t_2); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 420, __pyx_L1_error)
+            __pyx_t_2 = PyTuple_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_2); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 407, __pyx_L1_error)
             #else
-            __pyx_t_2 = PySequence_ITEM(__pyx_t_3, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 420, __pyx_L1_error)
+            __pyx_t_2 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 407, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_2);
             #endif
           }
         } else {
-          __pyx_t_2 = __pyx_t_19(__pyx_t_3);
+          __pyx_t_2 = __pyx_t_19(__pyx_t_16);
           if (unlikely(!__pyx_t_2)) {
             PyObject* exc_type = PyErr_Occurred();
             if (exc_type) {
               if (likely(__Pyx_PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-              else __PYX_ERR(0, 420, __pyx_L1_error)
+              else __PYX_ERR(0, 407, __pyx_L1_error)
             }
             break;
           }
           __Pyx_GOTREF(__pyx_t_2);
         }
-        __pyx_t_28 = __Pyx_PyInt_As_int(__pyx_t_2); if (unlikely((__pyx_t_28 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 420, __pyx_L1_error)
+        __pyx_t_28 = __Pyx_PyInt_As_int(__pyx_t_2); if (unlikely((__pyx_t_28 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 407, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
         __pyx_v_k = __pyx_t_28;
 
-        /* "aesara/scan/scan_perform.pyx":421
+        /* "aesara/scan/scan_perform.pyx":408
  *         for j in xrange(n_mit_mot):
  *             for k in mit_mot_out_slices[j]:
  *                 if mitmots_preallocated[<unsigned int>mitmot_out_idx]:             # <<<<<<<<<<<<<<
  *                     # This output tap has been preallocated.
  *                     inp_idx = (mitmot_inp_offset + tap_array[j].index(k))
  */
-        __pyx_t_8 = __Pyx_PyInt_As_unsigned_int(__pyx_v_mitmot_out_idx); if (unlikely((__pyx_t_8 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 421, __pyx_L1_error)
+        __pyx_t_8 = __Pyx_PyInt_As_unsigned_int(__pyx_v_mitmot_out_idx); if (unlikely((__pyx_t_8 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 408, __pyx_L1_error)
         __pyx_t_13 = ((unsigned int)__pyx_t_8);
         __pyx_t_5 = ((*__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_mitmots_preallocated.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_mitmots_preallocated.diminfo[0].strides)) != 0);
         if (__pyx_t_5) {
 
-          /* "aesara/scan/scan_perform.pyx":423
+          /* "aesara/scan/scan_perform.pyx":410
  *                 if mitmots_preallocated[<unsigned int>mitmot_out_idx]:
  *                     # This output tap has been preallocated.
  *                     inp_idx = (mitmot_inp_offset + tap_array[j].index(k))             # <<<<<<<<<<<<<<
+ *                     inner_inp_idx = n_seqs + inp_idx
  * 
- *                     # Verify whether the input points to the same data as
  */
           if (unlikely(__pyx_v_tap_array == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 423, __pyx_L1_error)
+            __PYX_ERR(0, 410, __pyx_L1_error)
           }
-          __pyx_t_1 = __Pyx_PyObject_GetAttrStr(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_j), __pyx_n_s_index); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 423, __pyx_L1_error)
+          __pyx_t_3 = __Pyx_PyObject_GetAttrStr(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_j), __pyx_n_s_index); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 410, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_3);
+          __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_k); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 410, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
-          __pyx_t_16 = __Pyx_PyInt_From_int(__pyx_v_k); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 423, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_16);
           __pyx_t_24 = NULL;
-          if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_1))) {
-            __pyx_t_24 = PyMethod_GET_SELF(__pyx_t_1);
+          if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_3))) {
+            __pyx_t_24 = PyMethod_GET_SELF(__pyx_t_3);
             if (likely(__pyx_t_24)) {
-              PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_1);
+              PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_3);
               __Pyx_INCREF(__pyx_t_24);
               __Pyx_INCREF(function);
-              __Pyx_DECREF_SET(__pyx_t_1, function);
+              __Pyx_DECREF_SET(__pyx_t_3, function);
             }
           }
-          __pyx_t_2 = (__pyx_t_24) ? __Pyx_PyObject_Call2Args(__pyx_t_1, __pyx_t_24, __pyx_t_16) : __Pyx_PyObject_CallOneArg(__pyx_t_1, __pyx_t_16);
+          __pyx_t_2 = (__pyx_t_24) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_24, __pyx_t_1) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_1);
           __Pyx_XDECREF(__pyx_t_24); __pyx_t_24 = 0;
-          __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-          if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 423, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_2);
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-          __pyx_t_1 = PyNumber_Add(__pyx_v_mitmot_inp_offset, __pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 423, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_1);
+          if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 410, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_2);
+          __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+          __pyx_t_3 = PyNumber_Add(__pyx_v_mitmot_inp_offset, __pyx_t_2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 410, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_3);
           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-          __Pyx_XDECREF_SET(__pyx_v_inp_idx, __pyx_t_1);
-          __pyx_t_1 = 0;
+          __Pyx_XDECREF_SET(__pyx_v_inp_idx, __pyx_t_3);
+          __pyx_t_3 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":427
+          /* "aesara/scan/scan_perform.pyx":411
+ *                     # This output tap has been preallocated.
+ *                     inp_idx = (mitmot_inp_offset + tap_array[j].index(k))
+ *                     inner_inp_idx = n_seqs + inp_idx             # <<<<<<<<<<<<<<
+ * 
+ *                     # Verify whether the input points to the same data as
+ */
+          __pyx_t_3 = __Pyx_PyInt_From_unsigned_int(__pyx_v_n_seqs); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 411, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_3);
+          __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_v_inp_idx); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 411, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_2);
+          __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+          __Pyx_XDECREF_SET(__pyx_v_inner_inp_idx, __pyx_t_2);
+          __pyx_t_2 = 0;
+
+          /* "aesara/scan/scan_perform.pyx":415
  *                     # Verify whether the input points to the same data as
  *                     # it did before the execution of the inner function.
  *                     old_var = old_mitmot_input_storage[inp_idx]             # <<<<<<<<<<<<<<
- *                     new_var = inner_input_storage[n_seqs + inp_idx][0]
+ *                     new_var = inner_input_storage[inner_inp_idx][0]
  *                     if old_var is new_var:
  */
-          __pyx_t_1 = __Pyx_PyObject_GetItem(__pyx_v_old_mitmot_input_storage, __pyx_v_inp_idx); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 427, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_1);
-          __Pyx_XDECREF_SET(__pyx_v_old_var, __pyx_t_1);
-          __pyx_t_1 = 0;
+          __pyx_t_2 = __Pyx_PyObject_GetItem(__pyx_v_old_mitmot_input_storage, __pyx_v_inp_idx); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 415, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_2);
+          __Pyx_XDECREF_SET(__pyx_v_old_var, __pyx_t_2);
+          __pyx_t_2 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":428
+          /* "aesara/scan/scan_perform.pyx":416
  *                     # it did before the execution of the inner function.
  *                     old_var = old_mitmot_input_storage[inp_idx]
- *                     new_var = inner_input_storage[n_seqs + inp_idx][0]             # <<<<<<<<<<<<<<
+ *                     new_var = inner_input_storage[inner_inp_idx][0]             # <<<<<<<<<<<<<<
  *                     if old_var is new_var:
  *                         old_data = old_mitmot_input_data[inp_idx]
  */
           if (unlikely(__pyx_v_inner_input_storage == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 428, __pyx_L1_error)
+            __PYX_ERR(0, 416, __pyx_L1_error)
           }
-          __pyx_t_1 = __Pyx_PyInt_From_unsigned_int(__pyx_v_n_seqs); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 428, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_1);
-          __pyx_t_2 = PyNumber_Add(__pyx_t_1, __pyx_v_inp_idx); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 428, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_PyObject_GetItem(__pyx_v_inner_input_storage, __pyx_v_inner_inp_idx); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 416, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_2);
-          __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-          __pyx_t_1 = __Pyx_PyObject_GetItem(__pyx_v_inner_input_storage, __pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 428, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_1);
+          __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_2, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 416, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_3);
           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-          __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_1, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 428, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_2);
-          __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-          __Pyx_XDECREF_SET(__pyx_v_new_var, __pyx_t_2);
-          __pyx_t_2 = 0;
+          __Pyx_XDECREF_SET(__pyx_v_new_var, __pyx_t_3);
+          __pyx_t_3 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":429
+          /* "aesara/scan/scan_perform.pyx":417
  *                     old_var = old_mitmot_input_storage[inp_idx]
- *                     new_var = inner_input_storage[n_seqs + inp_idx][0]
+ *                     new_var = inner_input_storage[inner_inp_idx][0]
  *                     if old_var is new_var:             # <<<<<<<<<<<<<<
  *                         old_data = old_mitmot_input_data[inp_idx]
  *                         same_data = (new_var.data == old_data)
@@ -5640,43 +5385,43 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           __pyx_t_15 = (__pyx_t_5 != 0);
           if (__pyx_t_15) {
 
-            /* "aesara/scan/scan_perform.pyx":430
- *                     new_var = inner_input_storage[n_seqs + inp_idx][0]
+            /* "aesara/scan/scan_perform.pyx":418
+ *                     new_var = inner_input_storage[inner_inp_idx][0]
  *                     if old_var is new_var:
  *                         old_data = old_mitmot_input_data[inp_idx]             # <<<<<<<<<<<<<<
  *                         same_data = (new_var.data == old_data)
  *                     else:
  */
-            __pyx_t_2 = __Pyx_PyObject_GetItem(__pyx_v_old_mitmot_input_data, __pyx_v_inp_idx); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 430, __pyx_L1_error)
-            __Pyx_GOTREF(__pyx_t_2);
-            __Pyx_XDECREF_SET(__pyx_v_old_data, __pyx_t_2);
-            __pyx_t_2 = 0;
+            __pyx_t_3 = __Pyx_PyObject_GetItem(__pyx_v_old_mitmot_input_data, __pyx_v_inp_idx); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 418, __pyx_L1_error)
+            __Pyx_GOTREF(__pyx_t_3);
+            __Pyx_XDECREF_SET(__pyx_v_old_data, __pyx_t_3);
+            __pyx_t_3 = 0;
 
-            /* "aesara/scan/scan_perform.pyx":431
+            /* "aesara/scan/scan_perform.pyx":419
  *                     if old_var is new_var:
  *                         old_data = old_mitmot_input_data[inp_idx]
  *                         same_data = (new_var.data == old_data)             # <<<<<<<<<<<<<<
  *                     else:
  *                         same_data = False
  */
-            __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_new_var, __pyx_n_s_data); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 431, __pyx_L1_error)
-            __Pyx_GOTREF(__pyx_t_2);
-            __pyx_t_1 = PyObject_RichCompare(__pyx_t_2, __pyx_v_old_data, Py_EQ); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 431, __pyx_L1_error)
-            __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-            __Pyx_XDECREF_SET(__pyx_v_same_data, __pyx_t_1);
-            __pyx_t_1 = 0;
+            __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_new_var, __pyx_n_s_data); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 419, __pyx_L1_error)
+            __Pyx_GOTREF(__pyx_t_3);
+            __pyx_t_2 = PyObject_RichCompare(__pyx_t_3, __pyx_v_old_data, Py_EQ); __Pyx_XGOTREF(__pyx_t_2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 419, __pyx_L1_error)
+            __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+            __Pyx_XDECREF_SET(__pyx_v_same_data, __pyx_t_2);
+            __pyx_t_2 = 0;
 
-            /* "aesara/scan/scan_perform.pyx":429
+            /* "aesara/scan/scan_perform.pyx":417
  *                     old_var = old_mitmot_input_storage[inp_idx]
- *                     new_var = inner_input_storage[n_seqs + inp_idx][0]
+ *                     new_var = inner_input_storage[inner_inp_idx][0]
  *                     if old_var is new_var:             # <<<<<<<<<<<<<<
  *                         old_data = old_mitmot_input_data[inp_idx]
  *                         same_data = (new_var.data == old_data)
  */
-            goto __pyx_L100;
+            goto __pyx_L94;
           }
 
-          /* "aesara/scan/scan_perform.pyx":433
+          /* "aesara/scan/scan_perform.pyx":421
  *                         same_data = (new_var.data == old_data)
  *                     else:
  *                         same_data = False             # <<<<<<<<<<<<<<
@@ -5687,142 +5432,128 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
             __Pyx_INCREF(Py_False);
             __Pyx_XDECREF_SET(__pyx_v_same_data, Py_False);
           }
-          __pyx_L100:;
+          __pyx_L94:;
 
-          /* "aesara/scan/scan_perform.pyx":438
+          /* "aesara/scan/scan_perform.pyx":426
  *                     # recover the value as usual. Otherwise, the input was
  *                     # modified inplace and nothing needs to be done.
  *                     if not same_data:             # <<<<<<<<<<<<<<
  *                         outer_outputs[j][0][<unsigned int>(k + pos[j])] = \
- *                             inner_input_storage[<unsigned int>(n_seqs + inp_idx)][0]
+ *                             inner_input_storage[<unsigned int>(inner_inp_idx)][0]
  */
-          __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_v_same_data); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 438, __pyx_L1_error)
+          __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_v_same_data); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 426, __pyx_L1_error)
           __pyx_t_5 = ((!__pyx_t_15) != 0);
           if (__pyx_t_5) {
 
-            /* "aesara/scan/scan_perform.pyx":440
+            /* "aesara/scan/scan_perform.pyx":428
  *                     if not same_data:
  *                         outer_outputs[j][0][<unsigned int>(k + pos[j])] = \
- *                             inner_input_storage[<unsigned int>(n_seqs + inp_idx)][0]             # <<<<<<<<<<<<<<
+ *                             inner_input_storage[<unsigned int>(inner_inp_idx)][0]             # <<<<<<<<<<<<<<
  * 
  *                 else:
  */
             if (unlikely(__pyx_v_inner_input_storage == Py_None)) {
               PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-              __PYX_ERR(0, 440, __pyx_L1_error)
+              __PYX_ERR(0, 428, __pyx_L1_error)
             }
-            __pyx_t_1 = __Pyx_PyInt_From_unsigned_int(__pyx_v_n_seqs); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 440, __pyx_L1_error)
-            __Pyx_GOTREF(__pyx_t_1);
-            __pyx_t_2 = PyNumber_Add(__pyx_t_1, __pyx_v_inp_idx); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 440, __pyx_L1_error)
-            __Pyx_GOTREF(__pyx_t_2);
-            __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-            __pyx_t_8 = __Pyx_PyInt_As_unsigned_int(__pyx_t_2); if (unlikely((__pyx_t_8 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 440, __pyx_L1_error)
-            __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-            __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, ((unsigned int)__pyx_t_8)), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 440, __pyx_L1_error)
+            __pyx_t_8 = __Pyx_PyInt_As_unsigned_int(__pyx_v_inner_inp_idx); if (unlikely((__pyx_t_8 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 428, __pyx_L1_error)
+            __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, ((unsigned int)__pyx_t_8)), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 428, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_2);
 
-            /* "aesara/scan/scan_perform.pyx":439
+            /* "aesara/scan/scan_perform.pyx":427
  *                     # modified inplace and nothing needs to be done.
  *                     if not same_data:
  *                         outer_outputs[j][0][<unsigned int>(k + pos[j])] = \             # <<<<<<<<<<<<<<
- *                             inner_input_storage[<unsigned int>(n_seqs + inp_idx)][0]
+ *                             inner_input_storage[<unsigned int>(inner_inp_idx)][0]
  * 
  */
             if (unlikely(__pyx_v_outer_outputs == Py_None)) {
               PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-              __PYX_ERR(0, 439, __pyx_L1_error)
+              __PYX_ERR(0, 427, __pyx_L1_error)
             }
-            __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 439, __pyx_L1_error)
-            __Pyx_GOTREF(__pyx_t_1);
+            __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 427, __pyx_L1_error)
+            __Pyx_GOTREF(__pyx_t_3);
             __pyx_t_8 = ((unsigned int)(__pyx_v_k + (__pyx_v_pos[__pyx_v_j])));
-            if (unlikely(__Pyx_SetItemInt(__pyx_t_1, __pyx_t_8, __pyx_t_2, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 439, __pyx_L1_error)
-            __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+            if (unlikely(__Pyx_SetItemInt(__pyx_t_3, __pyx_t_8, __pyx_t_2, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 427, __pyx_L1_error)
+            __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
             __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-            /* "aesara/scan/scan_perform.pyx":438
+            /* "aesara/scan/scan_perform.pyx":426
  *                     # recover the value as usual. Otherwise, the input was
  *                     # modified inplace and nothing needs to be done.
  *                     if not same_data:             # <<<<<<<<<<<<<<
  *                         outer_outputs[j][0][<unsigned int>(k + pos[j])] = \
- *                             inner_input_storage[<unsigned int>(n_seqs + inp_idx)][0]
+ *                             inner_input_storage[<unsigned int>(inner_inp_idx)][0]
  */
           }
 
-          /* "aesara/scan/scan_perform.pyx":421
+          /* "aesara/scan/scan_perform.pyx":408
  *         for j in xrange(n_mit_mot):
  *             for k in mit_mot_out_slices[j]:
  *                 if mitmots_preallocated[<unsigned int>mitmot_out_idx]:             # <<<<<<<<<<<<<<
  *                     # This output tap has been preallocated.
  *                     inp_idx = (mitmot_inp_offset + tap_array[j].index(k))
  */
-          goto __pyx_L99;
+          goto __pyx_L93;
         }
 
-        /* "aesara/scan/scan_perform.pyx":445
- *                     # This output tap has not been preallocated, recover
- *                     # its value as usual
- *                     outer_outputs[j][0][<unsigned int>(k + pos[j])] = \             # <<<<<<<<<<<<<<
- *                             inner_output_storage[<unsigned int>offset_out][0]
- *                     offset_out += 1
- */
-        /*else*/ {
-
-          /* "aesara/scan/scan_perform.pyx":446
+        /* "aesara/scan/scan_perform.pyx":434
  *                     # its value as usual
  *                     outer_outputs[j][0][<unsigned int>(k + pos[j])] = \
  *                             inner_output_storage[<unsigned int>offset_out][0]             # <<<<<<<<<<<<<<
- *                     offset_out += 1
  * 
+ *                 offset_out += 1
  */
+        /*else*/ {
           if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 446, __pyx_L1_error)
+            __PYX_ERR(0, 434, __pyx_L1_error)
           }
-          __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, ((unsigned int)__pyx_v_offset_out)), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 446, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, ((unsigned int)__pyx_v_offset_out)), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 434, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_2);
 
-          /* "aesara/scan/scan_perform.pyx":445
+          /* "aesara/scan/scan_perform.pyx":433
  *                     # This output tap has not been preallocated, recover
  *                     # its value as usual
  *                     outer_outputs[j][0][<unsigned int>(k + pos[j])] = \             # <<<<<<<<<<<<<<
  *                             inner_output_storage[<unsigned int>offset_out][0]
- *                     offset_out += 1
+ * 
  */
           if (unlikely(__pyx_v_outer_outputs == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 445, __pyx_L1_error)
+            __PYX_ERR(0, 433, __pyx_L1_error)
           }
-          __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 445, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_1);
+          __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 433, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_3);
           __pyx_t_8 = ((unsigned int)(__pyx_v_k + (__pyx_v_pos[__pyx_v_j])));
-          if (unlikely(__Pyx_SetItemInt(__pyx_t_1, __pyx_t_8, __pyx_t_2, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 445, __pyx_L1_error)
-          __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+          if (unlikely(__Pyx_SetItemInt(__pyx_t_3, __pyx_t_8, __pyx_t_2, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 433, __pyx_L1_error)
+          __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-
-          /* "aesara/scan/scan_perform.pyx":447
- *                     outer_outputs[j][0][<unsigned int>(k + pos[j])] = \
- *                             inner_output_storage[<unsigned int>offset_out][0]
- *                     offset_out += 1             # <<<<<<<<<<<<<<
- * 
- *                 mitmot_out_idx += 1
- */
-          __pyx_v_offset_out = (__pyx_v_offset_out + 1);
         }
-        __pyx_L99:;
+        __pyx_L93:;
 
-        /* "aesara/scan/scan_perform.pyx":449
- *                     offset_out += 1
+        /* "aesara/scan/scan_perform.pyx":436
+ *                             inner_output_storage[<unsigned int>offset_out][0]
  * 
+ *                 offset_out += 1             # <<<<<<<<<<<<<<
+ *                 mitmot_out_idx += 1
+ * 
+ */
+        __pyx_v_offset_out = (__pyx_v_offset_out + 1);
+
+        /* "aesara/scan/scan_perform.pyx":437
+ * 
+ *                 offset_out += 1
  *                 mitmot_out_idx += 1             # <<<<<<<<<<<<<<
  * 
  *             mitmot_inp_offset += tap_array_len[j]
  */
-        __pyx_t_2 = __Pyx_PyInt_AddObjC(__pyx_v_mitmot_out_idx, __pyx_int_1, 1, 1, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 449, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyInt_AddObjC(__pyx_v_mitmot_out_idx, __pyx_int_1, 1, 1, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 437, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
         __Pyx_DECREF_SET(__pyx_v_mitmot_out_idx, __pyx_t_2);
         __pyx_t_2 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":420
+        /* "aesara/scan/scan_perform.pyx":407
  *         mitmot_out_idx = 0
  *         for j in xrange(n_mit_mot):
  *             for k in mit_mot_out_slices[j]:             # <<<<<<<<<<<<<<
@@ -5830,9 +5561,9 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *                     # This output tap has been preallocated.
  */
       }
-      __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+      __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":451
+      /* "aesara/scan/scan_perform.pyx":439
  *                 mitmot_out_idx += 1
  * 
  *             mitmot_inp_offset += tap_array_len[j]             # <<<<<<<<<<<<<<
@@ -5841,15 +5572,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       if (unlikely(__pyx_v_tap_array_len == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 451, __pyx_L1_error)
+        __PYX_ERR(0, 439, __pyx_L1_error)
       }
-      __pyx_t_3 = PyNumber_InPlaceAdd(__pyx_v_mitmot_inp_offset, PyTuple_GET_ITEM(__pyx_v_tap_array_len, __pyx_v_j)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 451, __pyx_L1_error)
-      __Pyx_GOTREF(__pyx_t_3);
-      __Pyx_DECREF_SET(__pyx_v_mitmot_inp_offset, __pyx_t_3);
-      __pyx_t_3 = 0;
+      __pyx_t_16 = PyNumber_InPlaceAdd(__pyx_v_mitmot_inp_offset, PyTuple_GET_ITEM(__pyx_v_tap_array_len, __pyx_v_j)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 439, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_16);
+      __Pyx_DECREF_SET(__pyx_v_mitmot_inp_offset, __pyx_t_16);
+      __pyx_t_16 = 0;
     }
 
-    /* "aesara/scan/scan_perform.pyx":454
+    /* "aesara/scan/scan_perform.pyx":442
  * 
  *         # 5.4 Copy over the values for mit_sot/sit_sot outputs
  *         begin = n_mit_mot             # <<<<<<<<<<<<<<
@@ -5858,7 +5589,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_begin = __pyx_v_n_mit_mot;
 
-    /* "aesara/scan/scan_perform.pyx":455
+    /* "aesara/scan/scan_perform.pyx":443
  *         # 5.4 Copy over the values for mit_sot/sit_sot outputs
  *         begin = n_mit_mot
  *         end   = n_outs             # <<<<<<<<<<<<<<
@@ -5867,7 +5598,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_end = __pyx_v_n_outs;
 
-    /* "aesara/scan/scan_perform.pyx":456
+    /* "aesara/scan/scan_perform.pyx":444
  *         begin = n_mit_mot
  *         end   = n_outs
  *         offset_out -= n_mit_mot             # <<<<<<<<<<<<<<
@@ -5876,7 +5607,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_offset_out = (__pyx_v_offset_out - __pyx_v_n_mit_mot);
 
-    /* "aesara/scan/scan_perform.pyx":458
+    /* "aesara/scan/scan_perform.pyx":446
  *         offset_out -= n_mit_mot
  * 
  *         for j in range(begin, end):             # <<<<<<<<<<<<<<
@@ -5888,7 +5619,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = __pyx_v_begin; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_j = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":461
+      /* "aesara/scan/scan_perform.pyx":449
  * 
  *             # Copy the output value to `outer_outputs`, if necessary
  *             if store_steps[j] == 1 or vector_outs[j] == 1:             # <<<<<<<<<<<<<<
@@ -5899,15 +5630,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       if (!__pyx_t_15) {
       } else {
         __pyx_t_5 = __pyx_t_15;
-        goto __pyx_L105_bool_binop_done;
+        goto __pyx_L99_bool_binop_done;
       }
       __pyx_t_13 = __pyx_v_j;
       __pyx_t_15 = (((*__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_vector_outs.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_vector_outs.diminfo[0].strides)) == 1) != 0);
       __pyx_t_5 = __pyx_t_15;
-      __pyx_L105_bool_binop_done:;
+      __pyx_L99_bool_binop_done:;
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":462
+        /* "aesara/scan/scan_perform.pyx":450
  *             # Copy the output value to `outer_outputs`, if necessary
  *             if store_steps[j] == 1 or vector_outs[j] == 1:
  *                 outer_outputs[j][0][pos[j]] = inner_output_storage[<unsigned int>(offset_out+j)][0]             # <<<<<<<<<<<<<<
@@ -5916,32 +5647,32 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 462, __pyx_L1_error)
+          __PYX_ERR(0, 450, __pyx_L1_error)
         }
         __pyx_t_8 = ((unsigned int)(__pyx_v_offset_out + __pyx_v_j));
-        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 462, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 450, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 462, __pyx_L1_error)
+          __PYX_ERR(0, 450, __pyx_L1_error)
         }
-        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 462, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 450, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        if (unlikely(__Pyx_SetItemInt(__pyx_t_2, (__pyx_v_pos[__pyx_v_j]), __pyx_t_3, int, 1, __Pyx_PyInt_From_int, 0, 1, 0) < 0)) __PYX_ERR(0, 462, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_t_2, (__pyx_v_pos[__pyx_v_j]), __pyx_t_16, int, 1, __Pyx_PyInt_From_int, 0, 1, 0) < 0)) __PYX_ERR(0, 450, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":461
+        /* "aesara/scan/scan_perform.pyx":449
  * 
  *             # Copy the output value to `outer_outputs`, if necessary
  *             if store_steps[j] == 1 or vector_outs[j] == 1:             # <<<<<<<<<<<<<<
  *                 outer_outputs[j][0][pos[j]] = inner_output_storage[<unsigned int>(offset_out+j)][0]
  *             else:
  */
-        goto __pyx_L104;
+        goto __pyx_L98;
       }
 
-      /* "aesara/scan/scan_perform.pyx":466
+      /* "aesara/scan/scan_perform.pyx":454
  *                 # Check whether the initialization of the output storage map
  *                 # for this output has been reused.
  *                 old_var = old_output_storage[offset_out + j]             # <<<<<<<<<<<<<<
@@ -5950,12 +5681,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       /*else*/ {
         __pyx_t_8 = (__pyx_v_offset_out + __pyx_v_j);
-        __pyx_t_3 = PyList_GET_ITEM(__pyx_v_old_output_storage, __pyx_t_8);
-        __Pyx_INCREF(__pyx_t_3);
-        __Pyx_XDECREF_SET(__pyx_v_old_var, __pyx_t_3);
-        __pyx_t_3 = 0;
+        __pyx_t_16 = PyList_GET_ITEM(__pyx_v_old_output_storage, __pyx_t_8);
+        __Pyx_INCREF(__pyx_t_16);
+        __Pyx_XDECREF_SET(__pyx_v_old_var, __pyx_t_16);
+        __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":467
+        /* "aesara/scan/scan_perform.pyx":455
  *                 # for this output has been reused.
  *                 old_var = old_output_storage[offset_out + j]
  *                 old_data = old_output_data[offset_out + j]             # <<<<<<<<<<<<<<
@@ -5963,12 +5694,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *                 if old_var is new_var:
  */
         __pyx_t_8 = (__pyx_v_offset_out + __pyx_v_j);
-        __pyx_t_3 = PyList_GET_ITEM(__pyx_v_old_output_data, __pyx_t_8);
-        __Pyx_INCREF(__pyx_t_3);
-        __Pyx_XDECREF_SET(__pyx_v_old_data, __pyx_t_3);
-        __pyx_t_3 = 0;
+        __pyx_t_16 = PyList_GET_ITEM(__pyx_v_old_output_data, __pyx_t_8);
+        __Pyx_INCREF(__pyx_t_16);
+        __Pyx_XDECREF_SET(__pyx_v_old_data, __pyx_t_16);
+        __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":468
+        /* "aesara/scan/scan_perform.pyx":456
  *                 old_var = old_output_storage[offset_out + j]
  *                 old_data = old_output_data[offset_out + j]
  *                 new_var = inner_output_storage[offset_out + j][0]             # <<<<<<<<<<<<<<
@@ -5977,15 +5708,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 468, __pyx_L1_error)
+          __PYX_ERR(0, 456, __pyx_L1_error)
         }
         __pyx_t_8 = (__pyx_v_offset_out + __pyx_v_j);
-        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 468, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
-        __Pyx_XDECREF_SET(__pyx_v_new_var, __pyx_t_3);
-        __pyx_t_3 = 0;
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 456, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
+        __Pyx_XDECREF_SET(__pyx_v_new_var, __pyx_t_16);
+        __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":469
+        /* "aesara/scan/scan_perform.pyx":457
  *                 old_data = old_output_data[offset_out + j]
  *                 new_var = inner_output_storage[offset_out + j][0]
  *                 if old_var is new_var:             # <<<<<<<<<<<<<<
@@ -5996,7 +5727,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_t_15 = (__pyx_t_5 != 0);
         if (__pyx_t_15) {
 
-          /* "aesara/scan/scan_perform.pyx":470
+          /* "aesara/scan/scan_perform.pyx":458
  *                 new_var = inner_output_storage[offset_out + j][0]
  *                 if old_var is new_var:
  *                     if old_data is None:             # <<<<<<<<<<<<<<
@@ -6007,7 +5738,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           __pyx_t_5 = (__pyx_t_15 != 0);
           if (__pyx_t_5) {
 
-            /* "aesara/scan/scan_perform.pyx":471
+            /* "aesara/scan/scan_perform.pyx":459
  *                 if old_var is new_var:
  *                     if old_data is None:
  *                         output_reused = False             # <<<<<<<<<<<<<<
@@ -6017,17 +5748,17 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
             __Pyx_INCREF(Py_False);
             __Pyx_XDECREF_SET(__pyx_v_output_reused, Py_False);
 
-            /* "aesara/scan/scan_perform.pyx":470
+            /* "aesara/scan/scan_perform.pyx":458
  *                 new_var = inner_output_storage[offset_out + j][0]
  *                 if old_var is new_var:
  *                     if old_data is None:             # <<<<<<<<<<<<<<
  *                         output_reused = False
  *                     else:
  */
-            goto __pyx_L108;
+            goto __pyx_L102;
           }
 
-          /* "aesara/scan/scan_perform.pyx":473
+          /* "aesara/scan/scan_perform.pyx":461
  *                         output_reused = False
  *                     else:
  *                         output_reused = (new_var.data == old_data)             # <<<<<<<<<<<<<<
@@ -6035,26 +5766,26 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *                     output_reused = False
  */
           /*else*/ {
-            __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_new_var, __pyx_n_s_data); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 473, __pyx_L1_error)
-            __Pyx_GOTREF(__pyx_t_3);
-            __pyx_t_2 = PyObject_RichCompare(__pyx_t_3, __pyx_v_old_data, Py_EQ); __Pyx_XGOTREF(__pyx_t_2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 473, __pyx_L1_error)
-            __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+            __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_v_new_var, __pyx_n_s_data); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 461, __pyx_L1_error)
+            __Pyx_GOTREF(__pyx_t_16);
+            __pyx_t_2 = PyObject_RichCompare(__pyx_t_16, __pyx_v_old_data, Py_EQ); __Pyx_XGOTREF(__pyx_t_2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 461, __pyx_L1_error)
+            __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
             __Pyx_XDECREF_SET(__pyx_v_output_reused, __pyx_t_2);
             __pyx_t_2 = 0;
           }
-          __pyx_L108:;
+          __pyx_L102:;
 
-          /* "aesara/scan/scan_perform.pyx":469
+          /* "aesara/scan/scan_perform.pyx":457
  *                 old_data = old_output_data[offset_out + j]
  *                 new_var = inner_output_storage[offset_out + j][0]
  *                 if old_var is new_var:             # <<<<<<<<<<<<<<
  *                     if old_data is None:
  *                         output_reused = False
  */
-          goto __pyx_L107;
+          goto __pyx_L101;
         }
 
-        /* "aesara/scan/scan_perform.pyx":475
+        /* "aesara/scan/scan_perform.pyx":463
  *                         output_reused = (new_var.data == old_data)
  *                 else:
  *                     output_reused = False             # <<<<<<<<<<<<<<
@@ -6065,20 +5796,20 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           __Pyx_INCREF(Py_False);
           __Pyx_XDECREF_SET(__pyx_v_output_reused, Py_False);
         }
-        __pyx_L107:;
+        __pyx_L101:;
 
-        /* "aesara/scan/scan_perform.pyx":477
+        /* "aesara/scan/scan_perform.pyx":465
  *                     output_reused = False
  * 
  *                 if not output_reused:             # <<<<<<<<<<<<<<
  *                     outer_outputs[j][0][pos[j]] = \
  *                         inner_output_storage[<unsigned int>(offset_out+j)][0]
  */
-        __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_output_reused); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 477, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_v_output_reused); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 465, __pyx_L1_error)
         __pyx_t_15 = ((!__pyx_t_5) != 0);
         if (__pyx_t_15) {
 
-          /* "aesara/scan/scan_perform.pyx":479
+          /* "aesara/scan/scan_perform.pyx":467
  *                 if not output_reused:
  *                     outer_outputs[j][0][pos[j]] = \
  *                         inner_output_storage[<unsigned int>(offset_out+j)][0]             # <<<<<<<<<<<<<<
@@ -6087,13 +5818,13 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 479, __pyx_L1_error)
+            __PYX_ERR(0, 467, __pyx_L1_error)
           }
           __pyx_t_8 = ((unsigned int)(__pyx_v_offset_out + __pyx_v_j));
-          __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 479, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 467, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_2);
 
-          /* "aesara/scan/scan_perform.pyx":478
+          /* "aesara/scan/scan_perform.pyx":466
  * 
  *                 if not output_reused:
  *                     outer_outputs[j][0][pos[j]] = \             # <<<<<<<<<<<<<<
@@ -6102,15 +5833,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           if (unlikely(__pyx_v_outer_outputs == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 478, __pyx_L1_error)
+            __PYX_ERR(0, 466, __pyx_L1_error)
           }
-          __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 478, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_3);
-          if (unlikely(__Pyx_SetItemInt(__pyx_t_3, (__pyx_v_pos[__pyx_v_j]), __pyx_t_2, int, 1, __Pyx_PyInt_From_int, 0, 1, 0) < 0)) __PYX_ERR(0, 478, __pyx_L1_error)
-          __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+          __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 466, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_16);
+          if (unlikely(__Pyx_SetItemInt(__pyx_t_16, (__pyx_v_pos[__pyx_v_j]), __pyx_t_2, int, 1, __Pyx_PyInt_From_int, 0, 1, 0) < 0)) __PYX_ERR(0, 466, __pyx_L1_error)
+          __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":477
+          /* "aesara/scan/scan_perform.pyx":465
  *                     output_reused = False
  * 
  *                 if not output_reused:             # <<<<<<<<<<<<<<
@@ -6119,10 +5850,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         }
       }
-      __pyx_L104:;
+      __pyx_L98:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":483
+    /* "aesara/scan/scan_perform.pyx":471
  * 
  *         # 5.5 Copy over the values for nit_sot outputs
  *         begin  = end             # <<<<<<<<<<<<<<
@@ -6131,7 +5862,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_begin = __pyx_v_end;
 
-    /* "aesara/scan/scan_perform.pyx":484
+    /* "aesara/scan/scan_perform.pyx":472
  *         # 5.5 Copy over the values for nit_sot outputs
  *         begin  = end
  *         end   += n_nit_sot             # <<<<<<<<<<<<<<
@@ -6140,7 +5871,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_end = (__pyx_v_end + __pyx_v_n_nit_sot);
 
-    /* "aesara/scan/scan_perform.pyx":485
+    /* "aesara/scan/scan_perform.pyx":473
  *         begin  = end
  *         end   += n_nit_sot
  *         for j in range(begin,end):             # <<<<<<<<<<<<<<
@@ -6152,7 +5883,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = __pyx_v_begin; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_j = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":487
+      /* "aesara/scan/scan_perform.pyx":475
  *         for j in range(begin,end):
  * 
  *             if i == 0:             # <<<<<<<<<<<<<<
@@ -6162,7 +5893,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_15 = ((__pyx_v_i == 0) != 0);
       if (__pyx_t_15) {
 
-        /* "aesara/scan/scan_perform.pyx":488
+        /* "aesara/scan/scan_perform.pyx":476
  * 
  *             if i == 0:
  *                 jout = j+offset_out             # <<<<<<<<<<<<<<
@@ -6171,37 +5902,37 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         __pyx_v_jout = (__pyx_v_j + __pyx_v_offset_out);
 
-        /* "aesara/scan/scan_perform.pyx":489
+        /* "aesara/scan/scan_perform.pyx":477
  *             if i == 0:
  *                 jout = j+offset_out
  *                 shape = (store_steps[j],) + inner_output_storage[jout][0].shape             # <<<<<<<<<<<<<<
  *                 dtype = inner_output_storage[jout][0].dtype
  *                 if (outer_outputs[j][0] is None or
  */
-        __pyx_t_2 = __Pyx_PyInt_From_int((__pyx_v_store_steps[__pyx_v_j])); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 489, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyInt_From_int((__pyx_v_store_steps[__pyx_v_j])); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 477, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 489, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
+        __pyx_t_16 = PyTuple_New(1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 477, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
         __Pyx_GIVEREF(__pyx_t_2);
-        PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_2);
+        PyTuple_SET_ITEM(__pyx_t_16, 0, __pyx_t_2);
         __pyx_t_2 = 0;
         if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 489, __pyx_L1_error)
+          __PYX_ERR(0, 477, __pyx_L1_error)
         }
-        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 489, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 477, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_shape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 489, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_1);
+        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_shape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 477, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        __pyx_t_2 = PyNumber_Add(__pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 489, __pyx_L1_error)
+        __pyx_t_2 = PyNumber_Add(__pyx_t_16, __pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 477, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __Pyx_XDECREF_SET(__pyx_v_shape, __pyx_t_2);
         __pyx_t_2 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":490
+        /* "aesara/scan/scan_perform.pyx":478
  *                 jout = j+offset_out
  *                 shape = (store_steps[j],) + inner_output_storage[jout][0].shape
  *                 dtype = inner_output_storage[jout][0].dtype             # <<<<<<<<<<<<<<
@@ -6210,17 +5941,17 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 490, __pyx_L1_error)
+          __PYX_ERR(0, 478, __pyx_L1_error)
         }
-        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 490, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 478, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dtype); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 490, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_1);
+        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_dtype); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 478, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        __Pyx_XDECREF_SET(__pyx_v_dtype, __pyx_t_1);
-        __pyx_t_1 = 0;
+        __Pyx_XDECREF_SET(__pyx_v_dtype, __pyx_t_3);
+        __pyx_t_3 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":491
+        /* "aesara/scan/scan_perform.pyx":479
  *                 shape = (store_steps[j],) + inner_output_storage[jout][0].shape
  *                 dtype = inner_output_storage[jout][0].dtype
  *                 if (outer_outputs[j][0] is None or             # <<<<<<<<<<<<<<
@@ -6229,20 +5960,20 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 491, __pyx_L1_error)
+          __PYX_ERR(0, 479, __pyx_L1_error)
         }
-        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 491, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_5 = (__pyx_t_1 == Py_None);
-        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 479, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
+        __pyx_t_5 = (__pyx_t_3 == Py_None);
+        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         __pyx_t_14 = (__pyx_t_5 != 0);
         if (!__pyx_t_14) {
         } else {
           __pyx_t_15 = __pyx_t_14;
-          goto __pyx_L114_bool_binop_done;
+          goto __pyx_L108_bool_binop_done;
         }
 
-        /* "aesara/scan/scan_perform.pyx":492
+        /* "aesara/scan/scan_perform.pyx":480
  *                 dtype = inner_output_storage[jout][0].dtype
  *                 if (outer_outputs[j][0] is None or
  *                         outer_outputs[j][0].shape[0] < store_steps[j] or             # <<<<<<<<<<<<<<
@@ -6251,30 +5982,30 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 492, __pyx_L1_error)
+          __PYX_ERR(0, 480, __pyx_L1_error)
         }
-        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 492, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 492, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 480, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
+        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 480, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_2, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 492, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_1);
-        __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        __pyx_t_2 = __Pyx_PyInt_From_int((__pyx_v_store_steps[__pyx_v_j])); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 492, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_3 = PyObject_RichCompare(__pyx_t_1, __pyx_t_2, Py_LT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 492, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        __pyx_t_14 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_14 < 0)) __PYX_ERR(0, 492, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_2, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 480, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
+        __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+        __pyx_t_2 = __Pyx_PyInt_From_int((__pyx_v_store_steps[__pyx_v_j])); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 480, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_2);
+        __pyx_t_16 = PyObject_RichCompare(__pyx_t_3, __pyx_t_2, Py_LT); __Pyx_XGOTREF(__pyx_t_16); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 480, __pyx_L1_error)
+        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+        __pyx_t_14 = __Pyx_PyObject_IsTrue(__pyx_t_16); if (unlikely(__pyx_t_14 < 0)) __PYX_ERR(0, 480, __pyx_L1_error)
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         if (!__pyx_t_14) {
         } else {
           __pyx_t_15 = __pyx_t_14;
-          goto __pyx_L114_bool_binop_done;
+          goto __pyx_L108_bool_binop_done;
         }
 
-        /* "aesara/scan/scan_perform.pyx":493
+        /* "aesara/scan/scan_perform.pyx":481
  *                 if (outer_outputs[j][0] is None or
  *                         outer_outputs[j][0].shape[0] < store_steps[j] or
  *                         outer_outputs[j][0].shape[1:] != shape[1:] or             # <<<<<<<<<<<<<<
@@ -6283,30 +6014,30 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 493, __pyx_L1_error)
+          __PYX_ERR(0, 481, __pyx_L1_error)
         }
-        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 493, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 493, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 481, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
+        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_16, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 481, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-        __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_t_2, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 493, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
+        __pyx_t_16 = __Pyx_PyObject_GetSlice(__pyx_t_2, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 481, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_v_shape, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 493, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_v_shape, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 481, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_1 = PyObject_RichCompare(__pyx_t_3, __pyx_t_2, Py_NE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 493, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __pyx_t_3 = PyObject_RichCompare(__pyx_t_16, __pyx_t_2, Py_NE); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 481, __pyx_L1_error)
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        __pyx_t_14 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_14 < 0)) __PYX_ERR(0, 493, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+        __pyx_t_14 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_14 < 0)) __PYX_ERR(0, 481, __pyx_L1_error)
+        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         if (!__pyx_t_14) {
         } else {
           __pyx_t_15 = __pyx_t_14;
-          goto __pyx_L114_bool_binop_done;
+          goto __pyx_L108_bool_binop_done;
         }
 
-        /* "aesara/scan/scan_perform.pyx":494
+        /* "aesara/scan/scan_perform.pyx":482
  *                         outer_outputs[j][0].shape[0] < store_steps[j] or
  *                         outer_outputs[j][0].shape[1:] != shape[1:] or
  *                         outer_outputs[j][0].dtype != dtype ):             # <<<<<<<<<<<<<<
@@ -6315,21 +6046,21 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 494, __pyx_L1_error)
+          __PYX_ERR(0, 482, __pyx_L1_error)
         }
-        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 494, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_dtype); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 494, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 482, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
+        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_dtype); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 482, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_1 = PyObject_RichCompare(__pyx_t_2, __pyx_v_dtype, Py_NE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 494, __pyx_L1_error)
+        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __pyx_t_3 = PyObject_RichCompare(__pyx_t_2, __pyx_v_dtype, Py_NE); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 482, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        __pyx_t_14 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_14 < 0)) __PYX_ERR(0, 494, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+        __pyx_t_14 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_14 < 0)) __PYX_ERR(0, 482, __pyx_L1_error)
+        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         __pyx_t_15 = __pyx_t_14;
-        __pyx_L114_bool_binop_done:;
+        __pyx_L108_bool_binop_done:;
 
-        /* "aesara/scan/scan_perform.pyx":491
+        /* "aesara/scan/scan_perform.pyx":479
  *                 shape = (store_steps[j],) + inner_output_storage[jout][0].shape
  *                 dtype = inner_output_storage[jout][0].dtype
  *                 if (outer_outputs[j][0] is None or             # <<<<<<<<<<<<<<
@@ -6338,53 +6069,53 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (__pyx_t_15) {
 
-          /* "aesara/scan/scan_perform.pyx":495
+          /* "aesara/scan/scan_perform.pyx":483
  *                         outer_outputs[j][0].shape[1:] != shape[1:] or
  *                         outer_outputs[j][0].dtype != dtype ):
  *                     outer_outputs[j][0] = numpy.empty(shape, dtype=outer_output_dtypes[j])             # <<<<<<<<<<<<<<
  *                 elif outer_outputs[j][0].shape[0] != store_steps[j]:
  *                     outer_outputs[j][0] = outer_outputs[j][0][:store_steps[j]]
  */
-          __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_numpy); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 495, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_1);
-          __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_empty); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 495, __pyx_L1_error)
+          __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 483, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_3);
+          __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_empty); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 483, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_2);
-          __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 495, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_1);
+          __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+          __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 483, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_3);
           __Pyx_INCREF(__pyx_v_shape);
           __Pyx_GIVEREF(__pyx_v_shape);
-          PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_v_shape);
-          __pyx_t_3 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 495, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_3);
+          PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_v_shape);
+          __pyx_t_16 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 483, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_16);
           if (unlikely(__pyx_v_outer_output_dtypes == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 495, __pyx_L1_error)
+            __PYX_ERR(0, 483, __pyx_L1_error)
           }
-          if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, PyTuple_GET_ITEM(__pyx_v_outer_output_dtypes, __pyx_v_j)) < 0) __PYX_ERR(0, 495, __pyx_L1_error)
-          __pyx_t_16 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 495, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_16);
+          if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_dtype, PyTuple_GET_ITEM(__pyx_v_outer_output_dtypes, __pyx_v_j)) < 0) __PYX_ERR(0, 483, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_16); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 483, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_1);
           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-          __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+          __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
           if (unlikely(__pyx_v_outer_outputs == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 495, __pyx_L1_error)
+            __PYX_ERR(0, 483, __pyx_L1_error)
           }
-          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 495, __pyx_L1_error)
-          __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
+          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, __pyx_t_1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 483, __pyx_L1_error)
+          __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":491
+          /* "aesara/scan/scan_perform.pyx":479
  *                 shape = (store_steps[j],) + inner_output_storage[jout][0].shape
  *                 dtype = inner_output_storage[jout][0].dtype
  *                 if (outer_outputs[j][0] is None or             # <<<<<<<<<<<<<<
  *                         outer_outputs[j][0].shape[0] < store_steps[j] or
  *                         outer_outputs[j][0].shape[1:] != shape[1:] or
  */
-          goto __pyx_L113;
+          goto __pyx_L107;
         }
 
-        /* "aesara/scan/scan_perform.pyx":496
+        /* "aesara/scan/scan_perform.pyx":484
  *                         outer_outputs[j][0].dtype != dtype ):
  *                     outer_outputs[j][0] = numpy.empty(shape, dtype=outer_output_dtypes[j])
  *                 elif outer_outputs[j][0].shape[0] != store_steps[j]:             # <<<<<<<<<<<<<<
@@ -6393,26 +6124,26 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 496, __pyx_L1_error)
+          __PYX_ERR(0, 484, __pyx_L1_error)
         }
-        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 496, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 484, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_1);
+        __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_shape); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 484, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
-        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_16, __pyx_n_s_shape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 496, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
-        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-        __pyx_t_16 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 496, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_16);
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-        __pyx_t_3 = __Pyx_PyInt_From_int((__pyx_v_store_steps[__pyx_v_j])); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 496, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_1 = PyObject_RichCompare(__pyx_t_16, __pyx_t_3, Py_NE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 496, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-        __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 496, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+        __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_16, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 484, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_1);
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
+        __pyx_t_16 = __Pyx_PyInt_From_int((__pyx_v_store_steps[__pyx_v_j])); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 484, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
+        __pyx_t_3 = PyObject_RichCompare(__pyx_t_1, __pyx_t_16, Py_NE); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 484, __pyx_L1_error)
+        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
+        __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 484, __pyx_L1_error)
+        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         if (__pyx_t_15) {
 
-          /* "aesara/scan/scan_perform.pyx":497
+          /* "aesara/scan/scan_perform.pyx":485
  *                     outer_outputs[j][0] = numpy.empty(shape, dtype=outer_output_dtypes[j])
  *                 elif outer_outputs[j][0].shape[0] != store_steps[j]:
  *                     outer_outputs[j][0] = outer_outputs[j][0][:store_steps[j]]             # <<<<<<<<<<<<<<
@@ -6421,21 +6152,21 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           if (unlikely(__pyx_v_outer_outputs == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 497, __pyx_L1_error)
+            __PYX_ERR(0, 485, __pyx_L1_error)
           }
-          __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 497, __pyx_L1_error)
-          __Pyx_GOTREF(__pyx_t_1);
-          __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_t_1, 0, (__pyx_v_store_steps[__pyx_v_j]), NULL, NULL, NULL, 0, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 497, __pyx_L1_error)
+          __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 485, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_3);
-          __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+          __pyx_t_16 = __Pyx_PyObject_GetSlice(__pyx_t_3, 0, (__pyx_v_store_steps[__pyx_v_j]), NULL, NULL, NULL, 0, 1, 1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 485, __pyx_L1_error)
+          __Pyx_GOTREF(__pyx_t_16);
+          __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
           if (unlikely(__pyx_v_outer_outputs == Py_None)) {
             PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-            __PYX_ERR(0, 497, __pyx_L1_error)
+            __PYX_ERR(0, 485, __pyx_L1_error)
           }
-          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, __pyx_t_3, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 497, __pyx_L1_error)
-          __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 485, __pyx_L1_error)
+          __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":496
+          /* "aesara/scan/scan_perform.pyx":484
  *                         outer_outputs[j][0].dtype != dtype ):
  *                     outer_outputs[j][0] = numpy.empty(shape, dtype=outer_output_dtypes[j])
  *                 elif outer_outputs[j][0].shape[0] != store_steps[j]:             # <<<<<<<<<<<<<<
@@ -6443,9 +6174,9 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *                 outer_outputs[j][0][pos[j]] = inner_output_storage[jout][0]
  */
         }
-        __pyx_L113:;
+        __pyx_L107:;
 
-        /* "aesara/scan/scan_perform.pyx":498
+        /* "aesara/scan/scan_perform.pyx":486
  *                 elif outer_outputs[j][0].shape[0] != store_steps[j]:
  *                     outer_outputs[j][0] = outer_outputs[j][0][:store_steps[j]]
  *                 outer_outputs[j][0][pos[j]] = inner_output_storage[jout][0]             # <<<<<<<<<<<<<<
@@ -6454,31 +6185,31 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 498, __pyx_L1_error)
+          __PYX_ERR(0, 486, __pyx_L1_error)
         }
-        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 498, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 486, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 498, __pyx_L1_error)
+          __PYX_ERR(0, 486, __pyx_L1_error)
         }
-        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 498, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_1);
-        if (unlikely(__Pyx_SetItemInt(__pyx_t_1, (__pyx_v_pos[__pyx_v_j]), __pyx_t_3, int, 1, __Pyx_PyInt_From_int, 0, 1, 0) < 0)) __PYX_ERR(0, 498, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 486, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
+        if (unlikely(__Pyx_SetItemInt(__pyx_t_3, (__pyx_v_pos[__pyx_v_j]), __pyx_t_16, int, 1, __Pyx_PyInt_From_int, 0, 1, 0) < 0)) __PYX_ERR(0, 486, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":487
+        /* "aesara/scan/scan_perform.pyx":475
  *         for j in range(begin,end):
  * 
  *             if i == 0:             # <<<<<<<<<<<<<<
  *                 jout = j+offset_out
  *                 shape = (store_steps[j],) + inner_output_storage[jout][0].shape
  */
-        goto __pyx_L112;
+        goto __pyx_L106;
       }
 
-      /* "aesara/scan/scan_perform.pyx":499
+      /* "aesara/scan/scan_perform.pyx":487
  *                     outer_outputs[j][0] = outer_outputs[j][0][:store_steps[j]]
  *                 outer_outputs[j][0][pos[j]] = inner_output_storage[jout][0]
  *             elif store_steps[j] == 1 or vector_outs[j] == 1:             # <<<<<<<<<<<<<<
@@ -6489,15 +6220,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       if (!__pyx_t_14) {
       } else {
         __pyx_t_15 = __pyx_t_14;
-        goto __pyx_L118_bool_binop_done;
+        goto __pyx_L112_bool_binop_done;
       }
       __pyx_t_13 = __pyx_v_j;
       __pyx_t_14 = (((*__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_vector_outs.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_vector_outs.diminfo[0].strides)) == 1) != 0);
       __pyx_t_15 = __pyx_t_14;
-      __pyx_L118_bool_binop_done:;
+      __pyx_L112_bool_binop_done:;
       if (__pyx_t_15) {
 
-        /* "aesara/scan/scan_perform.pyx":500
+        /* "aesara/scan/scan_perform.pyx":488
  *                 outer_outputs[j][0][pos[j]] = inner_output_storage[jout][0]
  *             elif store_steps[j] == 1 or vector_outs[j] == 1:
  *                 outer_outputs[j][0][pos[j]] = inner_output_storage[j+offset_out][0]             # <<<<<<<<<<<<<<
@@ -6506,32 +6237,32 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 500, __pyx_L1_error)
+          __PYX_ERR(0, 488, __pyx_L1_error)
         }
         __pyx_t_8 = (__pyx_v_j + __pyx_v_offset_out);
-        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 500, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 488, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 500, __pyx_L1_error)
+          __PYX_ERR(0, 488, __pyx_L1_error)
         }
-        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 500, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_1);
-        if (unlikely(__Pyx_SetItemInt(__pyx_t_1, (__pyx_v_pos[__pyx_v_j]), __pyx_t_3, int, 1, __Pyx_PyInt_From_int, 0, 1, 0) < 0)) __PYX_ERR(0, 500, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 488, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
+        if (unlikely(__Pyx_SetItemInt(__pyx_t_3, (__pyx_v_pos[__pyx_v_j]), __pyx_t_16, int, 1, __Pyx_PyInt_From_int, 0, 1, 0) < 0)) __PYX_ERR(0, 488, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":499
+        /* "aesara/scan/scan_perform.pyx":487
  *                     outer_outputs[j][0] = outer_outputs[j][0][:store_steps[j]]
  *                 outer_outputs[j][0][pos[j]] = inner_output_storage[jout][0]
  *             elif store_steps[j] == 1 or vector_outs[j] == 1:             # <<<<<<<<<<<<<<
  *                 outer_outputs[j][0][pos[j]] = inner_output_storage[j+offset_out][0]
  *             else:
  */
-        goto __pyx_L112;
+        goto __pyx_L106;
       }
 
-      /* "aesara/scan/scan_perform.pyx":504
+      /* "aesara/scan/scan_perform.pyx":492
  *                 # Check whether the initialization of the output storage map
  *                 # for this output has been reused.
  *                 old_var = old_output_storage[offset_out + j]             # <<<<<<<<<<<<<<
@@ -6540,12 +6271,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       /*else*/ {
         __pyx_t_8 = (__pyx_v_offset_out + __pyx_v_j);
-        __pyx_t_3 = PyList_GET_ITEM(__pyx_v_old_output_storage, __pyx_t_8);
-        __Pyx_INCREF(__pyx_t_3);
-        __Pyx_XDECREF_SET(__pyx_v_old_var, __pyx_t_3);
-        __pyx_t_3 = 0;
+        __pyx_t_16 = PyList_GET_ITEM(__pyx_v_old_output_storage, __pyx_t_8);
+        __Pyx_INCREF(__pyx_t_16);
+        __Pyx_XDECREF_SET(__pyx_v_old_var, __pyx_t_16);
+        __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":505
+        /* "aesara/scan/scan_perform.pyx":493
  *                 # for this output has been reused.
  *                 old_var = old_output_storage[offset_out + j]
  *                 old_data = old_output_data[offset_out + j]             # <<<<<<<<<<<<<<
@@ -6553,12 +6284,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *                 if old_var is new_var:
  */
         __pyx_t_8 = (__pyx_v_offset_out + __pyx_v_j);
-        __pyx_t_3 = PyList_GET_ITEM(__pyx_v_old_output_data, __pyx_t_8);
-        __Pyx_INCREF(__pyx_t_3);
-        __Pyx_XDECREF_SET(__pyx_v_old_data, __pyx_t_3);
-        __pyx_t_3 = 0;
+        __pyx_t_16 = PyList_GET_ITEM(__pyx_v_old_output_data, __pyx_t_8);
+        __Pyx_INCREF(__pyx_t_16);
+        __Pyx_XDECREF_SET(__pyx_v_old_data, __pyx_t_16);
+        __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":506
+        /* "aesara/scan/scan_perform.pyx":494
  *                 old_var = old_output_storage[offset_out + j]
  *                 old_data = old_output_data[offset_out + j]
  *                 new_var = inner_output_storage[offset_out + j][0]             # <<<<<<<<<<<<<<
@@ -6567,15 +6298,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 506, __pyx_L1_error)
+          __PYX_ERR(0, 494, __pyx_L1_error)
         }
         __pyx_t_8 = (__pyx_v_offset_out + __pyx_v_j);
-        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 506, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
-        __Pyx_XDECREF_SET(__pyx_v_new_var, __pyx_t_3);
-        __pyx_t_3 = 0;
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 494, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
+        __Pyx_XDECREF_SET(__pyx_v_new_var, __pyx_t_16);
+        __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":507
+        /* "aesara/scan/scan_perform.pyx":495
  *                 old_data = old_output_data[offset_out + j]
  *                 new_var = inner_output_storage[offset_out + j][0]
  *                 if old_var is new_var:             # <<<<<<<<<<<<<<
@@ -6586,7 +6317,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_t_14 = (__pyx_t_15 != 0);
         if (__pyx_t_14) {
 
-          /* "aesara/scan/scan_perform.pyx":508
+          /* "aesara/scan/scan_perform.pyx":496
  *                 new_var = inner_output_storage[offset_out + j][0]
  *                 if old_var is new_var:
  *                     if old_data is None:             # <<<<<<<<<<<<<<
@@ -6597,7 +6328,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           __pyx_t_15 = (__pyx_t_14 != 0);
           if (__pyx_t_15) {
 
-            /* "aesara/scan/scan_perform.pyx":509
+            /* "aesara/scan/scan_perform.pyx":497
  *                 if old_var is new_var:
  *                     if old_data is None:
  *                         output_reused = False             # <<<<<<<<<<<<<<
@@ -6607,17 +6338,17 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
             __Pyx_INCREF(Py_False);
             __Pyx_XDECREF_SET(__pyx_v_output_reused, Py_False);
 
-            /* "aesara/scan/scan_perform.pyx":508
+            /* "aesara/scan/scan_perform.pyx":496
  *                 new_var = inner_output_storage[offset_out + j][0]
  *                 if old_var is new_var:
  *                     if old_data is None:             # <<<<<<<<<<<<<<
  *                         output_reused = False
  *                     else:
  */
-            goto __pyx_L121;
+            goto __pyx_L115;
           }
 
-          /* "aesara/scan/scan_perform.pyx":511
+          /* "aesara/scan/scan_perform.pyx":499
  *                         output_reused = False
  *                     else:
  *                         output_reused = (new_var.data == old_data)             # <<<<<<<<<<<<<<
@@ -6625,26 +6356,26 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *                     output_reused = False
  */
           /*else*/ {
-            __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_new_var, __pyx_n_s_data); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 511, __pyx_L1_error)
-            __Pyx_GOTREF(__pyx_t_3);
-            __pyx_t_1 = PyObject_RichCompare(__pyx_t_3, __pyx_v_old_data, Py_EQ); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 511, __pyx_L1_error)
-            __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-            __Pyx_XDECREF_SET(__pyx_v_output_reused, __pyx_t_1);
-            __pyx_t_1 = 0;
+            __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_v_new_var, __pyx_n_s_data); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 499, __pyx_L1_error)
+            __Pyx_GOTREF(__pyx_t_16);
+            __pyx_t_3 = PyObject_RichCompare(__pyx_t_16, __pyx_v_old_data, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 499, __pyx_L1_error)
+            __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
+            __Pyx_XDECREF_SET(__pyx_v_output_reused, __pyx_t_3);
+            __pyx_t_3 = 0;
           }
-          __pyx_L121:;
+          __pyx_L115:;
 
-          /* "aesara/scan/scan_perform.pyx":507
+          /* "aesara/scan/scan_perform.pyx":495
  *                 old_data = old_output_data[offset_out + j]
  *                 new_var = inner_output_storage[offset_out + j][0]
  *                 if old_var is new_var:             # <<<<<<<<<<<<<<
  *                     if old_data is None:
  *                         output_reused = False
  */
-          goto __pyx_L120;
+          goto __pyx_L114;
         }
 
-        /* "aesara/scan/scan_perform.pyx":513
+        /* "aesara/scan/scan_perform.pyx":501
  *                         output_reused = (new_var.data == old_data)
  *                 else:
  *                     output_reused = False             # <<<<<<<<<<<<<<
@@ -6655,20 +6386,20 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           __Pyx_INCREF(Py_False);
           __Pyx_XDECREF_SET(__pyx_v_output_reused, Py_False);
         }
-        __pyx_L120:;
+        __pyx_L114:;
 
-        /* "aesara/scan/scan_perform.pyx":515
+        /* "aesara/scan/scan_perform.pyx":503
  *                     output_reused = False
  * 
  *                 if not output_reused:             # <<<<<<<<<<<<<<
  *                     try:
  *                         outer_outputs[j][0][pos[j]] = inner_output_storage[j+offset_out][0]
  */
-        __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_v_output_reused); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 515, __pyx_L1_error)
+        __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_v_output_reused); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 503, __pyx_L1_error)
         __pyx_t_14 = ((!__pyx_t_15) != 0);
         if (__pyx_t_14) {
 
-          /* "aesara/scan/scan_perform.pyx":516
+          /* "aesara/scan/scan_perform.pyx":504
  * 
  *                 if not output_reused:
  *                     try:             # <<<<<<<<<<<<<<
@@ -6684,7 +6415,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
             __Pyx_XGOTREF(__pyx_t_21);
             /*try:*/ {
 
-              /* "aesara/scan/scan_perform.pyx":517
+              /* "aesara/scan/scan_perform.pyx":505
  *                 if not output_reused:
  *                     try:
  *                         outer_outputs[j][0][pos[j]] = inner_output_storage[j+offset_out][0]             # <<<<<<<<<<<<<<
@@ -6693,22 +6424,22 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
               if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
                 PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-                __PYX_ERR(0, 517, __pyx_L123_error)
+                __PYX_ERR(0, 505, __pyx_L117_error)
               }
               __pyx_t_8 = (__pyx_v_j + __pyx_v_offset_out);
-              __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 517, __pyx_L123_error)
-              __Pyx_GOTREF(__pyx_t_1);
+              __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_8), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 505, __pyx_L117_error)
+              __Pyx_GOTREF(__pyx_t_3);
               if (unlikely(__pyx_v_outer_outputs == Py_None)) {
                 PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-                __PYX_ERR(0, 517, __pyx_L123_error)
+                __PYX_ERR(0, 505, __pyx_L117_error)
               }
-              __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 517, __pyx_L123_error)
-              __Pyx_GOTREF(__pyx_t_3);
-              if (unlikely(__Pyx_SetItemInt(__pyx_t_3, (__pyx_v_pos[__pyx_v_j]), __pyx_t_1, int, 1, __Pyx_PyInt_From_int, 0, 1, 0) < 0)) __PYX_ERR(0, 517, __pyx_L123_error)
+              __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 505, __pyx_L117_error)
+              __Pyx_GOTREF(__pyx_t_16);
+              if (unlikely(__Pyx_SetItemInt(__pyx_t_16, (__pyx_v_pos[__pyx_v_j]), __pyx_t_3, int, 1, __Pyx_PyInt_From_int, 0, 1, 0) < 0)) __PYX_ERR(0, 505, __pyx_L117_error)
+              __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
               __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-              __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-              /* "aesara/scan/scan_perform.pyx":516
+              /* "aesara/scan/scan_perform.pyx":504
  * 
  *                 if not output_reused:
  *                     try:             # <<<<<<<<<<<<<<
@@ -6719,8 +6450,8 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
             __Pyx_XDECREF(__pyx_t_23); __pyx_t_23 = 0;
             __Pyx_XDECREF(__pyx_t_22); __pyx_t_22 = 0;
             __Pyx_XDECREF(__pyx_t_21); __pyx_t_21 = 0;
-            goto __pyx_L130_try_end;
-            __pyx_L123_error:;
+            goto __pyx_L124_try_end;
+            __pyx_L117_error:;
             __Pyx_XDECREF(__pyx_t_1); __pyx_t_1 = 0;
             __Pyx_XDECREF(__pyx_t_16); __pyx_t_16 = 0;
             __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -6730,7 +6461,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
             __Pyx_XDECREF(__pyx_t_27); __pyx_t_27 = 0;
             __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-            /* "aesara/scan/scan_perform.pyx":518
+            /* "aesara/scan/scan_perform.pyx":506
  *                     try:
  *                         outer_outputs[j][0][pos[j]] = inner_output_storage[j+offset_out][0]
  *                     except ValueError as e:             # <<<<<<<<<<<<<<
@@ -6740,15 +6471,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
             __pyx_t_28 = __Pyx_PyErr_ExceptionMatches(__pyx_builtin_ValueError);
             if (__pyx_t_28) {
               __Pyx_AddTraceback("aesara.scan.scan_perform.perform", __pyx_clineno, __pyx_lineno, __pyx_filename);
-              if (__Pyx_GetException(&__pyx_t_1, &__pyx_t_3, &__pyx_t_16) < 0) __PYX_ERR(0, 518, __pyx_L125_except_error)
-              __Pyx_GOTREF(__pyx_t_1);
+              if (__Pyx_GetException(&__pyx_t_3, &__pyx_t_16, &__pyx_t_1) < 0) __PYX_ERR(0, 506, __pyx_L119_except_error)
               __Pyx_GOTREF(__pyx_t_3);
               __Pyx_GOTREF(__pyx_t_16);
-              __Pyx_INCREF(__pyx_t_3);
-              __pyx_v_e = __pyx_t_3;
+              __Pyx_GOTREF(__pyx_t_1);
+              __Pyx_INCREF(__pyx_t_16);
+              __pyx_v_e = __pyx_t_16;
               /*try:*/ {
 
-                /* "aesara/scan/scan_perform.pyx":519
+                /* "aesara/scan/scan_perform.pyx":507
  *                         outer_outputs[j][0][pos[j]] = inner_output_storage[j+offset_out][0]
  *                     except ValueError as e:
  *                         if i == 0:             # <<<<<<<<<<<<<<
@@ -6758,21 +6489,21 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
                 __pyx_t_14 = ((__pyx_v_i == 0) != 0);
                 if (unlikely(__pyx_t_14)) {
 
-                  /* "aesara/scan/scan_perform.pyx":520
+                  /* "aesara/scan/scan_perform.pyx":508
  *                     except ValueError as e:
  *                         if i == 0:
  *                             raise             # <<<<<<<<<<<<<<
  *                         raise ValueError(
  *                             "An output of the Scan has changed shape. "
  */
-                  __Pyx_GIVEREF(__pyx_t_1);
                   __Pyx_GIVEREF(__pyx_t_3);
-                  __Pyx_XGIVEREF(__pyx_t_16);
-                  __Pyx_ErrRestoreWithState(__pyx_t_1, __pyx_t_3, __pyx_t_16);
-                  __pyx_t_1 = 0; __pyx_t_3 = 0; __pyx_t_16 = 0; 
-                  __PYX_ERR(0, 520, __pyx_L136_error)
+                  __Pyx_GIVEREF(__pyx_t_16);
+                  __Pyx_XGIVEREF(__pyx_t_1);
+                  __Pyx_ErrRestoreWithState(__pyx_t_3, __pyx_t_16, __pyx_t_1);
+                  __pyx_t_3 = 0; __pyx_t_16 = 0; __pyx_t_1 = 0; 
+                  __PYX_ERR(0, 508, __pyx_L130_error)
 
-                  /* "aesara/scan/scan_perform.pyx":519
+                  /* "aesara/scan/scan_perform.pyx":507
  *                         outer_outputs[j][0][pos[j]] = inner_output_storage[j+offset_out][0]
  *                     except ValueError as e:
  *                         if i == 0:             # <<<<<<<<<<<<<<
@@ -6781,21 +6512,21 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
                 }
 
-                /* "aesara/scan/scan_perform.pyx":521
+                /* "aesara/scan/scan_perform.pyx":509
  *                         if i == 0:
  *                             raise
  *                         raise ValueError(             # <<<<<<<<<<<<<<
  *                             "An output of the Scan has changed shape. "
  *                             "This may be caused by a push-out optimization."
  */
-                __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_tuple__6, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 521, __pyx_L136_error)
+                __pyx_t_2 = __Pyx_PyObject_Call(__pyx_builtin_ValueError, __pyx_tuple__5, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 509, __pyx_L130_error)
                 __Pyx_GOTREF(__pyx_t_2);
                 __Pyx_Raise(__pyx_t_2, 0, 0, 0);
                 __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-                __PYX_ERR(0, 521, __pyx_L136_error)
+                __PYX_ERR(0, 509, __pyx_L130_error)
               }
 
-              /* "aesara/scan/scan_perform.pyx":518
+              /* "aesara/scan/scan_perform.pyx":506
  *                     try:
  *                         outer_outputs[j][0][pos[j]] = inner_output_storage[j+offset_out][0]
  *                     except ValueError as e:             # <<<<<<<<<<<<<<
@@ -6803,7 +6534,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *                             raise
  */
               /*finally:*/ {
-                __pyx_L136_error:;
+                __pyx_L130_error:;
                 /*exception exit:*/{
                   __Pyx_PyThreadState_declare
                   __Pyx_PyThreadState_assign
@@ -6821,7 +6552,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
                   __Pyx_XGOTREF(__pyx_t_32);
                   __Pyx_XGOTREF(__pyx_t_31);
                   __Pyx_XGOTREF(__pyx_t_30);
-                  __pyx_t_28 = __pyx_lineno; __pyx_t_12 = __pyx_clineno; __pyx_t_37 = __pyx_filename;
+                  __pyx_t_28 = __pyx_lineno; __pyx_t_12 = __pyx_clineno; __pyx_t_36 = __pyx_filename;
                   {
                     __Pyx_DECREF(__pyx_v_e);
                     __pyx_v_e = NULL;
@@ -6837,15 +6568,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
                   __Pyx_XGIVEREF(__pyx_t_33);
                   __Pyx_ErrRestore(__pyx_t_35, __pyx_t_34, __pyx_t_33);
                   __pyx_t_35 = 0; __pyx_t_34 = 0; __pyx_t_33 = 0; __pyx_t_32 = 0; __pyx_t_31 = 0; __pyx_t_30 = 0;
-                  __pyx_lineno = __pyx_t_28; __pyx_clineno = __pyx_t_12; __pyx_filename = __pyx_t_37;
-                  goto __pyx_L125_except_error;
+                  __pyx_lineno = __pyx_t_28; __pyx_clineno = __pyx_t_12; __pyx_filename = __pyx_t_36;
+                  goto __pyx_L119_except_error;
                 }
               }
             }
-            goto __pyx_L125_except_error;
-            __pyx_L125_except_error:;
+            goto __pyx_L119_except_error;
+            __pyx_L119_except_error:;
 
-            /* "aesara/scan/scan_perform.pyx":516
+            /* "aesara/scan/scan_perform.pyx":504
  * 
  *                 if not output_reused:
  *                     try:             # <<<<<<<<<<<<<<
@@ -6857,10 +6588,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
             __Pyx_XGIVEREF(__pyx_t_21);
             __Pyx_ExceptionReset(__pyx_t_23, __pyx_t_22, __pyx_t_21);
             goto __pyx_L1_error;
-            __pyx_L130_try_end:;
+            __pyx_L124_try_end:;
           }
 
-          /* "aesara/scan/scan_perform.pyx":515
+          /* "aesara/scan/scan_perform.pyx":503
  *                     output_reused = False
  * 
  *                 if not output_reused:             # <<<<<<<<<<<<<<
@@ -6869,10 +6600,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         }
       }
-      __pyx_L112:;
+      __pyx_L106:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":529
+    /* "aesara/scan/scan_perform.pyx":517
  *         # 5.6 Copy over the values for outputs corresponding to shared
  *         # variables
  *         begin  = end             # <<<<<<<<<<<<<<
@@ -6881,7 +6612,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_begin = __pyx_v_end;
 
-    /* "aesara/scan/scan_perform.pyx":530
+    /* "aesara/scan/scan_perform.pyx":518
  *         # variables
  *         begin  = end
  *         end   += n_shared_outs             # <<<<<<<<<<<<<<
@@ -6890,7 +6621,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_end = (__pyx_v_end + __pyx_v_n_shared_outs);
 
-    /* "aesara/scan/scan_perform.pyx":531
+    /* "aesara/scan/scan_perform.pyx":519
  *         begin  = end
  *         end   += n_shared_outs
  *         for j in range(begin,end):             # <<<<<<<<<<<<<<
@@ -6902,7 +6633,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = __pyx_v_begin; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_j = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":532
+      /* "aesara/scan/scan_perform.pyx":520
  *         end   += n_shared_outs
  *         for j in range(begin,end):
  *             jout = j +offset_out             # <<<<<<<<<<<<<<
@@ -6911,7 +6642,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       __pyx_v_jout = (__pyx_v_j + __pyx_v_offset_out);
 
-      /* "aesara/scan/scan_perform.pyx":533
+      /* "aesara/scan/scan_perform.pyx":521
  *         for j in range(begin,end):
  *             jout = j +offset_out
  *             outer_outputs[j][0] = inner_output_storage[jout][0]             # <<<<<<<<<<<<<<
@@ -6920,19 +6651,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 533, __pyx_L1_error)
+        __PYX_ERR(0, 521, __pyx_L1_error)
       }
-      __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 533, __pyx_L1_error)
-      __Pyx_GOTREF(__pyx_t_16);
+      __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 521, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_1);
       if (unlikely(__pyx_v_outer_outputs == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 533, __pyx_L1_error)
+        __PYX_ERR(0, 521, __pyx_L1_error)
       }
-      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 533, __pyx_L1_error)
-      __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
+      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, __pyx_t_1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 521, __pyx_L1_error)
+      __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     }
 
-    /* "aesara/scan/scan_perform.pyx":535
+    /* "aesara/scan/scan_perform.pyx":523
  *             outer_outputs[j][0] = inner_output_storage[jout][0]
  * 
  *         for idx in range(lenpos):             # <<<<<<<<<<<<<<
@@ -6944,7 +6675,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":536
+      /* "aesara/scan/scan_perform.pyx":524
  * 
  *         for idx in range(lenpos):
  *             pos[idx] = (pos[idx]+1)%store_steps[idx]             # <<<<<<<<<<<<<<
@@ -6954,12 +6685,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_11 = ((__pyx_v_pos[__pyx_v_idx]) + 1);
       if (unlikely((__pyx_v_store_steps[__pyx_v_idx]) == 0)) {
         PyErr_SetString(PyExc_ZeroDivisionError, "integer division or modulo by zero");
-        __PYX_ERR(0, 536, __pyx_L1_error)
+        __PYX_ERR(0, 524, __pyx_L1_error)
       }
       (__pyx_v_pos[__pyx_v_idx]) = __Pyx_mod_long(__pyx_t_11, (__pyx_v_store_steps[__pyx_v_idx]));
     }
 
-    /* "aesara/scan/scan_perform.pyx":537
+    /* "aesara/scan/scan_perform.pyx":525
  *         for idx in range(lenpos):
  *             pos[idx] = (pos[idx]+1)%store_steps[idx]
  *         i = i + 1             # <<<<<<<<<<<<<<
@@ -6969,7 +6700,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_v_i = (__pyx_v_i + 1);
   }
 
-  /* "aesara/scan/scan_perform.pyx":540
+  /* "aesara/scan/scan_perform.pyx":528
  * 
  *     # 6. Check if you need to re-order output buffers
  *     begin = n_mit_mot             # <<<<<<<<<<<<<<
@@ -6978,7 +6709,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_begin = __pyx_v_n_mit_mot;
 
-  /* "aesara/scan/scan_perform.pyx":541
+  /* "aesara/scan/scan_perform.pyx":529
  *     # 6. Check if you need to re-order output buffers
  *     begin = n_mit_mot
  *     end   = n_outs + n_nit_sot             # <<<<<<<<<<<<<<
@@ -6987,7 +6718,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_end = (__pyx_v_n_outs + __pyx_v_n_nit_sot);
 
-  /* "aesara/scan/scan_perform.pyx":542
+  /* "aesara/scan/scan_perform.pyx":530
  *     begin = n_mit_mot
  *     end   = n_outs + n_nit_sot
  *     for idx in range(begin, end):             # <<<<<<<<<<<<<<
@@ -6999,7 +6730,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   for (__pyx_t_7 = __pyx_v_begin; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
     __pyx_v_idx = __pyx_t_7;
 
-    /* "aesara/scan/scan_perform.pyx":543
+    /* "aesara/scan/scan_perform.pyx":531
  *     end   = n_outs + n_nit_sot
  *     for idx in range(begin, end):
  *         if ( store_steps[idx] < i-mintaps[idx] and             # <<<<<<<<<<<<<<
@@ -7011,10 +6742,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     if (__pyx_t_15) {
     } else {
       __pyx_t_14 = __pyx_t_15;
-      goto __pyx_L150_bool_binop_done;
+      goto __pyx_L144_bool_binop_done;
     }
 
-    /* "aesara/scan/scan_perform.pyx":544
+    /* "aesara/scan/scan_perform.pyx":532
  *     for idx in range(begin, end):
  *         if ( store_steps[idx] < i-mintaps[idx] and
  *             pos[idx] < store_steps[idx] ):             # <<<<<<<<<<<<<<
@@ -7023,9 +6754,9 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_t_15 = (((__pyx_v_pos[__pyx_v_idx]) < (__pyx_v_store_steps[__pyx_v_idx])) != 0);
     __pyx_t_14 = __pyx_t_15;
-    __pyx_L150_bool_binop_done:;
+    __pyx_L144_bool_binop_done:;
 
-    /* "aesara/scan/scan_perform.pyx":543
+    /* "aesara/scan/scan_perform.pyx":531
  *     end   = n_outs + n_nit_sot
  *     for idx in range(begin, end):
  *         if ( store_steps[idx] < i-mintaps[idx] and             # <<<<<<<<<<<<<<
@@ -7034,7 +6765,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     if (__pyx_t_14) {
 
-      /* "aesara/scan/scan_perform.pyx":546
+      /* "aesara/scan/scan_perform.pyx":534
  *             pos[idx] < store_steps[idx] ):
  * 
  *             pdx = pos[idx]             # <<<<<<<<<<<<<<
@@ -7043,7 +6774,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       __pyx_v_pdx = (__pyx_v_pos[__pyx_v_idx]);
 
-      /* "aesara/scan/scan_perform.pyx":547
+      /* "aesara/scan/scan_perform.pyx":535
  * 
  *             pdx = pos[idx]
  *             if pdx >= store_steps[idx]//2 :             # <<<<<<<<<<<<<<
@@ -7053,72 +6784,72 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_14 = ((__pyx_v_pdx >= __Pyx_div_long((__pyx_v_store_steps[__pyx_v_idx]), 2)) != 0);
       if (__pyx_t_14) {
 
-        /* "aesara/scan/scan_perform.pyx":554
+        /* "aesara/scan/scan_perform.pyx":542
  *                 # This way, there will be no information overwritten
  *                 # before it is read (as it used to happen).
  *                 shape = (pdx,)+ outer_outputs[idx][0].shape[1:]             # <<<<<<<<<<<<<<
  *                 tmp = numpy.empty(shape, dtype=outer_output_dtypes[idx])
  *                 tmp[:] = outer_outputs[idx][0][:pdx]
  */
-        __pyx_t_16 = __Pyx_PyInt_From_unsigned_int(__pyx_v_pdx); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 554, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyInt_From_unsigned_int(__pyx_v_pdx); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 542, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_1);
+        __pyx_t_16 = PyTuple_New(1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 542, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
-        __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 554, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
-        __Pyx_GIVEREF(__pyx_t_16);
-        PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_16);
-        __pyx_t_16 = 0;
+        __Pyx_GIVEREF(__pyx_t_1);
+        PyTuple_SET_ITEM(__pyx_t_16, 0, __pyx_t_1);
+        __pyx_t_1 = 0;
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 554, __pyx_L1_error)
+          __PYX_ERR(0, 542, __pyx_L1_error)
         }
-        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 554, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_16);
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_16, __pyx_n_s_shape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 554, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 542, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-        __pyx_t_16 = __Pyx_PyObject_GetSlice(__pyx_t_1, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 554, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_16);
+        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_shape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 542, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_1 = PyNumber_Add(__pyx_t_3, __pyx_t_16); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 554, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_t_3, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 542, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __pyx_t_3 = PyNumber_Add(__pyx_t_16, __pyx_t_1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 542, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-        __Pyx_XDECREF_SET(__pyx_v_shape, __pyx_t_1);
-        __pyx_t_1 = 0;
+        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+        __Pyx_XDECREF_SET(__pyx_v_shape, __pyx_t_3);
+        __pyx_t_3 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":555
+        /* "aesara/scan/scan_perform.pyx":543
  *                 # before it is read (as it used to happen).
  *                 shape = (pdx,)+ outer_outputs[idx][0].shape[1:]
  *                 tmp = numpy.empty(shape, dtype=outer_output_dtypes[idx])             # <<<<<<<<<<<<<<
  *                 tmp[:] = outer_outputs[idx][0][:pdx]
  *                 outer_outputs[idx][0][:store_steps[idx]-pdx] = outer_outputs[idx][0][pdx:]
  */
-        __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_numpy); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 555, __pyx_L1_error)
+        __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 543, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_empty); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 543, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_empty); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 555, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_16);
-        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 555, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_1);
+        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 543, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
         __Pyx_INCREF(__pyx_v_shape);
         __Pyx_GIVEREF(__pyx_v_shape);
-        PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_v_shape);
-        __pyx_t_3 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 555, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
+        PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_v_shape);
+        __pyx_t_16 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 543, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
         if (unlikely(__pyx_v_outer_output_dtypes == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 555, __pyx_L1_error)
+          __PYX_ERR(0, 543, __pyx_L1_error)
         }
-        if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, PyTuple_GET_ITEM(__pyx_v_outer_output_dtypes, __pyx_v_idx)) < 0) __PYX_ERR(0, 555, __pyx_L1_error)
-        __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_16, __pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 555, __pyx_L1_error)
+        if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_dtype, PyTuple_GET_ITEM(__pyx_v_outer_output_dtypes, __pyx_v_idx)) < 0) __PYX_ERR(0, 543, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, __pyx_t_16); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 543, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         __Pyx_XDECREF_SET(__pyx_v_tmp, __pyx_t_2);
         __pyx_t_2 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":556
+        /* "aesara/scan/scan_perform.pyx":544
  *                 shape = (pdx,)+ outer_outputs[idx][0].shape[1:]
  *                 tmp = numpy.empty(shape, dtype=outer_output_dtypes[idx])
  *                 tmp[:] = outer_outputs[idx][0][:pdx]             # <<<<<<<<<<<<<<
@@ -7127,17 +6858,17 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 556, __pyx_L1_error)
+          __PYX_ERR(0, 544, __pyx_L1_error)
         }
-        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 556, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 544, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_t_2, 0, __pyx_v_pdx, NULL, NULL, NULL, 0, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 556, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
+        __pyx_t_16 = __Pyx_PyObject_GetSlice(__pyx_t_2, 0, __pyx_v_pdx, NULL, NULL, NULL, 0, 1, 1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 544, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        if (__Pyx_PyObject_SetSlice(__pyx_v_tmp, __pyx_t_3, 0, 0, NULL, NULL, &__pyx_slice__2, 0, 0, 1) < 0) __PYX_ERR(0, 556, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        if (__Pyx_PyObject_SetSlice(__pyx_v_tmp, __pyx_t_16, 0, 0, NULL, NULL, &__pyx_slice__2, 0, 0, 1) < 0) __PYX_ERR(0, 544, __pyx_L1_error)
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":557
+        /* "aesara/scan/scan_perform.pyx":545
  *                 tmp = numpy.empty(shape, dtype=outer_output_dtypes[idx])
  *                 tmp[:] = outer_outputs[idx][0][:pdx]
  *                 outer_outputs[idx][0][:store_steps[idx]-pdx] = outer_outputs[idx][0][pdx:]             # <<<<<<<<<<<<<<
@@ -7146,24 +6877,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 557, __pyx_L1_error)
+          __PYX_ERR(0, 545, __pyx_L1_error)
         }
-        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 557, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_t_3, __pyx_v_pdx, 0, NULL, NULL, NULL, 1, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 557, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 545, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
+        __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_t_16, __pyx_v_pdx, 0, NULL, NULL, NULL, 1, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 545, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 557, __pyx_L1_error)
+          __PYX_ERR(0, 545, __pyx_L1_error)
         }
-        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 557, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
-        if (__Pyx_PyObject_SetSlice(__pyx_t_3, __pyx_t_2, 0, ((__pyx_v_store_steps[__pyx_v_idx]) - __pyx_v_pdx), NULL, NULL, NULL, 0, 1, 1) < 0) __PYX_ERR(0, 557, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 545, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
+        if (__Pyx_PyObject_SetSlice(__pyx_t_16, __pyx_t_2, 0, ((__pyx_v_store_steps[__pyx_v_idx]) - __pyx_v_pdx), NULL, NULL, NULL, 0, 1, 1) < 0) __PYX_ERR(0, 545, __pyx_L1_error)
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":558
+        /* "aesara/scan/scan_perform.pyx":546
  *                 tmp[:] = outer_outputs[idx][0][:pdx]
  *                 outer_outputs[idx][0][:store_steps[idx]-pdx] = outer_outputs[idx][0][pdx:]
  *                 outer_outputs[idx][0][store_steps[idx]-pdx:] = tmp             # <<<<<<<<<<<<<<
@@ -7172,24 +6903,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 558, __pyx_L1_error)
+          __PYX_ERR(0, 546, __pyx_L1_error)
         }
-        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 558, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 546, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        if (__Pyx_PyObject_SetSlice(__pyx_t_2, __pyx_v_tmp, ((__pyx_v_store_steps[__pyx_v_idx]) - __pyx_v_pdx), 0, NULL, NULL, NULL, 1, 0, 1) < 0) __PYX_ERR(0, 558, __pyx_L1_error)
+        if (__Pyx_PyObject_SetSlice(__pyx_t_2, __pyx_v_tmp, ((__pyx_v_store_steps[__pyx_v_idx]) - __pyx_v_pdx), 0, NULL, NULL, NULL, 1, 0, 1) < 0) __PYX_ERR(0, 546, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":547
+        /* "aesara/scan/scan_perform.pyx":535
  * 
  *             pdx = pos[idx]
  *             if pdx >= store_steps[idx]//2 :             # <<<<<<<<<<<<<<
  *                 # It seems inefficient to copy the bigger part of the
  *                 # array over, and back, but it is the only way that
  */
-        goto __pyx_L152;
+        goto __pyx_L146;
       }
 
-      /* "aesara/scan/scan_perform.pyx":560
+      /* "aesara/scan/scan_perform.pyx":548
  *                 outer_outputs[idx][0][store_steps[idx]-pdx:] = tmp
  *             else:
  *                 shape = (store_steps[idx]-pdx,) + outer_outputs[idx][0].shape[1:]             # <<<<<<<<<<<<<<
@@ -7197,65 +6928,65 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *                 tmp[:] = outer_outputs[idx][0][pdx:]
  */
       /*else*/ {
-        __pyx_t_2 = __Pyx_PyInt_From_unsigned_int(((__pyx_v_store_steps[__pyx_v_idx]) - __pyx_v_pdx)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 560, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyInt_From_unsigned_int(((__pyx_v_store_steps[__pyx_v_idx]) - __pyx_v_pdx)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 548, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 560, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
+        __pyx_t_16 = PyTuple_New(1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 548, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
         __Pyx_GIVEREF(__pyx_t_2);
-        PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_2);
+        PyTuple_SET_ITEM(__pyx_t_16, 0, __pyx_t_2);
         __pyx_t_2 = 0;
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 560, __pyx_L1_error)
+          __PYX_ERR(0, 548, __pyx_L1_error)
         }
-        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 560, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 548, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_shape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 560, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_1);
+        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_shape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 548, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_t_1, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 560, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_t_3, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 548, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_1 = PyNumber_Add(__pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 560, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_1);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __pyx_t_3 = PyNumber_Add(__pyx_t_16, __pyx_t_2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 548, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        __Pyx_XDECREF_SET(__pyx_v_shape, __pyx_t_1);
-        __pyx_t_1 = 0;
+        __Pyx_XDECREF_SET(__pyx_v_shape, __pyx_t_3);
+        __pyx_t_3 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":561
+        /* "aesara/scan/scan_perform.pyx":549
  *             else:
  *                 shape = (store_steps[idx]-pdx,) + outer_outputs[idx][0].shape[1:]
  *                 tmp = numpy.empty(shape, dtype=outer_output_dtypes[idx])             # <<<<<<<<<<<<<<
  *                 tmp[:] = outer_outputs[idx][0][pdx:]
  *                 outer_outputs[idx][0][store_steps[idx]-pdx:] = outer_outputs[idx][0][:pdx]
  */
-        __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_numpy); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 561, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_empty); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 561, __pyx_L1_error)
+        __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 549, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
+        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_empty); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 549, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 561, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_1);
+        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 549, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_3);
         __Pyx_INCREF(__pyx_v_shape);
         __Pyx_GIVEREF(__pyx_v_shape);
-        PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_v_shape);
-        __pyx_t_3 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 561, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
+        PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_v_shape);
+        __pyx_t_16 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 549, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
         if (unlikely(__pyx_v_outer_output_dtypes == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 561, __pyx_L1_error)
+          __PYX_ERR(0, 549, __pyx_L1_error)
         }
-        if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, PyTuple_GET_ITEM(__pyx_v_outer_output_dtypes, __pyx_v_idx)) < 0) __PYX_ERR(0, 561, __pyx_L1_error)
-        __pyx_t_16 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 561, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_16);
+        if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_dtype, PyTuple_GET_ITEM(__pyx_v_outer_output_dtypes, __pyx_v_idx)) < 0) __PYX_ERR(0, 549, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_16); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 549, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_1);
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-        __Pyx_XDECREF_SET(__pyx_v_tmp, __pyx_t_16);
-        __pyx_t_16 = 0;
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
+        __Pyx_XDECREF_SET(__pyx_v_tmp, __pyx_t_1);
+        __pyx_t_1 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":562
+        /* "aesara/scan/scan_perform.pyx":550
  *                 shape = (store_steps[idx]-pdx,) + outer_outputs[idx][0].shape[1:]
  *                 tmp = numpy.empty(shape, dtype=outer_output_dtypes[idx])
  *                 tmp[:] = outer_outputs[idx][0][pdx:]             # <<<<<<<<<<<<<<
@@ -7264,17 +6995,17 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 562, __pyx_L1_error)
+          __PYX_ERR(0, 550, __pyx_L1_error)
         }
-        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 562, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 550, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_1);
+        __pyx_t_16 = __Pyx_PyObject_GetSlice(__pyx_t_1, __pyx_v_pdx, 0, NULL, NULL, NULL, 1, 0, 1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 550, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
-        __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_t_16, __pyx_v_pdx, 0, NULL, NULL, NULL, 1, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 562, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
+        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+        if (__Pyx_PyObject_SetSlice(__pyx_v_tmp, __pyx_t_16, 0, 0, NULL, NULL, &__pyx_slice__2, 0, 0, 1) < 0) __PYX_ERR(0, 550, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-        if (__Pyx_PyObject_SetSlice(__pyx_v_tmp, __pyx_t_3, 0, 0, NULL, NULL, &__pyx_slice__2, 0, 0, 1) < 0) __PYX_ERR(0, 562, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":563
+        /* "aesara/scan/scan_perform.pyx":551
  *                 tmp = numpy.empty(shape, dtype=outer_output_dtypes[idx])
  *                 tmp[:] = outer_outputs[idx][0][pdx:]
  *                 outer_outputs[idx][0][store_steps[idx]-pdx:] = outer_outputs[idx][0][:pdx]             # <<<<<<<<<<<<<<
@@ -7283,24 +7014,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 563, __pyx_L1_error)
+          __PYX_ERR(0, 551, __pyx_L1_error)
         }
-        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 563, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_16 = __Pyx_PyObject_GetSlice(__pyx_t_3, 0, __pyx_v_pdx, NULL, NULL, NULL, 0, 1, 1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 563, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 551, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_t_16, 0, __pyx_v_pdx, NULL, NULL, NULL, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 551, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_1);
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 563, __pyx_L1_error)
+          __PYX_ERR(0, 551, __pyx_L1_error)
         }
-        __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 563, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
-        if (__Pyx_PyObject_SetSlice(__pyx_t_3, __pyx_t_16, ((__pyx_v_store_steps[__pyx_v_idx]) - __pyx_v_pdx), 0, NULL, NULL, NULL, 1, 0, 1) < 0) __PYX_ERR(0, 563, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 551, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
+        if (__Pyx_PyObject_SetSlice(__pyx_t_16, __pyx_t_1, ((__pyx_v_store_steps[__pyx_v_idx]) - __pyx_v_pdx), 0, NULL, NULL, NULL, 1, 0, 1) < 0) __PYX_ERR(0, 551, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
+        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":564
+        /* "aesara/scan/scan_perform.pyx":552
  *                 tmp[:] = outer_outputs[idx][0][pdx:]
  *                 outer_outputs[idx][0][store_steps[idx]-pdx:] = outer_outputs[idx][0][:pdx]
  *                 outer_outputs[idx][0][:store_steps[idx]-pdx] = tmp             # <<<<<<<<<<<<<<
@@ -7309,26 +7040,26 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 564, __pyx_L1_error)
+          __PYX_ERR(0, 552, __pyx_L1_error)
         }
-        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 564, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_16);
-        if (__Pyx_PyObject_SetSlice(__pyx_t_16, __pyx_v_tmp, 0, ((__pyx_v_store_steps[__pyx_v_idx]) - __pyx_v_pdx), NULL, NULL, NULL, 0, 1, 1) < 0) __PYX_ERR(0, 564, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
+        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 552, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_1);
+        if (__Pyx_PyObject_SetSlice(__pyx_t_1, __pyx_v_tmp, 0, ((__pyx_v_store_steps[__pyx_v_idx]) - __pyx_v_pdx), NULL, NULL, NULL, 0, 1, 1) < 0) __PYX_ERR(0, 552, __pyx_L1_error)
+        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       }
-      __pyx_L152:;
+      __pyx_L146:;
 
-      /* "aesara/scan/scan_perform.pyx":543
+      /* "aesara/scan/scan_perform.pyx":531
  *     end   = n_outs + n_nit_sot
  *     for idx in range(begin, end):
  *         if ( store_steps[idx] < i-mintaps[idx] and             # <<<<<<<<<<<<<<
  *             pos[idx] < store_steps[idx] ):
  * 
  */
-      goto __pyx_L149;
+      goto __pyx_L143;
     }
 
-    /* "aesara/scan/scan_perform.pyx":570
+    /* "aesara/scan/scan_perform.pyx":558
  *         # expected to return 0 for all entries for which the gradient is
  *         # not actually computed
  *         elif store_steps[idx] > i - mintaps[idx]:             # <<<<<<<<<<<<<<
@@ -7339,7 +7070,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_14 = (((__pyx_v_store_steps[__pyx_v_idx]) > (__pyx_v_i - (*__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_mintaps.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_mintaps.diminfo[0].strides)))) != 0);
     if (__pyx_t_14) {
 
-      /* "aesara/scan/scan_perform.pyx":571
+      /* "aesara/scan/scan_perform.pyx":559
  *         # not actually computed
  *         elif store_steps[idx] > i - mintaps[idx]:
  *             outer_outputs[idx][0][i - mintaps[idx]:] = 0             # <<<<<<<<<<<<<<
@@ -7348,15 +7079,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       if (unlikely(__pyx_v_outer_outputs == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 571, __pyx_L1_error)
+        __PYX_ERR(0, 559, __pyx_L1_error)
       }
-      __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 571, __pyx_L1_error)
-      __Pyx_GOTREF(__pyx_t_16);
+      __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 559, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_1);
       __pyx_t_13 = __pyx_v_idx;
-      if (__Pyx_PyObject_SetSlice(__pyx_t_16, __pyx_int_0, (__pyx_v_i - (*__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_mintaps.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_mintaps.diminfo[0].strides))), 0, NULL, NULL, NULL, 1, 0, 1) < 0) __PYX_ERR(0, 571, __pyx_L1_error)
-      __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
+      if (__Pyx_PyObject_SetSlice(__pyx_t_1, __pyx_int_0, (__pyx_v_i - (*__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_mintaps.rcbuffer->pybuffer.buf, __pyx_t_13, __pyx_pybuffernd_mintaps.diminfo[0].strides))), 0, NULL, NULL, NULL, 1, 0, 1) < 0) __PYX_ERR(0, 559, __pyx_L1_error)
+      __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":580
+      /* "aesara/scan/scan_perform.pyx":568
  *             # if optimization gets applied compared to when optimization
  *             # do not get applied
  *             if i < n_steps:             # <<<<<<<<<<<<<<
@@ -7366,7 +7097,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_14 = ((__pyx_v_i < __pyx_v_n_steps) != 0);
       if (__pyx_t_14) {
 
-        /* "aesara/scan/scan_perform.pyx":587
+        /* "aesara/scan/scan_perform.pyx":575
  *                 # code faster, so this workaround is better then removing
  *                 # the directive.
  *                 sh0 = outer_outputs[idx][0].shape[0]             # <<<<<<<<<<<<<<
@@ -7375,20 +7106,20 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 587, __pyx_L1_error)
+          __PYX_ERR(0, 575, __pyx_L1_error)
         }
-        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 587, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 575, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_1);
+        __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_shape); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 575, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
-        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_16, __pyx_n_s_shape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 587, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
+        __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+        __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_16, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 575, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_1);
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-        __pyx_t_16 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 587, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_16);
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-        __Pyx_XDECREF_SET(__pyx_v_sh0, __pyx_t_16);
-        __pyx_t_16 = 0;
+        __Pyx_XDECREF_SET(__pyx_v_sh0, __pyx_t_1);
+        __pyx_t_1 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":588
+        /* "aesara/scan/scan_perform.pyx":576
  *                 # the directive.
  *                 sh0 = outer_outputs[idx][0].shape[0]
  *                 outer_outputs[idx][0] = outer_outputs[idx][0][:sh0-(n_steps - i)]             # <<<<<<<<<<<<<<
@@ -7397,27 +7128,27 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 588, __pyx_L1_error)
+          __PYX_ERR(0, 576, __pyx_L1_error)
         }
-        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 588, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_16);
-        __pyx_t_3 = __Pyx_PyInt_From_unsigned_int((__pyx_v_n_steps - __pyx_v_i)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 588, __pyx_L1_error)
-        __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_1 = PyNumber_Subtract(__pyx_v_sh0, __pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 588, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 576, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-        __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_t_16, 0, 0, NULL, &__pyx_t_1, NULL, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 588, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_PyInt_From_unsigned_int((__pyx_v_n_steps - __pyx_v_i)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 576, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
+        __pyx_t_3 = PyNumber_Subtract(__pyx_v_sh0, __pyx_t_16); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 576, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
+        __pyx_t_16 = __Pyx_PyObject_GetSlice(__pyx_t_1, 0, 0, NULL, &__pyx_t_3, NULL, 0, 0, 1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 576, __pyx_L1_error)
+        __Pyx_GOTREF(__pyx_t_16);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         if (unlikely(__pyx_v_outer_outputs == Py_None)) {
           PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-          __PYX_ERR(0, 588, __pyx_L1_error)
+          __PYX_ERR(0, 576, __pyx_L1_error)
         }
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, __pyx_t_3, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 588, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 576, __pyx_L1_error)
+        __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":580
+        /* "aesara/scan/scan_perform.pyx":568
  *             # if optimization gets applied compared to when optimization
  *             # do not get applied
  *             if i < n_steps:             # <<<<<<<<<<<<<<
@@ -7426,7 +7157,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       }
 
-      /* "aesara/scan/scan_perform.pyx":570
+      /* "aesara/scan/scan_perform.pyx":558
  *         # expected to return 0 for all entries for which the gradient is
  *         # not actually computed
  *         elif store_steps[idx] > i - mintaps[idx]:             # <<<<<<<<<<<<<<
@@ -7434,10 +7165,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  * 
  */
     }
-    __pyx_L149:;
+    __pyx_L143:;
   }
 
-  /* "aesara/scan/scan_perform.pyx":592
+  /* "aesara/scan/scan_perform.pyx":580
  *     # We never reuse the input or output storage of the
  *     # inner function so we clear it.
  *     for s in inner_input_storage:             # <<<<<<<<<<<<<<
@@ -7446,30 +7177,30 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   if (unlikely(__pyx_v_inner_input_storage == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 592, __pyx_L1_error)
+    __PYX_ERR(0, 580, __pyx_L1_error)
   }
-  __pyx_t_3 = __pyx_v_inner_input_storage; __Pyx_INCREF(__pyx_t_3); __pyx_t_9 = 0;
+  __pyx_t_16 = __pyx_v_inner_input_storage; __Pyx_INCREF(__pyx_t_16); __pyx_t_9 = 0;
   for (;;) {
-    if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_3)) break;
+    if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_16)) break;
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-    __pyx_t_1 = PyList_GET_ITEM(__pyx_t_3, __pyx_t_9); __Pyx_INCREF(__pyx_t_1); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 592, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 580, __pyx_L1_error)
     #else
-    __pyx_t_1 = PySequence_ITEM(__pyx_t_3, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 592, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_1);
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 580, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_3);
     #endif
-    __Pyx_XDECREF_SET(__pyx_v_s, __pyx_t_1);
-    __pyx_t_1 = 0;
+    __Pyx_XDECREF_SET(__pyx_v_s, __pyx_t_3);
+    __pyx_t_3 = 0;
 
-    /* "aesara/scan/scan_perform.pyx":593
+    /* "aesara/scan/scan_perform.pyx":581
  *     # inner function so we clear it.
  *     for s in inner_input_storage:
  *         s[0] = None             # <<<<<<<<<<<<<<
  *     for s in inner_output_storage:
  *         s[0] = None
  */
-    if (unlikely(__Pyx_SetItemInt(__pyx_v_s, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 593, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(__pyx_v_s, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 581, __pyx_L1_error)
 
-    /* "aesara/scan/scan_perform.pyx":592
+    /* "aesara/scan/scan_perform.pyx":580
  *     # We never reuse the input or output storage of the
  *     # inner function so we clear it.
  *     for s in inner_input_storage:             # <<<<<<<<<<<<<<
@@ -7477,9 +7208,9 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *     for s in inner_output_storage:
  */
   }
-  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+  __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":594
+  /* "aesara/scan/scan_perform.pyx":582
  *     for s in inner_input_storage:
  *         s[0] = None
  *     for s in inner_output_storage:             # <<<<<<<<<<<<<<
@@ -7488,30 +7219,30 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   if (unlikely(__pyx_v_inner_output_storage == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 594, __pyx_L1_error)
+    __PYX_ERR(0, 582, __pyx_L1_error)
   }
-  __pyx_t_3 = __pyx_v_inner_output_storage; __Pyx_INCREF(__pyx_t_3); __pyx_t_9 = 0;
+  __pyx_t_16 = __pyx_v_inner_output_storage; __Pyx_INCREF(__pyx_t_16); __pyx_t_9 = 0;
   for (;;) {
-    if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_3)) break;
+    if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_16)) break;
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-    __pyx_t_1 = PyList_GET_ITEM(__pyx_t_3, __pyx_t_9); __Pyx_INCREF(__pyx_t_1); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 594, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 582, __pyx_L1_error)
     #else
-    __pyx_t_1 = PySequence_ITEM(__pyx_t_3, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 594, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_1);
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 582, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_3);
     #endif
-    __Pyx_XDECREF_SET(__pyx_v_s, __pyx_t_1);
-    __pyx_t_1 = 0;
+    __Pyx_XDECREF_SET(__pyx_v_s, __pyx_t_3);
+    __pyx_t_3 = 0;
 
-    /* "aesara/scan/scan_perform.pyx":595
+    /* "aesara/scan/scan_perform.pyx":583
  *         s[0] = None
  *     for s in inner_output_storage:
  *         s[0] = None             # <<<<<<<<<<<<<<
  * 
  *     return t_fn, i
  */
-    if (unlikely(__Pyx_SetItemInt(__pyx_v_s, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 595, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(__pyx_v_s, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 583, __pyx_L1_error)
 
-    /* "aesara/scan/scan_perform.pyx":594
+    /* "aesara/scan/scan_perform.pyx":582
  *     for s in inner_input_storage:
  *         s[0] = None
  *     for s in inner_output_storage:             # <<<<<<<<<<<<<<
@@ -7519,28 +7250,28 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  * 
  */
   }
-  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+  __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":597
+  /* "aesara/scan/scan_perform.pyx":585
  *         s[0] = None
  * 
  *     return t_fn, i             # <<<<<<<<<<<<<<
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_3 = __Pyx_PyInt_From_unsigned_int(__pyx_v_t_fn); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 597, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_1 = __Pyx_PyInt_From_unsigned_int(__pyx_v_i); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 597, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_16 = PyTuple_New(2); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 597, __pyx_L1_error)
+  __pyx_t_16 = __Pyx_PyInt_From_unsigned_int(__pyx_v_t_fn); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 585, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_16);
+  __pyx_t_3 = __Pyx_PyInt_From_unsigned_int(__pyx_v_i); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 585, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_3);
+  __pyx_t_1 = PyTuple_New(2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 585, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __Pyx_GIVEREF(__pyx_t_16);
+  PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_16);
   __Pyx_GIVEREF(__pyx_t_3);
-  PyTuple_SET_ITEM(__pyx_t_16, 0, __pyx_t_3);
-  __Pyx_GIVEREF(__pyx_t_1);
-  PyTuple_SET_ITEM(__pyx_t_16, 1, __pyx_t_1);
-  __pyx_t_3 = 0;
-  __pyx_t_1 = 0;
-  __pyx_r = __pyx_t_16;
+  PyTuple_SET_ITEM(__pyx_t_1, 1, __pyx_t_3);
   __pyx_t_16 = 0;
+  __pyx_t_3 = 0;
+  __pyx_r = __pyx_t_1;
+  __pyx_t_1 = 0;
   goto __pyx_L0;
 
   /* "aesara/scan/scan_perform.pyx":65
@@ -7593,11 +7324,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __Pyx_XDECREF(__pyx_v_t0_fn);
   __Pyx_XDECREF(__pyx_v_exc);
   __Pyx_XDECREF(__pyx_v_dt_fn);
-  __Pyx_XDECREF(__pyx_v_needs_update);
-  __Pyx_XDECREF(__pyx_v_storage);
   __Pyx_XDECREF(__pyx_v_mitmot_inp_offset);
   __Pyx_XDECREF(__pyx_v_mitmot_out_idx);
   __Pyx_XDECREF(__pyx_v_inp_idx);
+  __Pyx_XDECREF(__pyx_v_inner_inp_idx);
   __Pyx_XDECREF(__pyx_v_old_var);
   __Pyx_XDECREF(__pyx_v_new_var);
   __Pyx_XDECREF(__pyx_v_old_data);
@@ -8146,7 +7876,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_array(void) {
  * 
  * cdef inline int import_umath() except -1:
  */
-      __pyx_t_8 = __Pyx_PyObject_Call(__pyx_builtin_ImportError, __pyx_tuple__7, NULL); if (unlikely(!__pyx_t_8)) __PYX_ERR(1, 945, __pyx_L5_except_error)
+      __pyx_t_8 = __Pyx_PyObject_Call(__pyx_builtin_ImportError, __pyx_tuple__6, NULL); if (unlikely(!__pyx_t_8)) __PYX_ERR(1, 945, __pyx_L5_except_error)
       __Pyx_GOTREF(__pyx_t_8);
       __Pyx_Raise(__pyx_t_8, 0, 0, 0);
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
@@ -8278,7 +8008,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_umath(void) {
  * 
  * cdef inline int import_ufunc() except -1:
  */
-      __pyx_t_8 = __Pyx_PyObject_Call(__pyx_builtin_ImportError, __pyx_tuple__8, NULL); if (unlikely(!__pyx_t_8)) __PYX_ERR(1, 951, __pyx_L5_except_error)
+      __pyx_t_8 = __Pyx_PyObject_Call(__pyx_builtin_ImportError, __pyx_tuple__7, NULL); if (unlikely(!__pyx_t_8)) __PYX_ERR(1, 951, __pyx_L5_except_error)
       __Pyx_GOTREF(__pyx_t_8);
       __Pyx_Raise(__pyx_t_8, 0, 0, 0);
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
@@ -8410,7 +8140,7 @@ static CYTHON_INLINE int __pyx_f_5numpy_import_ufunc(void) {
  * 
  * cdef extern from *:
  */
-      __pyx_t_8 = __Pyx_PyObject_Call(__pyx_builtin_ImportError, __pyx_tuple__8, NULL); if (unlikely(!__pyx_t_8)) __PYX_ERR(1, 957, __pyx_L5_except_error)
+      __pyx_t_8 = __Pyx_PyObject_Call(__pyx_builtin_ImportError, __pyx_tuple__7, NULL); if (unlikely(!__pyx_t_8)) __PYX_ERR(1, 957, __pyx_L5_except_error)
       __Pyx_GOTREF(__pyx_t_8);
       __Pyx_Raise(__pyx_t_8, 0, 0, 0);
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
@@ -8710,7 +8440,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_idx_2, __pyx_k_idx_2, sizeof(__pyx_k_idx_2), 0, 0, 1, 1},
   {&__pyx_n_s_import, __pyx_k_import, sizeof(__pyx_k_import), 0, 0, 1, 1},
   {&__pyx_n_s_index, __pyx_k_index, sizeof(__pyx_k_index), 0, 0, 1, 1},
-  {&__pyx_n_s_inner_input_needs_update, __pyx_k_inner_input_needs_update, sizeof(__pyx_k_inner_input_needs_update), 0, 0, 1, 1},
+  {&__pyx_n_s_inner_inp_idx, __pyx_k_inner_inp_idx, sizeof(__pyx_k_inner_inp_idx), 0, 0, 1, 1},
   {&__pyx_n_s_inner_input_storage, __pyx_k_inner_input_storage, sizeof(__pyx_k_inner_input_storage), 0, 0, 1, 1},
   {&__pyx_n_s_inner_output_storage, __pyx_k_inner_output_storage, sizeof(__pyx_k_inner_output_storage), 0, 0, 1, 1},
   {&__pyx_n_s_inp_idx, __pyx_k_inp_idx, sizeof(__pyx_k_inp_idx), 0, 0, 1, 1},
@@ -8740,8 +8470,6 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_n_steps, __pyx_k_n_steps, sizeof(__pyx_k_n_steps), 0, 0, 1, 1},
   {&__pyx_n_s_name, __pyx_k_name, sizeof(__pyx_k_name), 0, 0, 1, 1},
   {&__pyx_n_s_nb_mitmot_in, __pyx_k_nb_mitmot_in, sizeof(__pyx_k_nb_mitmot_in), 0, 0, 1, 1},
-  {&__pyx_n_s_need_update_inputs, __pyx_k_need_update_inputs, sizeof(__pyx_k_need_update_inputs), 0, 0, 1, 1},
-  {&__pyx_n_s_needs_update, __pyx_k_needs_update, sizeof(__pyx_k_needs_update), 0, 0, 1, 1},
   {&__pyx_n_s_new_var, __pyx_k_new_var, sizeof(__pyx_k_new_var), 0, 0, 1, 1},
   {&__pyx_n_s_nit_sot_arg_offset, __pyx_k_nit_sot_arg_offset, sizeof(__pyx_k_nit_sot_arg_offset), 0, 0, 1, 1},
   {&__pyx_n_s_numpy, __pyx_k_numpy, sizeof(__pyx_k_numpy), 0, 0, 1, 1},
@@ -8775,7 +8503,6 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_sh0, __pyx_k_sh0, sizeof(__pyx_k_sh0), 0, 0, 1, 1},
   {&__pyx_n_s_shape, __pyx_k_shape, sizeof(__pyx_k_shape), 0, 0, 1, 1},
   {&__pyx_n_s_shared_arg_offset, __pyx_k_shared_arg_offset, sizeof(__pyx_k_shared_arg_offset), 0, 0, 1, 1},
-  {&__pyx_n_s_storage, __pyx_k_storage, sizeof(__pyx_k_storage), 0, 0, 1, 1},
   {&__pyx_n_s_store_steps, __pyx_k_store_steps, sizeof(__pyx_k_store_steps), 0, 0, 1, 1},
   {&__pyx_n_s_sys, __pyx_k_sys, sizeof(__pyx_k_sys), 0, 0, 1, 1},
   {&__pyx_n_s_t0_fn, __pyx_k_t0_fn, sizeof(__pyx_k_t0_fn), 0, 0, 1, 1},
@@ -8791,19 +8518,17 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_vector_outs, __pyx_k_vector_outs, sizeof(__pyx_k_vector_outs), 0, 0, 1, 1},
   {&__pyx_n_s_vector_seqs, __pyx_k_vector_seqs, sizeof(__pyx_k_vector_seqs), 0, 0, 1, 1},
   {&__pyx_n_s_xrange, __pyx_k_xrange, sizeof(__pyx_k_xrange), 0, 0, 1, 1},
-  {&__pyx_n_s_zip, __pyx_k_zip, sizeof(__pyx_k_zip), 0, 0, 1, 1},
   {0, 0, 0, 0, 0, 0, 0}
 };
 static CYTHON_SMALL_CODE int __Pyx_InitCachedBuiltins(void) {
-  __pyx_builtin_IndexError = __Pyx_GetBuiltinName(__pyx_n_s_IndexError); if (!__pyx_builtin_IndexError) __PYX_ERR(0, 203, __pyx_L1_error)
-  __pyx_builtin_range = __Pyx_GetBuiltinName(__pyx_n_s_range); if (!__pyx_builtin_range) __PYX_ERR(0, 207, __pyx_L1_error)
-  __pyx_builtin_ValueError = __Pyx_GetBuiltinName(__pyx_n_s_ValueError); if (!__pyx_builtin_ValueError) __PYX_ERR(0, 209, __pyx_L1_error)
+  __pyx_builtin_IndexError = __Pyx_GetBuiltinName(__pyx_n_s_IndexError); if (!__pyx_builtin_IndexError) __PYX_ERR(0, 202, __pyx_L1_error)
+  __pyx_builtin_range = __Pyx_GetBuiltinName(__pyx_n_s_range); if (!__pyx_builtin_range) __PYX_ERR(0, 206, __pyx_L1_error)
+  __pyx_builtin_ValueError = __Pyx_GetBuiltinName(__pyx_n_s_ValueError); if (!__pyx_builtin_ValueError) __PYX_ERR(0, 208, __pyx_L1_error)
   #if PY_MAJOR_VERSION >= 3
-  __pyx_builtin_xrange = __Pyx_GetBuiltinName(__pyx_n_s_range); if (!__pyx_builtin_xrange) __PYX_ERR(0, 380, __pyx_L1_error)
+  __pyx_builtin_xrange = __Pyx_GetBuiltinName(__pyx_n_s_range); if (!__pyx_builtin_xrange) __PYX_ERR(0, 378, __pyx_L1_error)
   #else
-  __pyx_builtin_xrange = __Pyx_GetBuiltinName(__pyx_n_s_xrange); if (!__pyx_builtin_xrange) __PYX_ERR(0, 380, __pyx_L1_error)
+  __pyx_builtin_xrange = __Pyx_GetBuiltinName(__pyx_n_s_xrange); if (!__pyx_builtin_xrange) __PYX_ERR(0, 378, __pyx_L1_error)
   #endif
-  __pyx_builtin_zip = __Pyx_GetBuiltinName(__pyx_n_s_zip); if (!__pyx_builtin_zip) __PYX_ERR(0, 408, __pyx_L1_error)
   __pyx_builtin_ImportError = __Pyx_GetBuiltinName(__pyx_n_s_ImportError); if (!__pyx_builtin_ImportError) __PYX_ERR(1, 945, __pyx_L1_error)
   return 0;
   __pyx_L1_error:;
@@ -8814,74 +8539,63 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__Pyx_InitCachedConstants", 0);
 
-  /* "aesara/scan/scan_perform.pyx":236
+  /* "aesara/scan/scan_perform.pyx":234
  *             outer_outputs[idx][0] = outer_inputs[ <unsigned int>(1+ n_seqs + idx)]
  *         elif ( outer_outputs[idx][0] is not None and
  *               outer_outputs[idx][0].shape[1:] == outer_inputs[<unsigned int>(1+ n_seqs + idx)].shape[1:]             # <<<<<<<<<<<<<<
  *               and outer_outputs[idx][0].shape[0] >= store_steps[idx] ):
  *             # Put in the values of the initial state
  */
-  __pyx_slice_ = PySlice_New(__pyx_int_1, Py_None, Py_None); if (unlikely(!__pyx_slice_)) __PYX_ERR(0, 236, __pyx_L1_error)
+  __pyx_slice_ = PySlice_New(__pyx_int_1, Py_None, Py_None); if (unlikely(!__pyx_slice_)) __PYX_ERR(0, 234, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_slice_);
   __Pyx_GIVEREF(__pyx_slice_);
 
-  /* "aesara/scan/scan_perform.pyx":245
+  /* "aesara/scan/scan_perform.pyx":243
  *                                                        idx)][:l]
  *             else:
  *                 outer_outputs[idx][0][:] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)]             # <<<<<<<<<<<<<<
  *         else:
  *             outer_outputs[idx][0] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)].copy()
  */
-  __pyx_slice__2 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__2)) __PYX_ERR(0, 245, __pyx_L1_error)
+  __pyx_slice__2 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__2)) __PYX_ERR(0, 243, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_slice__2);
   __Pyx_GIVEREF(__pyx_slice__2);
 
-  /* "aesara/scan/scan_perform.pyx":257
+  /* "aesara/scan/scan_perform.pyx":255
  *                 # access, because it's not going to produce a very efficient
  *                 # Cython function!)
  *                 outer_outputs[idx][0] = numpy.empty((0,) * outer_output_ndims[idx], dtype=outer_output_dtypes[idx])             # <<<<<<<<<<<<<<
  *             else:
  *                 outer_outputs[idx][0] = None
  */
-  __pyx_tuple__3 = PyTuple_New(1); if (unlikely(!__pyx_tuple__3)) __PYX_ERR(0, 257, __pyx_L1_error)
+  __pyx_tuple__3 = PyTuple_New(1); if (unlikely(!__pyx_tuple__3)) __PYX_ERR(0, 255, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__3);
   __Pyx_INCREF(__pyx_int_0);
   __Pyx_GIVEREF(__pyx_int_0);
   PyTuple_SET_ITEM(__pyx_tuple__3, 0, __pyx_int_0);
   __Pyx_GIVEREF(__pyx_tuple__3);
 
-  /* "aesara/scan/scan_perform.pyx":260
+  /* "aesara/scan/scan_perform.pyx":258
  *             else:
  *                 outer_outputs[idx][0] = None
  *         return 0.0, 0             # <<<<<<<<<<<<<<
  * 
  *     for idx in range(n_outs + n_nit_sot):
  */
-  __pyx_tuple__4 = PyTuple_Pack(2, __pyx_float_0_0, __pyx_int_0); if (unlikely(!__pyx_tuple__4)) __PYX_ERR(0, 260, __pyx_L1_error)
+  __pyx_tuple__4 = PyTuple_Pack(2, __pyx_float_0_0, __pyx_int_0); if (unlikely(!__pyx_tuple__4)) __PYX_ERR(0, 258, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__4);
   __Pyx_GIVEREF(__pyx_tuple__4);
 
-  /* "aesara/scan/scan_perform.pyx":408
- *         if need_update_inputs:
- *             offset_out = len(inner_output_storage) - 1
- *             for needs_update, storage in zip(inner_input_needs_update[::-1],             # <<<<<<<<<<<<<<
- *                                              inner_input_storage[::-1]):
- *                 if needs_update:
- */
-  __pyx_slice__5 = PySlice_New(Py_None, Py_None, __pyx_int_neg_1); if (unlikely(!__pyx_slice__5)) __PYX_ERR(0, 408, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_slice__5);
-  __Pyx_GIVEREF(__pyx_slice__5);
-
-  /* "aesara/scan/scan_perform.pyx":521
+  /* "aesara/scan/scan_perform.pyx":509
  *                         if i == 0:
  *                             raise
  *                         raise ValueError(             # <<<<<<<<<<<<<<
  *                             "An output of the Scan has changed shape. "
  *                             "This may be caused by a push-out optimization."
  */
-  __pyx_tuple__6 = PyTuple_Pack(1, __pyx_kp_u_An_output_of_the_Scan_has_change); if (unlikely(!__pyx_tuple__6)) __PYX_ERR(0, 521, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_tuple__6);
-  __Pyx_GIVEREF(__pyx_tuple__6);
+  __pyx_tuple__5 = PyTuple_Pack(1, __pyx_kp_u_An_output_of_the_Scan_has_change); if (unlikely(!__pyx_tuple__5)) __PYX_ERR(0, 509, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__5);
+  __Pyx_GIVEREF(__pyx_tuple__5);
 
   /* "../../../../../../apps/anaconda3/envs/aesara-3.9/lib/python3.9/site-packages/numpy/__init__.pxd":945
  *         __pyx_import_array()
@@ -8890,9 +8604,9 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
  * 
  * cdef inline int import_umath() except -1:
  */
-  __pyx_tuple__7 = PyTuple_Pack(1, __pyx_kp_u_numpy_core_multiarray_failed_to); if (unlikely(!__pyx_tuple__7)) __PYX_ERR(1, 945, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_tuple__7);
-  __Pyx_GIVEREF(__pyx_tuple__7);
+  __pyx_tuple__6 = PyTuple_Pack(1, __pyx_kp_u_numpy_core_multiarray_failed_to); if (unlikely(!__pyx_tuple__6)) __PYX_ERR(1, 945, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__6);
+  __Pyx_GIVEREF(__pyx_tuple__6);
 
   /* "../../../../../../apps/anaconda3/envs/aesara-3.9/lib/python3.9/site-packages/numpy/__init__.pxd":951
  *         _import_umath()
@@ -8901,18 +8615,18 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
  * 
  * cdef inline int import_ufunc() except -1:
  */
-  __pyx_tuple__8 = PyTuple_Pack(1, __pyx_kp_u_numpy_core_umath_failed_to_impor); if (unlikely(!__pyx_tuple__8)) __PYX_ERR(1, 951, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_tuple__8);
-  __Pyx_GIVEREF(__pyx_tuple__8);
+  __pyx_tuple__7 = PyTuple_Pack(1, __pyx_kp_u_numpy_core_umath_failed_to_impor); if (unlikely(!__pyx_tuple__7)) __PYX_ERR(1, 951, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__7);
+  __Pyx_GIVEREF(__pyx_tuple__7);
 
   /* "aesara/scan/scan_perform.pyx":61
  * 
  * 
  * def get_version():             # <<<<<<<<<<<<<<
- *     return 0.313
+ *     return 0.314
  * 
  */
-  __pyx_codeobj__9 = (PyObject*)__Pyx_PyCode_New(0, 0, 0, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_scan_perform_pyx, __pyx_n_s_get_version, 61, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__9)) __PYX_ERR(0, 61, __pyx_L1_error)
+  __pyx_codeobj__8 = (PyObject*)__Pyx_PyCode_New(0, 0, 0, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_scan_perform_pyx, __pyx_n_s_get_version, 61, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__8)) __PYX_ERR(0, 61, __pyx_L1_error)
 
   /* "aesara/scan/scan_perform.pyx":65
  * 
@@ -8921,10 +8635,10 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
  *         unsigned int n_shared_outs,
  *         unsigned int n_mit_mot_outs,
  */
-  __pyx_tuple__10 = PyTuple_Pack(81, __pyx_n_s_n_shared_outs, __pyx_n_s_n_mit_mot_outs, __pyx_n_s_n_seqs, __pyx_n_s_n_mit_mot, __pyx_n_s_n_mit_sot, __pyx_n_s_n_sit_sot, __pyx_n_s_n_nit_sot, __pyx_n_s_as_while, __pyx_n_s_mintaps, __pyx_n_s_tap_array, __pyx_n_s_tap_array_len, __pyx_n_s_vector_seqs, __pyx_n_s_vector_outs, __pyx_n_s_mit_mot_out_slices, __pyx_n_s_mitmots_preallocated, __pyx_n_s_outs_is_tensor, __pyx_n_s_inner_input_storage, __pyx_n_s_inner_output_storage, __pyx_n_s_need_update_inputs, __pyx_n_s_inner_input_needs_update, __pyx_n_s_destroy_map, __pyx_n_s_outer_inputs, __pyx_n_s_outer_outputs, __pyx_n_s_outer_output_dtypes, __pyx_n_s_outer_output_ndims, __pyx_n_s_fn, __pyx_n_s_t_fn, __pyx_n_s_n_steps, __pyx_n_s_n_outs, __pyx_n_s_seqs_arg_offset, __pyx_n_s_shared_arg_offset, __pyx_n_s_nit_sot_arg_offset, __pyx_n_s_offset_out, __pyx_n_s_lenpos, __pyx_n_s_pos, __pyx_n_s_len_store_steps, __pyx_n_s_store_steps, __pyx_n_s_l, __pyx_n_s_offset, __pyx_n_s_tap, __pyx_n_s_idx, __pyx_n_s_a_offset, __pyx_n_s_o_offset, __pyx_n_s_idx_2, __pyx_n_s_i, __pyx_n_s_j, __pyx_n_s_k, __pyx_n_s_kdx, __pyx_n_s_tdx, __pyx_n_s_pdx, __pyx_n_s_jout, __pyx_n_s_begin, __pyx_n_s_end, __pyx_n_s_cond, __pyx_n_s_len_output_storage, __pyx_n_s_other_args, __pyx_n_s_nb_mitmot_in, __pyx_n_s_old_mitmot_input_storage, __pyx_n_s_old_mitmot_input_data, __pyx_n_s_old_output_storage, __pyx_n_s_old_output_data, __pyx_n_s_var, __pyx_n_s_t0_fn, __pyx_n_s_exc, __pyx_n_s_dt_fn, __pyx_n_s_needs_update, __pyx_n_s_storage, __pyx_n_s_mitmot_inp_offset, __pyx_n_s_mitmot_out_idx, __pyx_n_s_inp_idx, __pyx_n_s_old_var, __pyx_n_s_new_var, __pyx_n_s_old_data, __pyx_n_s_same_data, __pyx_n_s_output_reused, __pyx_n_s_shape, __pyx_n_s_dtype, __pyx_n_s_e, __pyx_n_s_tmp, __pyx_n_s_sh0, __pyx_n_s_s); if (unlikely(!__pyx_tuple__10)) __PYX_ERR(0, 65, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_tuple__10);
-  __Pyx_GIVEREF(__pyx_tuple__10);
-  __pyx_codeobj__11 = (PyObject*)__Pyx_PyCode_New(26, 0, 81, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__10, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_scan_perform_pyx, __pyx_n_s_perform, 65, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__11)) __PYX_ERR(0, 65, __pyx_L1_error)
+  __pyx_tuple__9 = PyTuple_Pack(78, __pyx_n_s_n_shared_outs, __pyx_n_s_n_mit_mot_outs, __pyx_n_s_n_seqs, __pyx_n_s_n_mit_mot, __pyx_n_s_n_mit_sot, __pyx_n_s_n_sit_sot, __pyx_n_s_n_nit_sot, __pyx_n_s_as_while, __pyx_n_s_mintaps, __pyx_n_s_tap_array, __pyx_n_s_tap_array_len, __pyx_n_s_vector_seqs, __pyx_n_s_vector_outs, __pyx_n_s_mit_mot_out_slices, __pyx_n_s_mitmots_preallocated, __pyx_n_s_outs_is_tensor, __pyx_n_s_inner_input_storage, __pyx_n_s_inner_output_storage, __pyx_n_s_destroy_map, __pyx_n_s_outer_inputs, __pyx_n_s_outer_outputs, __pyx_n_s_outer_output_dtypes, __pyx_n_s_outer_output_ndims, __pyx_n_s_fn, __pyx_n_s_t_fn, __pyx_n_s_n_steps, __pyx_n_s_n_outs, __pyx_n_s_seqs_arg_offset, __pyx_n_s_shared_arg_offset, __pyx_n_s_nit_sot_arg_offset, __pyx_n_s_offset_out, __pyx_n_s_lenpos, __pyx_n_s_pos, __pyx_n_s_len_store_steps, __pyx_n_s_store_steps, __pyx_n_s_l, __pyx_n_s_offset, __pyx_n_s_tap, __pyx_n_s_idx, __pyx_n_s_a_offset, __pyx_n_s_o_offset, __pyx_n_s_idx_2, __pyx_n_s_i, __pyx_n_s_j, __pyx_n_s_k, __pyx_n_s_kdx, __pyx_n_s_tdx, __pyx_n_s_pdx, __pyx_n_s_jout, __pyx_n_s_begin, __pyx_n_s_end, __pyx_n_s_cond, __pyx_n_s_len_output_storage, __pyx_n_s_other_args, __pyx_n_s_nb_mitmot_in, __pyx_n_s_old_mitmot_input_storage, __pyx_n_s_old_mitmot_input_data, __pyx_n_s_old_output_storage, __pyx_n_s_old_output_data, __pyx_n_s_var, __pyx_n_s_t0_fn, __pyx_n_s_exc, __pyx_n_s_dt_fn, __pyx_n_s_mitmot_inp_offset, __pyx_n_s_mitmot_out_idx, __pyx_n_s_inp_idx, __pyx_n_s_inner_inp_idx, __pyx_n_s_old_var, __pyx_n_s_new_var, __pyx_n_s_old_data, __pyx_n_s_same_data, __pyx_n_s_output_reused, __pyx_n_s_shape, __pyx_n_s_dtype, __pyx_n_s_e, __pyx_n_s_tmp, __pyx_n_s_sh0, __pyx_n_s_s); if (unlikely(!__pyx_tuple__9)) __PYX_ERR(0, 65, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__9);
+  __Pyx_GIVEREF(__pyx_tuple__9);
+  __pyx_codeobj__10 = (PyObject*)__Pyx_PyCode_New(24, 0, 78, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__9, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_scan_perform_pyx, __pyx_n_s_perform, 65, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__10)) __PYX_ERR(0, 65, __pyx_L1_error)
   __Pyx_RefNannyFinishContext();
   return 0;
   __pyx_L1_error:;
@@ -8935,10 +8649,9 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
 static CYTHON_SMALL_CODE int __Pyx_InitGlobals(void) {
   if (__Pyx_InitStrings(__pyx_string_tab) < 0) __PYX_ERR(0, 1, __pyx_L1_error);
   __pyx_float_0_0 = PyFloat_FromDouble(0.0); if (unlikely(!__pyx_float_0_0)) __PYX_ERR(0, 1, __pyx_L1_error)
-  __pyx_float_0_313 = PyFloat_FromDouble(0.313); if (unlikely(!__pyx_float_0_313)) __PYX_ERR(0, 1, __pyx_L1_error)
+  __pyx_float_0_314 = PyFloat_FromDouble(0.314); if (unlikely(!__pyx_float_0_314)) __PYX_ERR(0, 1, __pyx_L1_error)
   __pyx_int_0 = PyInt_FromLong(0); if (unlikely(!__pyx_int_0)) __PYX_ERR(0, 1, __pyx_L1_error)
   __pyx_int_1 = PyInt_FromLong(1); if (unlikely(!__pyx_int_1)) __PYX_ERR(0, 1, __pyx_L1_error)
-  __pyx_int_neg_1 = PyInt_FromLong(-1); if (unlikely(!__pyx_int_neg_1)) __PYX_ERR(0, 1, __pyx_L1_error)
   return 0;
   __pyx_L1_error:;
   return -1;
@@ -9334,7 +9047,7 @@ if (!__Pyx_RefNanny) {
  * 
  * 
  * def get_version():             # <<<<<<<<<<<<<<
- *     return 0.313
+ *     return 0.314
  * 
  */
   __pyx_t_2 = PyCFunction_NewEx(&__pyx_mdef_6aesara_4scan_12scan_perform_1get_version, NULL, __pyx_n_s_aesara_scan_scan_perform); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 61, __pyx_L1_error)
@@ -11630,66 +11343,6 @@ static PyObject *__Pyx_PyObject_GetItem(PyObject *obj, PyObject* key) {
     return __Pyx_PyObject_GetIndex(obj, key);
 }
 #endif
-
-/* RaiseTooManyValuesToUnpack */
-  static CYTHON_INLINE void __Pyx_RaiseTooManyValuesError(Py_ssize_t expected) {
-    PyErr_Format(PyExc_ValueError,
-                 "too many values to unpack (expected %" CYTHON_FORMAT_SSIZE_T "d)", expected);
-}
-
-/* RaiseNeedMoreValuesToUnpack */
-  static CYTHON_INLINE void __Pyx_RaiseNeedMoreValuesError(Py_ssize_t index) {
-    PyErr_Format(PyExc_ValueError,
-                 "need more than %" CYTHON_FORMAT_SSIZE_T "d value%.1s to unpack",
-                 index, (index == 1) ? "" : "s");
-}
-
-/* IterFinish */
-  static CYTHON_INLINE int __Pyx_IterFinish(void) {
-#if CYTHON_FAST_THREAD_STATE
-    PyThreadState *tstate = __Pyx_PyThreadState_Current;
-    PyObject* exc_type = tstate->curexc_type;
-    if (unlikely(exc_type)) {
-        if (likely(__Pyx_PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) {
-            PyObject *exc_value, *exc_tb;
-            exc_value = tstate->curexc_value;
-            exc_tb = tstate->curexc_traceback;
-            tstate->curexc_type = 0;
-            tstate->curexc_value = 0;
-            tstate->curexc_traceback = 0;
-            Py_DECREF(exc_type);
-            Py_XDECREF(exc_value);
-            Py_XDECREF(exc_tb);
-            return 0;
-        } else {
-            return -1;
-        }
-    }
-    return 0;
-#else
-    if (unlikely(PyErr_Occurred())) {
-        if (likely(PyErr_ExceptionMatches(PyExc_StopIteration))) {
-            PyErr_Clear();
-            return 0;
-        } else {
-            return -1;
-        }
-    }
-    return 0;
-#endif
-}
-
-/* UnpackItemEndCheck */
-  static int __Pyx_IternextUnpackEndCheck(PyObject *retval, Py_ssize_t expected) {
-    if (unlikely(retval)) {
-        Py_DECREF(retval);
-        __Pyx_RaiseTooManyValuesError(expected);
-        return -1;
-    } else {
-        return __Pyx_IterFinish();
-    }
-    return 0;
-}
 
 /* PyIntBinop */
   #if !CYTHON_COMPILING_IN_PYPY

--- a/aesara/scan/op.py
+++ b/aesara/scan/op.py
@@ -47,7 +47,7 @@ import dataclasses
 import logging
 import time
 from collections import OrderedDict
-from itertools import product
+from itertools import chain, product
 from typing import Callable, List, Optional, Union
 
 import numpy as np
@@ -203,11 +203,9 @@ def copy_var_format(var, as_var):
 
 @dataclasses.dataclass(frozen=True)
 class ScanInfo:
-    tap_array: tuple
-    """
-    This is a tuple containing tuples of inner-output lag/lead values for the
-    mit-mots, mit-sots, and ``[-1]`` for each sit-sot.
-    """
+    mit_mot_in_slices: tuple
+    mit_sot_in_slices: tuple
+    sit_sot_in_slices: tuple
     n_seqs: int
     n_mit_mot: int
     n_mit_mot_outs: int
@@ -218,6 +216,10 @@ class ScanInfo:
     n_nit_sot: int
     n_non_seqs: int
     as_while: bool
+
+    @property
+    def tap_array(self):
+        return self.mit_mot_in_slices + self.mit_sot_in_slices + self.sit_sot_in_slices
 
 
 TensorConstructorType = Callable[[List[bool], Union[str, np.generic]], TensorType]
@@ -235,7 +237,7 @@ class ScanMethodsMixin:
         return list_inputs[1 : 1 + self.info.n_seqs]
 
     def inner_mitmot(self, list_inputs):
-        n_taps = sum(len(x) for x in self.info.tap_array[: self.info.n_mit_mot])
+        n_taps = sum(len(x) for x in self.info.mit_mot_in_slices)
         return list_inputs[self.info.n_seqs : self.info.n_seqs + n_taps]
 
     def outer_mitmot(self, list_inputs):
@@ -251,16 +253,15 @@ class ScanMethodsMixin:
         return list_outputs[: self.info.n_mit_mot]
 
     def mitmot_taps(self):
-        return self.info.tap_array[: self.info.n_mit_mot]
+        return self.info.mit_mot_in_slices
 
     def mitmot_out_taps(self):
         return self.info.mit_mot_out_slices[: self.info.n_mit_mot]
 
     def inner_mitsot(self, list_inputs):
-        n_mitmot_taps = sum(len(x) for x in self.info.tap_array[: self.info.n_mit_mot])
-        ntaps_upto_sit_sot = sum(
-            len(x)
-            for x in self.info.tap_array[: (self.info.n_mit_mot + self.info.n_mit_sot)]
+        n_mitmot_taps = sum(len(x) for x in self.info.mit_mot_in_slices)
+        ntaps_upto_sit_sot = n_mitmot_taps + sum(
+            len(x) for x in self.info.mit_sot_in_slices
         )
         return list_inputs[
             self.info.n_seqs + n_mitmot_taps : self.info.n_seqs + ntaps_upto_sit_sot
@@ -280,14 +281,12 @@ class ScanMethodsMixin:
         ]
 
     def mitsot_taps(self):
-        return self.info.tap_array[
-            self.info.n_mit_mot : self.info.n_mit_mot + self.info.n_mit_sot
-        ]
+        return self.info.mit_sot_in_slices
 
     def inner_sitsot(self, list_inputs):
         n_taps_upto_sit_sot = sum(
             len(x)
-            for x in self.info.tap_array[: (self.info.n_mit_mot + self.info.n_mit_sot)]
+            for x in chain(self.info.mit_mot_in_slices, self.info.mit_sot_in_slices)
         )
         offset = self.info.n_seqs + n_taps_upto_sit_sot
         return list_inputs[offset : offset + self.info.n_sit_sot]
@@ -328,7 +327,7 @@ class ScanMethodsMixin:
     def inner_shared(self, list_inputs):
         n_taps_upto_sit_sot = sum(
             len(x)
-            for x in self.info.tap_array[: (self.info.n_mit_mot + self.info.n_mit_sot)]
+            for x in chain(self.info.mit_mot_in_slices, self.info.mit_sot_in_slices)
         )
         offset = self.info.n_seqs + n_taps_upto_sit_sot + self.info.n_sit_sot
         return list_inputs[offset : offset + self.info.n_shared_outs]
@@ -362,7 +361,7 @@ class ScanMethodsMixin:
     def inner_non_seqs(self, list_inputs):
         n_taps_upto_sit_sot = sum(
             len(x)
-            for x in self.info.tap_array[: (self.info.n_mit_mot + self.info.n_mit_sot)]
+            for x in chain(self.info.mit_mot_in_slices, self.info.mit_sot_in_slices)
         )
         offset = (
             self.info.n_seqs
@@ -427,8 +426,14 @@ class ScanMethodsMixin:
             outer_oidx += 0
 
         # Handle mitmots, mitsots and sitsots variables
-        for i in range(len(self.info.tap_array)):
-            nb_input_taps = len(self.info.tap_array[i])
+        for i, tap in enumerate(
+            chain(
+                self.info.mit_mot_in_slices,
+                self.info.mit_sot_in_slices,
+                self.info.sit_sot_in_slices,
+            )
+        ):
+            nb_input_taps = len(tap)
 
             if i < self.info.n_mit_mot:
                 nb_output_taps = len(self.info.mit_mot_out_slices[i])
@@ -758,7 +763,12 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             self.name = "scan_fn"
 
         # Pre-computing some values to speed up perform
-        self.mintaps = [np.min(x) for x in info.tap_array]
+        self.mintaps = [
+            min(x)
+            for x in chain(
+                info.mit_mot_in_slices, info.mit_sot_in_slices, info.sit_sot_in_slices
+            )
+        ]
         self.mintaps += [0 for x in range(info.n_nit_sot)]
         self.seqs_arg_offset = 1 + info.n_seqs
         self.shared_arg_offset = (
@@ -813,7 +823,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             info = self.info
             input_idx = info.n_seqs
             for mitmot_idx in range(info.n_mit_mot):
-                for inp_tap in info.tap_array[mitmot_idx]:
+                for inp_tap in info.mit_mot_in_slices[mitmot_idx]:
                     if inp_tap in info.mit_mot_out_slices[mitmot_idx]:
                         # Figure out the index of the corresponding output
                         output_idx = sum(
@@ -1292,7 +1302,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
 
             input_idx = self.info.n_seqs
             for mitmot_idx in range(self.info.n_mit_mot):
-                for inp_tap in self.info.tap_array[mitmot_idx]:
+                for inp_tap in self.info.mit_mot_in_slices[mitmot_idx]:
                     if inp_tap in self.info.mit_mot_out_slices[mitmot_idx]:
                         inp = self.inputs[input_idx]
 
@@ -1447,7 +1457,14 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
 
             cython_mintaps = np.asarray(self.mintaps, dtype="int32")
 
-            tap_array_len = tuple(len(x) for x in self.info.tap_array)
+            tap_array_len = tuple(
+                len(x)
+                for x in chain(
+                    self.info.mit_mot_in_slices,
+                    self.info.mit_sot_in_slices,
+                    self.info.sit_sot_in_slices,
+                )
+            )
 
             cython_vector_seqs = np.asarray(self.vector_seqs, dtype="int32")
             cython_vector_outs = np.asarray(self.vector_outs, dtype="int32")
@@ -1506,7 +1523,9 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                         self.info.n_nit_sot,
                         self.info.as_while,
                         cython_mintaps,
-                        self.info.tap_array,
+                        self.info.mit_mot_in_slices
+                        + self.info.mit_sot_in_slices
+                        + self.info.sit_sot_in_slices,
                         tap_array_len,
                         cython_vector_seqs,
                         cython_vector_outs,
@@ -1679,7 +1698,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         offset = self.nit_sot_arg_offset + info.n_nit_sot
         other_args = inputs[offset:]
         inner_input_storage = self.fn.input_storage
-        nb_mitmot_in = sum(map(len, info.tap_array[: info.n_mit_mot]))
+        nb_mitmot_in = sum(map(len, info.mit_mot_in_slices))
         old_mitmot_input_storage = [None] * nb_mitmot_in
         old_mitmot_input_data = [None] * nb_mitmot_in
         inner_output_storage = self.fn.output_storage
@@ -1688,7 +1707,14 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         fn = self.fn.fn
         offset = (
             info.n_seqs
-            + sum(map(len, info.tap_array[: self.n_outs]))
+            + sum(
+                len(x)
+                for x in chain(
+                    info.mit_mot_in_slices,
+                    info.mit_sot_in_slices,
+                    info.sit_sot_in_slices,
+                )
+            )
             + info.n_shared_outs
         )
         for idx in range(len(other_args)):
@@ -1710,17 +1736,23 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                     inner_input_storage[idx].storage[0] = seqs[idx][i]
 
             offset = info.n_seqs
-            for idx in range(self.n_outs):
+            for idx, taps in enumerate(
+                chain(
+                    info.mit_mot_in_slices,
+                    info.mit_sot_in_slices,
+                    info.sit_sot_in_slices,
+                )
+            ):
                 if self.vector_outs[idx]:
-                    for tap in info.tap_array[idx]:
-                        _idx = (pos[idx] + tap) % store_steps[idx]
+                    for t in taps:
+                        _idx = (pos[idx] + t) % store_steps[idx]
                         inner_input_storage[offset].storage[0] = output_storage[idx][0][
                             _idx : _idx + 1
                         ].reshape(())
                         offset += 1
                 else:
-                    for tap in info.tap_array[idx]:
-                        _idx = (pos[idx] + tap) % store_steps[idx]
+                    for t in taps:
+                        _idx = (pos[idx] + t) % store_steps[idx]
                         inner_input_storage[offset].storage[0] = output_storage[idx][0][
                             _idx
                         ]
@@ -1864,11 +1896,11 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             # 5.3 Copy over the values for mit_mot outputs
             mitmot_inp_offset = 0
             mitmot_out_idx = 0
-            for j in range(info.n_mit_mot):
+            for j, taps in enumerate(info.mit_mot_in_slices):
                 for k in info.mit_mot_out_slices[j]:
                     if self.mitmots_preallocated[mitmot_out_idx]:
                         # This output tap has been preallocated.
-                        inp_idx = mitmot_inp_offset + info.tap_array[j].index(k)
+                        inp_idx = mitmot_inp_offset + taps.index(k)
 
                         # Verify whether the input points to the same data as
                         # it did before the execution of the inner function.
@@ -1899,7 +1931,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
 
                     mitmot_out_idx += 1
 
-                mitmot_inp_offset += len(info.tap_array[j])
+                mitmot_inp_offset += len(taps)
 
             # 5.4 Copy over the values for mit_sot/sit_sot outputs
             begin = info.n_mit_mot
@@ -2141,14 +2173,17 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
 
         n_outs = info.n_mit_mot + info.n_mit_sot + info.n_sit_sot
         outs_shape = []
-        for idx in range(n_outs):
-            abs(min(info.tap_array[idx]))
-            for k in info.tap_array[idx]:
+        for idx, taps in enumerate(
+            chain(
+                info.mit_mot_in_slices, info.mit_sot_in_slices, info.sit_sot_in_slices
+            )
+        ):
+            for k in taps:
                 outs_shape += [input_shapes[idx + info.n_seqs + 1][1:]]
                 # if extra_infer_shape:
+                #     mintap = abs(min(taps))
                 #     corresponding_tap = node.inputs[outer_inp_idx][mintap + k]
                 #     out_equivalent[self.inputs[inner_inp_idx]] = corresponding_tap
-                #     inner_inp_idx += 1
             outer_inp_idx += 1
 
         # shared_outs
@@ -2511,7 +2546,14 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
 
             # Check if the pos-th input is associated with one of the
             # recurrent states
-            x_is_state = pos < sum(len(t) for t in info.tap_array)
+            x_is_state = pos < sum(
+                len(t)
+                for t in chain(
+                    info.mit_mot_in_slices,
+                    info.mit_sot_in_slices,
+                    info.sit_sot_in_slices,
+                )
+            )
 
             if x_is_state and len(idxs) > 0:
                 opos = idxs[0]
@@ -2537,14 +2579,16 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             outer_inp_seqs = [x[n_steps - 1 :: -1] for x in inputs[1 : 1 + info.n_seqs]]
         else:
             outer_inp_seqs = [x[::-1] for x in inputs[1 : 1 + info.n_seqs]]
-        for idx in range(info.n_mit_mot + info.n_mit_sot):
-            mintap = np.min(info.tap_array[idx])
+        for idx, taps in enumerate(
+            chain(info.mit_mot_in_slices, info.mit_sot_in_slices)
+        ):
+            mintap = min(taps)
             if idx < info.n_mit_mot:
                 outmaxtap = np.max(self.mitmot_out_taps()[idx])
             else:
                 outmaxtap = 0
             seq = outs[idx]
-            for k in info.tap_array[idx]:
+            for k in taps:
                 if outmaxtap - k != 0:
                     nw_seq = seq[k - mintap : -(outmaxtap - k)][::-1]
                 else:
@@ -2611,7 +2655,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         n_mitmot_outs = 0
         n_mitmot_inps = 0
 
-        for idx in range(info.n_mit_mot):
+        for idx, taps in enumerate(info.mit_mot_in_slices):
             if isinstance(dC_douts[idx].type, DisconnectedType):
                 out = outs[idx]
                 outer_inp_mitmot.append(at.zeros_like(out))
@@ -2623,14 +2667,14 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             through_shared = False
             disconnected = True
 
-            for jdx in range(len(info.mit_mot_out_slices[idx])):
+            for mit_mot_out_slice in info.mit_mot_out_slices[idx]:
                 inner_inp_mitmot.append(dC_dXts[out_pos])
-                mitmot_inp_taps[idx].append(-info.mit_mot_out_slices[idx][jdx])
+                mitmot_inp_taps[idx].append(-mit_mot_out_slice)
                 n_mitmot_inps += 1
                 out_pos += 1
 
-            for jdx in range(len(info.tap_array[idx])):
-                tap = -info.tap_array[idx][jdx]
+            for tap in taps:
+                tap = -tap
 
                 # Only create a new inner input if there is not already one
                 # associated with this input tap
@@ -2656,29 +2700,27 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                             idx
                         ].index(tap)
                         replacement = inner_inp_mitmot[-replacement_idx]
-
-                        info.tap_array[idx]
                         new_inner_out_mitmot = clone_replace(
                             new_inner_out_mitmot, replace=[(to_replace, replacement)]
                         )
 
                     inner_out_mitmot.append(new_inner_out_mitmot)
 
-                if not disconnected_dC_dinps_t[ins_pos]:
-                    disconnected = False
+                disconnected &= disconnected_dC_dinps_t[ins_pos]
 
-                for _sh in self.inner_shared(self_inputs):
-                    if _sh in graph_inputs([dC_dinps_t[ins_pos]]):
-                        through_shared = True
+                through_shared = any(
+                    _sh in graph_inputs([dC_dinps_t[ins_pos]])
+                    for _sh in self.inner_shared(self_inputs)
+                )
 
                 ins_pos += 1
                 n_mitmot_outs += 1
-                mitmot_out_taps[idx].append(-info.tap_array[idx][jdx])
+                mitmot_out_taps[idx].append(tap)
 
                 # Only add the tap as a new input tap if needed
                 if tap not in mitmot_inp_taps[idx]:
                     n_mitmot_inps += 1
-                    mitmot_inp_taps[idx].append(-info.tap_array[idx][jdx])
+                    mitmot_inp_taps[idx].append(tap)
 
             if undefined_msg:
                 type_outs.append(undefined_msg)
@@ -2690,14 +2732,13 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                 type_outs.append("connected")
 
         offset = info.n_mit_mot
-        for idx in range(info.n_mit_sot):
+        for idx, taps in enumerate(info.mit_sot_in_slices):
             if isinstance(dC_douts[idx + offset].type, DisconnectedType):
                 outer_inp_mitmot.append(outs[idx + offset].zeros_like())
             else:
                 outer_inp_mitmot.append(dC_douts[idx + offset][::-1])
             mitmot_inp_taps.append([])
             mitmot_out_taps.append([])
-            idx_tap = idx + info.n_mit_mot
             inner_inp_mitmot.append(dC_dXts[out_pos])
             out_pos += 1
             n_mitmot_inps += 1
@@ -2705,7 +2746,8 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             through_shared = False
             disconnected = True
             mitmot_inp_taps[idx + offset].append(0)
-            for jdx in range(len(info.tap_array[idx_tap])):
+            for tap in taps:
+                tap = -tap
                 inner_inp_mitmot.append(dC_dXtm1s[ins_pos - info.n_seqs])
 
                 if isinstance(dC_dinps_t[ins_pos].type, NullType):
@@ -2718,13 +2760,15 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                 else:
                     inner_out_mitmot.append(dC_dinps_t[ins_pos])
 
-                mitmot_inp_taps[idx + offset].append(-info.tap_array[idx_tap][jdx])
-                mitmot_out_taps[idx].append(-info.tap_array[idx_tap][jdx])
-                if not disconnected_dC_dinps_t[ins_pos]:
-                    disconnected = False
-                for _sh in self.inner_shared(self_inputs):
-                    if _sh in graph_inputs([dC_dinps_t[ins_pos]]):
-                        through_shared = True
+                mitmot_inp_taps[idx + offset].append(tap)
+                mitmot_out_taps[idx].append(tap)
+
+                disconnected &= disconnected_dC_dinps_t[ins_pos]
+
+                through_shared = any(
+                    _sh in graph_inputs([dC_dinps_t[ins_pos]])
+                    for _sh in self.inner_shared(self_inputs)
+                )
 
                 n_mitmot_inps += 1
                 ins_pos += 1
@@ -2770,9 +2814,10 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             else:
                 inner_out_mitmot.append(dC_dinps_t[ins_pos])
 
-            for _sh in self.inner_shared(self_inputs):
-                if _sh in graph_inputs([dC_dinps_t[ins_pos]]):
-                    through_shared = True
+            through_shared = any(
+                _sh in graph_inputs([dC_dinps_t[ins_pos]])
+                for _sh in self.inner_shared(self_inputs)
+            )
 
             if isinstance(dC_dinps_t[ins_pos].type, NullType):
                 type_outs.append(dC_dinps_t[ins_pos].type.why_null)
@@ -2860,7 +2905,6 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                 )
 
         n_sitsot_outs = len(outer_inp_sitsot)
-        new_tap_array = mitmot_inp_taps + [[-1] for k in range(n_sitsot_outs)]
 
         outer_inputs = (
             [grad_steps]
@@ -2884,7 +2928,9 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         out_info = ScanInfo(
             n_seqs=len(outer_inp_seqs),
             n_mit_sot=0,
-            tap_array=tuple(tuple(v) for v in new_tap_array),
+            mit_mot_in_slices=tuple(tuple(v) for v in mitmot_inp_taps),
+            mit_sot_in_slices=(),
+            sit_sot_in_slices=tuple((-1,) for k in range(n_sitsot_outs)),
             n_mit_mot=len(outer_inp_mitmot),
             n_mit_mot_outs=n_mitmot_outs,
             mit_mot_out_slices=tuple(tuple(v) for v in mitmot_out_taps),
@@ -3065,16 +3111,9 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         # evan point for the number of nit_sot which I think should just be
         # ignored (?)
 
-        new_tap_array = []
-        b = 0
-        e = info.n_mit_mot
-        new_tap_array += info.tap_array[b:e] * 2
-        b = e
-        e += info.n_mit_sot
-        new_tap_array += info.tap_array[b:e] * 2
-        b = e
-        e += info.n_sit_sot
-        new_tap_array += info.tap_array[b:e] * 2
+        new_mit_mot_in_slices = info.mit_mot_in_slices * 2
+        new_mit_sot_in_slices = info.mit_sot_in_slices * 2
+        new_sit_sot_in_slices = info.sit_sot_in_slices * 2
 
         # Sequences ...
         b = 1
@@ -3095,7 +3134,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         b = e
         e = e + info.n_mit_mot
         ib = ie
-        ie = ie + int(sum(len(x) for x in info.tap_array[: info.n_mit_mot]))
+        ie = ie + int(sum(len(x) for x in info.mit_mot_in_slices))
         clean_eval_points = []
         for inp, evp in zip(inputs[b:e], eval_points[b:e]):
             if evp is not None:
@@ -3110,14 +3149,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
         b = e
         e = e + info.n_mit_sot
         ib = ie
-        ie = ie + int(
-            sum(
-                len(x)
-                for x in info.tap_array[
-                    info.n_mit_mot : info.n_mit_mot + info.n_mit_sot
-                ]
-            )
-        )
+        ie = ie + int(sum(len(x) for x in info.mit_sot_in_slices))
         clean_eval_points = []
         for inp, evp in zip(inputs[b:e], eval_points[b:e]):
             if evp is not None:
@@ -3217,13 +3249,15 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
 
         out_info = ScanInfo(
             n_seqs=info.n_seqs * 2,
+            mit_mot_in_slices=new_mit_mot_in_slices,
+            mit_sot_in_slices=new_mit_sot_in_slices,
+            sit_sot_in_slices=new_sit_sot_in_slices,
             n_mit_sot=info.n_mit_sot * 2,
             n_sit_sot=info.n_sit_sot * 2,
             n_mit_mot=info.n_mit_mot * 2,
             n_nit_sot=info.n_nit_sot * 2,
             n_shared_outs=info.n_shared_outs,
             n_mit_mot_outs=n_mit_mot_outs * 2,
-            tap_array=tuple(tuple(v) for v in new_tap_array),
             mit_mot_out_slices=tuple(tuple(v) for v in info.mit_mot_out_slices) * 2,
             n_non_seqs=len(inner_other),
             as_while=info.as_while,

--- a/aesara/scan/op.py
+++ b/aesara/scan/op.py
@@ -877,7 +877,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             mitsot_start = info.n_mit_mot_outs - len(self.preallocated_mitmot_outs)
             nitsot_end = mitsot_start + info.n_mit_sot + info.n_sit_sot + info.n_nit_sot
 
-            features.append(NoOutputFromInplace(mitsot_start, nitsot_end))
+            features.append(NoOutputFromInplace(range(mitsot_start, nitsot_end)))
 
         self.fgraph = FunctionGraph(
             inputs,

--- a/aesara/scan/op.py
+++ b/aesara/scan/op.py
@@ -47,6 +47,7 @@ import dataclasses
 import logging
 import time
 from collections import OrderedDict
+from copy import copy
 from itertools import chain, product
 from typing import Callable, List, Optional, Union
 
@@ -1494,6 +1495,11 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
     @property
     def inner_outputs(self):
         return self.fgraph.outputs
+
+    def clone(self):
+        res = copy(self)
+        res.fgraph = res.fgraph.clone()
+        return res
 
     def make_thunk(self, node, storage_map, compute_map, no_recycling, impl=None):
         """

--- a/aesara/scan/opt.py
+++ b/aesara/scan/opt.py
@@ -720,6 +720,8 @@ def push_out_inner_vars(
             fgraph, old_scan_node, old_scan_args, add_as_nitsots
         )
 
+        assert isinstance(new_scan_node.op, Scan)
+
         new_scan_args = ScanArgs(
             new_scan_node.inputs,
             new_scan_node.outputs,
@@ -760,6 +762,8 @@ def add_nitsot_outputs(
     new_scan_args = copy.copy(old_scan_args)
     new_scan_args.inner_out_nit_sot.extend(new_outputs_inner)
     new_scan_args.outer_in_nit_sot.extend(new_nitsots_initial_value)
+
+    assert isinstance(old_scan_node.op, Scan)
 
     # Create the `Scan` `Op` from the `ScanArgs`
     new_scan_op = Scan(

--- a/aesara/scan/opt.py
+++ b/aesara/scan/opt.py
@@ -1794,17 +1794,13 @@ class ScanMerge(GlobalOptimizer):
                     new_inner_outs += inner_outs[idx][gr_idx]
 
         info = ScanInfo(
+            n_seqs=sum(nd.op.n_seqs for nd in nodes),
             mit_mot_in_slices=mit_mot_in_slices,
+            mit_mot_out_slices=mit_mot_out_slices,
             mit_sot_in_slices=mit_sot_in_slices,
             sit_sot_in_slices=sit_sot_in_slices,
-            n_seqs=sum(nd.op.n_seqs for nd in nodes),
-            n_mit_mot=sum(nd.op.n_mit_mot for nd in nodes),
-            n_mit_mot_outs=sum(nd.op.n_mit_mot_outs for nd in nodes),
-            mit_mot_out_slices=mit_mot_out_slices,
-            n_mit_sot=sum(nd.op.n_mit_sot for nd in nodes),
-            n_sit_sot=sum(nd.op.n_sit_sot for nd in nodes),
-            n_shared_outs=sum(nd.op.n_shared_outs for nd in nodes),
             n_nit_sot=sum(nd.op.n_nit_sot for nd in nodes),
+            n_shared_outs=sum(nd.op.n_shared_outs for nd in nodes),
             n_non_seqs=n_non_seqs,
             as_while=as_while,
         )
@@ -2218,7 +2214,6 @@ def push_out_dot1_scan(fgraph, node):
                         op.info,
                         sit_sot_in_slices=op.info.sit_sot_in_slices[:idx]
                         + op.info.sit_sot_in_slices[idx + 1 :],
-                        n_sit_sot=op.info.n_sit_sot - 1,
                         n_nit_sot=op.info.n_nit_sot + 1,
                     )
                     inner_sitsot = inner_sitsot[:idx] + inner_sitsot[idx + 1 :]

--- a/aesara/scan/opt.py
+++ b/aesara/scan/opt.py
@@ -751,6 +751,8 @@ def add_nitsot_outputs(
     new_outputs_inner,
 ) -> Tuple[Apply, Dict[Variable, Variable]]:
 
+    assert isinstance(old_scan_node.op, Scan)
+
     nb_new_outs = len(new_outputs_inner)
 
     # Create the initial values for the new nitsot outputs

--- a/aesara/scan/opt.py
+++ b/aesara/scan/opt.py
@@ -168,7 +168,9 @@ def remove_constants_and_unused_inputs_scan(fgraph, node):
 
     if len(nw_inner) != len(op_ins):
         op_outs = clone_replace(op_outs, replace=givens)
-        nw_info = dataclasses.replace(op.info, n_seqs=nw_n_seqs)
+        nw_info = dataclasses.replace(
+            op.info, n_seqs=nw_n_seqs, n_non_seqs=len(nw_inner_nonseq)
+        )
         nwScan = Scan(
             nw_inner,
             op_outs,
@@ -339,11 +341,15 @@ def push_out_non_seq_scan(fgraph, node):
         op_outs = clone_replace(node_outputs, replace=givens)
         op_ins = node_inputs + nw_inner
 
+        new_info = dataclasses.replace(
+            op.info, n_non_seqs=op.info.n_non_seqs + len(nw_outer)
+        )
+
         # Reconstruct node
         nwScan = Scan(
             op_ins,
             op_outs,
-            op.info,
+            new_info,
             mode=op.mode,
             as_while=op.as_while,
             profile=op.profile,
@@ -1725,9 +1731,12 @@ class ScanMerge(GlobalOptimizer):
             outer_outs += nd.op.outer_shared_outs(nd.outputs)
             inner_outs[idx].append(nd.op.inner_shared_outs(nd.op.outputs))
 
+        n_non_seqs = 0
         for idx, nd in enumerate(nodes):
             # Non Seqs
-            inner_ins[idx].append(rename(nd.op.inner_non_seqs(nd.op.inputs), idx))
+            node_inner_non_seqs = nd.op.inner_non_seqs(nd.op.inputs)
+            n_non_seqs += len(node_inner_non_seqs)
+            inner_ins[idx].append(rename(node_inner_non_seqs, idx))
             outer_ins += rename(nd.op.outer_non_seqs(nd.inputs), idx)
 
         # Add back the number of steps
@@ -1803,6 +1812,7 @@ class ScanMerge(GlobalOptimizer):
             n_sit_sot=sum(nd.op.n_sit_sot for nd in nodes),
             n_shared_outs=sum(nd.op.n_shared_outs for nd in nodes),
             n_nit_sot=sum(nd.op.n_nit_sot for nd in nodes),
+            n_non_seqs=n_non_seqs,
         )
 
         old_op = nodes[0].op

--- a/aesara/scan/scan_perform_ext.py
+++ b/aesara/scan/scan_perform_ext.py
@@ -23,7 +23,7 @@ if not config.cxx:
 
 _logger = logging.getLogger("aesara.scan.scan_perform")
 
-version = 0.313  # must match constant returned in function get_version()
+version = 0.314  # must match constant returned in function get_version()
 
 need_reload = False
 scan_perform: Optional[ModuleType] = None

--- a/aesara/scan/utils.py
+++ b/aesara/scan/utils.py
@@ -407,6 +407,7 @@ def compress_outs(op, not_required, inputs):
         n_sit_sot=0,
         n_shared_outs=0,
         n_nit_sot=0,
+        n_non_seqs=0,
     )
 
     op_inputs = op.inputs[: op.n_seqs]
@@ -525,6 +526,7 @@ def compress_outs(op, not_required, inputs):
     node_inputs += nit_sot_ins
     # other stuff
     op_inputs += op.inputs[i_offset:]
+    info = dataclasses.replace(info, n_non_seqs=len(op.inputs[i_offset:]))
     node_inputs += inputs[ni_offset + op.n_shared_outs + op.n_nit_sot :]
     if op.as_while:
         op_outputs += [op.outputs[o_offset]]
@@ -812,6 +814,7 @@ class ScanArgs:
             n_shared_outs=len(self.outer_in_shared),
             n_mit_mot_outs=sum(len(s) for s in self.mit_mot_out_slices),
             mit_mot_out_slices=tuple(self.mit_mot_out_slices),
+            n_non_seqs=len(self.inner_in_non_seqs),
         )
 
     def get_alt_field(

--- a/aesara/scan/utils.py
+++ b/aesara/scan/utils.py
@@ -408,6 +408,7 @@ def compress_outs(op, not_required, inputs):
         n_shared_outs=0,
         n_nit_sot=0,
         n_non_seqs=0,
+        as_while=op.info.as_while,
     )
 
     op_inputs = op.inputs[: op.n_seqs]
@@ -528,7 +529,7 @@ def compress_outs(op, not_required, inputs):
     op_inputs += op.inputs[i_offset:]
     info = dataclasses.replace(info, n_non_seqs=len(op.inputs[i_offset:]))
     node_inputs += inputs[ni_offset + op.n_shared_outs + op.n_nit_sot :]
-    if op.as_while:
+    if op.info.as_while:
         op_outputs += [op.outputs[o_offset]]
         map_old_new[o_offset] = len(op_outputs) - 1
         # map_old_new[len(op_outputs)-1] = o_offset
@@ -582,11 +583,10 @@ class ScanArgs:
         _inner_inputs: Sequence[Variable],
         _inner_outputs: Sequence[Variable],
         info: "ScanInfo",
-        as_while: bool,
         clone: Optional[bool] = True,
     ):
         self.n_steps = outer_inputs[0]
-        self.as_while = as_while
+        self.as_while = info.as_while
 
         if clone:
             rval = reconstruct_graph(_inner_inputs, _inner_outputs, "")
@@ -710,7 +710,6 @@ class ScanArgs:
             node.op.inputs,
             node.op.outputs,
             node.op.info,
-            node.op.as_while,
             clone=clone,
         )
 
@@ -815,6 +814,7 @@ class ScanArgs:
             n_mit_mot_outs=sum(len(s) for s in self.mit_mot_out_slices),
             mit_mot_out_slices=tuple(self.mit_mot_out_slices),
             n_non_seqs=len(self.inner_in_non_seqs),
+            as_while=self.as_while,
         )
 
     def get_alt_field(

--- a/aesara/scan/utils.py
+++ b/aesara/scan/utils.py
@@ -401,17 +401,13 @@ def compress_outs(op, not_required, inputs):
     from aesara.scan.op import ScanInfo
 
     info = ScanInfo(
+        n_seqs=op.info.n_seqs,
         mit_mot_in_slices=(),
+        mit_mot_out_slices=(),
         mit_sot_in_slices=(),
         sit_sot_in_slices=(),
-        n_seqs=op.info.n_seqs,
-        n_mit_mot=0,
-        n_mit_mot_outs=0,
-        mit_mot_out_slices=(),
-        n_mit_sot=0,
-        n_sit_sot=0,
-        n_shared_outs=0,
         n_nit_sot=0,
+        n_shared_outs=0,
         n_non_seqs=0,
         as_while=op.info.as_while,
     )
@@ -432,7 +428,6 @@ def compress_outs(op, not_required, inputs):
             curr_pos += 1
             info = dataclasses.replace(
                 info,
-                n_mit_mot=info.n_mit_mot + 1,
                 mit_mot_in_slices=info.mit_mot_in_slices + (op.mit_mot_in_slices[idx],),
                 mit_mot_out_slices=info.mit_mot_out_slices
                 + (op.mit_mot_out_slices[idx],),
@@ -451,7 +446,6 @@ def compress_outs(op, not_required, inputs):
             o_offset += len(op.mit_mot_out_slices[idx])
             i_offset += len(op.mit_mot_in_slices[idx])
 
-    info = dataclasses.replace(info, n_mit_mot_outs=len(op_outputs))
     offset += op.n_mit_mot
     ni_offset += op.n_mit_mot
 
@@ -461,7 +455,6 @@ def compress_outs(op, not_required, inputs):
             curr_pos += 1
             info = dataclasses.replace(
                 info,
-                n_mit_sot=info.n_mit_sot + 1,
                 mit_sot_in_slices=info.mit_sot_in_slices + (op.mit_sot_in_slices[idx],),
             )
             # input taps
@@ -485,7 +478,6 @@ def compress_outs(op, not_required, inputs):
             curr_pos += 1
             info = dataclasses.replace(
                 info,
-                n_sit_sot=info.n_sit_sot + 1,
                 sit_sot_in_slices=info.sit_sot_in_slices + (op.sit_sot_in_slices[idx],),
             )
             # input taps
@@ -807,17 +799,13 @@ class ScanArgs:
         from aesara.scan.op import ScanInfo
 
         return ScanInfo(
+            n_seqs=len(self.outer_in_seqs),
             mit_mot_in_slices=tuple(tuple(v) for v in self.mit_mot_in_slices),
+            mit_mot_out_slices=tuple(self.mit_mot_out_slices),
             mit_sot_in_slices=tuple(tuple(v) for v in self.mit_sot_in_slices),
             sit_sot_in_slices=((-1,),) * len(self.inner_in_sit_sot),
-            n_seqs=len(self.outer_in_seqs),
-            n_mit_mot=len(self.outer_in_mit_mot),
-            n_mit_sot=len(self.outer_in_mit_sot),
-            n_sit_sot=len(self.outer_in_sit_sot),
             n_nit_sot=len(self.outer_in_nit_sot),
             n_shared_outs=len(self.outer_in_shared),
-            n_mit_mot_outs=sum(len(s) for s in self.mit_mot_out_slices),
-            mit_mot_out_slices=tuple(self.mit_mot_out_slices),
             n_non_seqs=len(self.inner_in_non_seqs),
             as_while=self.as_while,
         )

--- a/aesara/scan/utils.py
+++ b/aesara/scan/utils.py
@@ -4,6 +4,7 @@ import copy
 import dataclasses
 import logging
 from collections import OrderedDict, namedtuple
+from itertools import chain
 from typing import TYPE_CHECKING, Callable, List, Optional, Sequence, Set, Tuple, Union
 from typing import cast as type_cast
 
@@ -348,11 +349,12 @@ class Validator:
 
 
 def scan_can_remove_outs(op, out_idxs):
-    """
-    Looks at all outputs defined by indices ``out_idxs`` and see whom can be
-    removed from the scan op without affecting the rest. Return two lists,
-    the first one with the indices of outs that can be removed, the second
-    with the outputs that can not be removed.
+    """Look at all outputs defined by indices ``out_idxs`` and determines which can be removed.
+
+    Returns
+    -------
+    two lists, the first one with the indices of outs that can be removed, the
+    second with the outputs that can not be removed.
 
     """
     non_removable = [o for i, o in enumerate(op.outputs) if i not in out_idxs]
@@ -360,9 +362,10 @@ def scan_can_remove_outs(op, out_idxs):
 
     out_ins = []
     offset = op.n_seqs
-    lim = op.n_mit_mot + op.n_mit_sot + op.n_sit_sot
-    for idx in range(lim):
-        n_ins = len(op.info.tap_array[idx])
+    for idx, tap in enumerate(
+        chain(op.mit_mot_in_slices, op.mit_sot_in_slices, op.sit_sot_in_slices)
+    ):
+        n_ins = len(tap)
         out_ins += [op.inputs[offset : offset + n_ins]]
         offset += n_ins
     out_ins += [[] for k in range(op.n_nit_sot)]
@@ -398,7 +401,9 @@ def compress_outs(op, not_required, inputs):
     from aesara.scan.op import ScanInfo
 
     info = ScanInfo(
-        tap_array=(),
+        mit_mot_in_slices=(),
+        mit_sot_in_slices=(),
+        sit_sot_in_slices=(),
         n_seqs=op.info.n_seqs,
         n_mit_mot=0,
         n_mit_mot_outs=0,
@@ -428,23 +433,24 @@ def compress_outs(op, not_required, inputs):
             info = dataclasses.replace(
                 info,
                 n_mit_mot=info.n_mit_mot + 1,
-                tap_array=info.tap_array + (tuple(op.tap_array[offset + idx]),),
+                mit_mot_in_slices=info.mit_mot_in_slices + (op.mit_mot_in_slices[idx],),
                 mit_mot_out_slices=info.mit_mot_out_slices
-                + (tuple(op.mit_mot_out_slices[offset + idx]),),
+                + (op.mit_mot_out_slices[idx],),
             )
             # input taps
-            for jdx in op.tap_array[offset + idx]:
+            for jdx in op.mit_mot_in_slices[idx]:
                 op_inputs += [op.inputs[i_offset]]
                 i_offset += 1
             # output taps
-            for jdx in op.mit_mot_out_slices[offset + idx]:
+            for jdx in op.mit_mot_out_slices[idx]:
                 op_outputs += [op.outputs[o_offset]]
                 o_offset += 1
             # node inputs
             node_inputs += [inputs[ni_offset + idx]]
         else:
-            o_offset += len(op.mit_mot_out_slices[offset + idx])
-            i_offset += len(op.tap_array[offset + idx])
+            o_offset += len(op.mit_mot_out_slices[idx])
+            i_offset += len(op.mit_mot_in_slices[idx])
+
     info = dataclasses.replace(info, n_mit_mot_outs=len(op_outputs))
     offset += op.n_mit_mot
     ni_offset += op.n_mit_mot
@@ -456,10 +462,10 @@ def compress_outs(op, not_required, inputs):
             info = dataclasses.replace(
                 info,
                 n_mit_sot=info.n_mit_sot + 1,
-                tap_array=info.tap_array + (tuple(op.tap_array[offset + idx]),),
+                mit_sot_in_slices=info.mit_sot_in_slices + (op.mit_sot_in_slices[idx],),
             )
             # input taps
-            for jdx in op.tap_array[offset + idx]:
+            for jdx in op.mit_sot_in_slices[idx]:
                 op_inputs += [op.inputs[i_offset]]
                 i_offset += 1
             # output taps
@@ -469,7 +475,7 @@ def compress_outs(op, not_required, inputs):
             node_inputs += [inputs[ni_offset + idx]]
         else:
             o_offset += 1
-            i_offset += len(op.tap_array[offset + idx])
+            i_offset += len(op.mit_sot_in_slices[idx])
 
     offset += op.n_mit_sot
     ni_offset += op.n_mit_sot
@@ -480,7 +486,7 @@ def compress_outs(op, not_required, inputs):
             info = dataclasses.replace(
                 info,
                 n_sit_sot=info.n_sit_sot + 1,
-                tap_array=info.tap_array + (tuple(op.tap_array[offset + idx]),),
+                sit_sot_in_slices=info.sit_sot_in_slices + (op.sit_sot_in_slices[idx],),
             )
             # input taps
             op_inputs += [op.inputs[i_offset]]
@@ -613,8 +619,9 @@ class ScanArgs:
         n_mit_mot = info.n_mit_mot
         n_mit_sot = info.n_mit_sot
 
-        self.mit_mot_in_slices = list(info.tap_array[:n_mit_mot])
-        self.mit_sot_in_slices = list(info.tap_array[n_mit_mot : n_mit_mot + n_mit_sot])
+        self.mit_mot_in_slices = info.mit_mot_in_slices
+        self.mit_sot_in_slices = info.mit_sot_in_slices
+        self.sit_sot_in_slices = info.sit_sot_in_slices
 
         n_mit_mot_ins = sum(len(s) for s in self.mit_mot_in_slices)
         n_mit_sot_ins = sum(len(s) for s in self.mit_sot_in_slices)
@@ -800,14 +807,12 @@ class ScanArgs:
         from aesara.scan.op import ScanInfo
 
         return ScanInfo(
+            mit_mot_in_slices=tuple(tuple(v) for v in self.mit_mot_in_slices),
+            mit_sot_in_slices=tuple(tuple(v) for v in self.mit_sot_in_slices),
+            sit_sot_in_slices=((-1,),) * len(self.inner_in_sit_sot),
             n_seqs=len(self.outer_in_seqs),
             n_mit_mot=len(self.outer_in_mit_mot),
             n_mit_sot=len(self.outer_in_mit_sot),
-            tap_array=(
-                tuple(tuple(v) for v in self.mit_mot_in_slices)
-                + tuple(tuple(v) for v in self.mit_sot_in_slices)
-                + ((-1,),) * len(self.inner_in_sit_sot)
-            ),
             n_sit_sot=len(self.outer_in_sit_sot),
             n_nit_sot=len(self.outer_in_nit_sot),
             n_shared_outs=len(self.outer_in_shared),

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -15,7 +15,6 @@ import aesara.scalar.basic as aes
 from aesara import compile
 from aesara.compile.ops import ViewOp
 from aesara.configdefaults import config
-from aesara.graph import features
 from aesara.graph.basic import (
     Constant,
     Variable,
@@ -23,6 +22,7 @@ from aesara.graph.basic import (
     equal_computations,
     io_toposort,
 )
+from aesara.graph.features import AlreadyThere, Feature, ReplaceValidate
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.op import get_test_value
 from aesara.graph.opt import (
@@ -775,7 +775,7 @@ class MakeVectorPrinter(Printer):
 pprint.assign(MakeVector, MakeVectorPrinter())
 
 
-class ShapeFeature(features.Feature):
+class ShapeFeature(Feature):
     """Graph optimizer for removing all calls to shape().
 
     This optimizer replaces all Shapes and Subtensors of Shapes with
@@ -1230,7 +1230,7 @@ class ShapeFeature(features.Feature):
     def on_attach(self, fgraph):
 
         if hasattr(fgraph, "shape_feature"):
-            raise features.AlreadyThere("This FunctionGraph already has a ShapeFeature")
+            raise AlreadyThere("This FunctionGraph already has a ShapeFeature")
 
         if hasattr(self, "fgraph") and self.fgraph != fgraph:
             raise Exception("This ShapeFeature is already attached to a graph")
@@ -1452,6 +1452,9 @@ class ShapeFeature(features.Feature):
                 return False
 
         return True
+
+    def clone(self):
+        return type(self)()
 
 
 class ShapeOptimizer(GlobalOptimizer):
@@ -3275,7 +3278,7 @@ class FusionOptimizer(GlobalOptimizer):
         self.optimizer = local_optimizer
 
     def add_requirements(self, fgraph):
-        fgraph.attach_feature(features.ReplaceValidate())
+        fgraph.attach_feature(ReplaceValidate())
 
     def apply(self, fgraph):
         did_something = True

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -1229,13 +1229,13 @@ class ShapeFeature(features.Feature):
 
     def on_attach(self, fgraph):
 
-        if getattr(self, "fgraph", None):
-            raise ValueError("This ShapeFeature is already attached to a graph")
+        if hasattr(fgraph, "shape_feature"):
+            raise features.AlreadyThere("This FunctionGraph already has a ShapeFeature")
+
+        if hasattr(self, "fgraph") and self.fgraph != fgraph:
+            raise Exception("This ShapeFeature is already attached to a graph")
 
         self.fgraph = fgraph
-
-        if hasattr(fgraph, "shape_feature"):
-            raise ValueError("This FunctionGraph already has a ShapeFeature")
 
         fgraph.shape_feature = self
         # Must be local to the object as otherwise we reuse the same

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -3346,7 +3346,7 @@ class FusionOptimizer(GlobalOptimizer):
         print(blanc, " nb_inconsistency_replace", prof[3], file=stream)
         print(blanc, " validate_time", prof[4], file=stream)
         print(blanc, " callback_time", prof[5], file=stream)
-        if prof[5] > 1:
+        if prof[5] is not None and prof[5] > 1:
             print(blanc, " callbacks_time", file=stream)
             for i in sorted(prof[6].items(), key=lambda a: a[1])[::-1]:
                 if i[1] > 0:

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -141,8 +141,8 @@ with
 
 Also, for small Aesara functions, you can remove more Python overhead by
 making an Aesara function that does not take any input. You can use shared
-variables to achieve this. Then you can call it like this: ``f.fn()`` or
-``f.fn(n_calls=N)`` to speed it up. In the last case, only the last
+variables to achieve this. Then you can call it like this: ``f.vm()`` or
+``f.vm(n_calls=N)`` to speed it up. In the last case, only the last
 function output (out of N calls) is returned.
 
 You can also use the ``C`` linker that will put all nodes in the same C

--- a/doc/tutorial/debug_faq.rst
+++ b/doc/tutorial/debug_faq.rst
@@ -140,9 +140,9 @@ Running the above code generates the following error message:
       File "test1.py", line 31, in <module>
         f(np.random.random((5, 10)))
       File "PATH_TO_AESARA/aesara/compile/function/types.py", line 605, in __call__
-        self.fn.thunks[self.fn.position_of_error])
+        self.vm.thunks[self.vm.position_of_error])
       File "PATH_TO_AESARA/aesara/compile/function/types.py", line 595, in __call__
-        outputs = self.fn()
+        outputs = self.vm()
     ValueError: Shape mismatch: x has 10 cols (and 5 rows) but y has 20 rows (and 10 cols)
     Apply node that caused the error: Dot22(x, DimShuffle{1,0}.0)
     Inputs types: [TensorType(float64, (None, None)), TensorType(float64, (None, None))]

--- a/doc/tutorial/profiling.rst
+++ b/doc/tutorial/profiling.rst
@@ -52,8 +52,8 @@ function. aesara.function() has an optional parameter ``name`` that
 defaults to None. Change it to something else to help you profile many
 Aesara functions. In that section, we also see the number of times the
 function was called (1) and the total time spent in all those
-calls. The time spent in Function.fn.__call__ and in thunks is useful
-to understand Aesara overhead.
+calls. The time spent in :meth:`Function.vm.__call__` and in thunks is useful
+to understand Aesara's overhead.
 
 Also, we see the time spent in the two parts of the compilation
 process: optimization (modify the graph to make it more stable/faster)

--- a/doc/tutorial/profiling.rst
+++ b/doc/tutorial/profiling.rst
@@ -7,30 +7,29 @@ Profiling Aesara function
 
 .. note::
 
-    This method replace the old ProfileMode. Do not use ProfileMode
+    This method replaces the old `ProfileMode`. Do not use `ProfileMode`
     anymore.
 
-Besides checking for errors, another important task is to profile your
-code in terms of speed and/or memory usage.
+Besides checking for errors, another important task is to profile your code in
+terms of speed and/or memory usage.  You can profile your functions using either
+of the following two options:
 
-You can profile your
-functions using either of the following two options:
-
-
-1. Use Aesara flag :attr:`config.profile` to enable profiling.
+1. Use the Aesara flag :attr:`config.profile` to enable profiling.
     - To enable the memory profiler use the Aesara flag:
       :attr:`config.profile_memory` in addition to :attr:`config.profile`.
-    - Moreover, to enable the profiling of Aesara optimization phase,
+    - Moreover, to enable the profiling of Aesara optimization phases,
       use the Aesara flag: :attr:`config.profile_optimizer` in addition
       to :attr:`config.profile`.
     - You can also use the Aesara flags :attr:`profiling__n_apply`,
       :attr:`profiling__n_ops` and :attr:`profiling__min_memory_size`
       to modify the quantity of information printed.
 
-2. Pass the argument :attr:`profile=True` to the function :func:`aesara.function <function.function>`. And then call :attr:`f.profile.summary()` for a single function.
+2. Pass the argument :attr:`profile=True` to the function :func:`aesara.function
+   <function.function>` and then call :attr:`f.profile.summary()` for a single
+   function.
     - Use this option when you want to profile not all the
-      functions but one or more specific function(s).
-    - You can also combine the profile of many functions:
+      functions but only one or more specific function(s).
+    - You can also combine the profile results of many functions:
 
       .. doctest::
           :hide:
@@ -43,48 +42,45 @@ functions using either of the following two options:
 
 
 
-The profiler will output one profile per Aesara function and profile
-that is the sum of the printed profiles. Each profile contains 4
-sections: global info, class info, Ops info and Apply node info.
+The profiler will output one profile per Aesara function and produce a profile
+that is the sum of the printed profiles. Each profile contains four sections:
+global info, class info, `Op`\s info and `Apply` node info.
 
 In the global section, the "Message" is the name of the Aesara
-function. aesara.function() has an optional parameter ``name`` that
-defaults to None. Change it to something else to help you profile many
+function. :func:`aesara.function` has an optional parameter ``name`` that
+defaults to ``None``. Change it to something else to help profile many
 Aesara functions. In that section, we also see the number of times the
 function was called (1) and the total time spent in all those
 calls. The time spent in :meth:`Function.vm.__call__` and in thunks is useful
 to understand Aesara's overhead.
 
-Also, we see the time spent in the two parts of the compilation
-process: optimization (modify the graph to make it more stable/faster)
-and the linking (compile c code and make the Python callable returned
-by function).
+Also, we see the time spent in the two parts of the compilation process:
+optimization (i.e. modifying the graph to make it more stable/faster) and the
+linking (i.e. compile C code and make the Python callable returned by
+:func:`aesara.function`).
 
-The class, Ops and Apply nodes sections are the same information:
-information about the Apply node that ran. The Ops section takes the
-information from the Apply section and merge the Apply nodes that have
-exactly the same op. If two Apply nodes in the graph have two Ops that
-compare equal, they will be merged. Some Ops like Elemwise, will not
-compare equal, if their parameters differ (the scalar being
-executed). So the class section will merge more Apply nodes then the
-Ops section.
+The class, `Op`\s and `Apply` nodes sections have the same information: i.e.
+information about the `Apply` nodes that ran. The `Op`\s section takes the
+information from the `Apply` section and merges it with the `Apply` nodes that have
+exactly the same `Op`. If two `Apply` nodes in the graph have two `Op`\s that
+compare equal, they will be merged. Some `Op`\s, like `Elemwise`, will not
+compare equal if their parameters differ, so the class section will merge more
+`Apply` nodes than the `Op`\s section.
 
-Note that the profile also shows which Ops were running a c implementation.
+Note that the profile also shows which `Op`\s were run with C
+implementation.
 
 Developers wishing to optimize the performance of their graph should
-focus on the worst offending Ops and Apply nodes – either by optimizing
+focus on the worst offending `Op`\s and `Apply` nodes--either by optimizing
 an implementation, providing a missing C implementation, or by writing
-a graph optimization that eliminates the offending Op altogether.
-You should strongly consider emailing one of our lists about your
-issue before spending too much time on this.
+a graph optimization that eliminates the offending `Op` altogether.
 
-Here is an example output when we disable some Aesara optimizations to
-give you a better idea of the difference between sections. With all
-optimizations enabled, there would be only one op left in the graph.
+Here is some example output when some Aesara optimizations are disabled. With
+all optimizations enabled, there would be only one `Op` left in the graph.
 
-to run the example:
+To run the example:
 
-  AESARA_FLAGS=optimizer_excluding=fusion:inplace,profile=True python doc/tutorial/profiling_example.py
+    AESARA_FLAGS=optimizer_excluding=fusion:inplace,profile=True python doc/tutorial/profiling_example.py
 
 The output:
 

--- a/doc/tutorial/profiling_example_out.prof
+++ b/doc/tutorial/profiling_example_out.prof
@@ -2,7 +2,7 @@ Function profiling
 ==================
   Message: None
   Time in 1 calls to Function.__call__: 5.698204e-05s
-  Time in Function.fn.__call__: 1.192093e-05s (20.921%)
+  Time in Function.vm.__call__: 1.192093e-05s (20.921%)
   Time in thunks: 6.198883e-06s (10.879%)
   Total compile time: 3.642474e+00s
     Aesara Optimizer time: 7.326508e-02s

--- a/setup.cfg
+++ b/setup.cfg
@@ -119,6 +119,10 @@ check_untyped_defs = False
 ignore_errors = True
 check_untyped_defs = False
 
+[mypy-aesara.compile.function.pfunc]
+ignore_errors = True
+check_untyped_defs = False
+
 [mypy-aesara.compile.function.types]
 ignore_errors = True
 check_untyped_defs = False

--- a/tests/compile/function/test_types.py
+++ b/tests/compile/function/test_types.py
@@ -346,8 +346,8 @@ class TestFunction:
             cpy = ori.copy(share_memory=True)
 
             # Test if memories shared
-            storage_map_ori = ori.fn.storage_map
-            storage_map_cpy = cpy.fn.storage_map
+            storage_map_ori = ori.vm.storage_map
+            storage_map_cpy = cpy.vm.storage_map
             fgraph_cpy = cpy.maker.fgraph
 
             # Assert intermediate and Constants storages are shared.
@@ -424,11 +424,11 @@ class TestFunction:
             # 2. SharedVariable is updatable -> values did update(z == 5)
             # 1. sharedvariable is swap ->  Rpl sharedvariables share storage
             names = map_SV.keys()
-            for key in cpy.fn.storage_map:
+            for key in cpy.vm.storage_map:
                 if key.name in names:
                     assert (
                         map_SV[key.name].container.storage[0]
-                        == cpy.fn.storage_map[key][0]
+                        == cpy.vm.storage_map[key][0]
                     )
 
             second_time = True
@@ -688,18 +688,18 @@ class TestFunction:
 
         x = vector("x")
         func = function([x], x + 1)
-        func.fn.allow_gc = False
+        func.vm.allow_gc = False
         func([1])
 
         check_list = []
-        for key, val in func.fn.storage_map.items():
+        for key, val in func.vm.storage_map.items():
             if not isinstance(key, Constant):
                 check_list.append(val)
         assert any(val[0] for val in check_list)
 
         func.free()
 
-        for key, val in func.fn.storage_map.items():
+        for key, val in func.vm.storage_map.items():
             if not isinstance(key, Constant):
                 assert val[0] is None
 

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -9,6 +9,7 @@ from aesara.compile.builders import OpFromGraph
 from aesara.compile.function import function
 from aesara.configdefaults import config
 from aesara.gradient import DisconnectedType, Rop, disconnected_type, grad
+from aesara.graph.basic import equal_computations
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.null_type import NullType
 from aesara.graph.opt_utils import optimize_graph
@@ -51,6 +52,17 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
 
         with pytest.raises(NotImplementedError):
             OpFromGraph([x], [x], updates={})
+
+    def test_clone(self):
+        x, y, z = matrices("xyz")
+
+        ofg = OpFromGraph([x], [2 * x])
+
+        ofg_clone = ofg.clone()
+
+        assert ofg_clone.fgraph is not ofg.fgraph
+        assert ofg_clone.fgraph.outputs != ofg.fgraph.outputs
+        assert equal_computations(ofg_clone.fgraph.outputs, ofg.fgraph.outputs)
 
     @pytest.mark.parametrize(
         "cls_ofg", [OpFromGraph, partial(OpFromGraph, inline=True)]

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -466,7 +466,6 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         y = shared(1.0, name="y")
 
         test_ofg = OpFromGraph([x], [x + y], on_unused_input="ignore")
-        assert test_ofg.inputs == [x]
         assert test_ofg.shared_inputs == [y]
 
         out = test_ofg(x)
@@ -478,7 +477,6 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         out_new = test_ofg.make_node(*(out.owner.inputs[:1] + [y_clone])).outputs[0]
 
         assert "on_unused_input" in out_new.owner.op.kwargs
-        assert out_new.owner.op.inputs == [x]
         assert out_new.owner.op.shared_inputs == [y_clone]
 
         out_fn = function([x], out_new)
@@ -497,7 +495,6 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         y = shared(1.0, name="y")
 
         test_ofg = OpFromGraph([x], [x + y])
-        assert test_ofg.inputs == [x]
         assert test_ofg.shared_inputs == [y]
 
         out = test_ofg(at.as_tensor(1.0, dtype=config.floatX))
@@ -517,7 +514,6 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         y = shared(1.0, name="y")
 
         test_ofg = OpFromGraph([], [y])
-        assert test_ofg.inputs == []
         assert test_ofg.shared_inputs == [y]
 
         out_1_fn = function([], test_ofg())
@@ -526,7 +522,6 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         assert np.array_equal(res_1, 1.0)
 
         test_ofg_new = test_ofg.make_node(x)
-        assert test_ofg_new.op.inputs == [x]
         assert test_ofg_new.op.shared_inputs == []
 
         out_2_fn = function([x], test_ofg_new.outputs[0])
@@ -535,6 +530,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         assert np.array_equal(res_2, 1.0)
 
 
+@config.change_flags(floatX="float64")
 def test_debugprint():
     x, y, z = matrices("xyz")
     e = x + y * z
@@ -553,10 +549,10 @@ Inner graphs:
 
 OpFromGraph{inline=False} [id A]
  >Elemwise{add,no_inplace} [id E]
- > |x [id F]
+ > |*0-<TensorType(float64, (None, None))> [id F]
  > |Elemwise{mul,no_inplace} [id G]
- >   |y [id H]
- >   |z [id I]
+ >   |*1-<TensorType(float64, (None, None))> [id H]
+ >   |*2-<TensorType(float64, (None, None))> [id I]
 """
 
     for truth, out in zip(exp_res.split("\n"), lines):

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -26,7 +26,7 @@ from aesara.graph.basic import (
     vars_between,
     walk,
 )
-from aesara.graph.op import HasInnerGraph, Op
+from aesara.graph.op import Op
 from aesara.graph.type import Type
 from aesara.tensor.math import max_and_argmax
 from aesara.tensor.type import (
@@ -41,6 +41,7 @@ from aesara.tensor.type import (
 from aesara.tensor.type_other import NoneConst
 from aesara.tensor.var import TensorVariable
 from tests import unittest_tools as utt
+from tests.graph.utils import MyInnerGraphOp
 
 
 class MyType(Type):
@@ -83,36 +84,6 @@ class MyOp(Op):
 
 
 MyOp = MyOp()
-
-
-class MyInnerGraphOp(Op, HasInnerGraph):
-    __props__ = ()
-
-    def __init__(self, inner_inputs, inner_outputs):
-        self._inner_inputs = inner_inputs
-        self._inner_outputs = inner_outputs
-
-    def make_node(self, *inputs):
-        for input in inputs:
-            assert isinstance(input, Variable)
-            assert isinstance(input.type, MyType)
-        outputs = [MyVariable(sum(input.type.thingy for input in inputs))]
-        return Apply(self, list(inputs), outputs)
-
-    def perform(self, *args, **kwargs):
-        raise NotImplementedError("No Python implementation available.")
-
-    @property
-    def fn(self):
-        raise NotImplementedError("No Python implementation available.")
-
-    @property
-    def inner_inputs(self):
-        return self._inner_inputs
-
-    @property
-    def inner_outputs(self):
-        return self._inner_outputs
 
 
 class X:
@@ -550,7 +521,8 @@ def test_get_var_by_name():
 
     (res,) = get_var_by_name([o1, o2], "igo1")
 
-    assert res == igo_out_1
+    exp_res = igo.fgraph.outputs[0]
+    assert res == exp_res
 
 
 class TestCloneReplace:

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -8,6 +8,7 @@ from aesara import config, function, shared
 from aesara import tensor as at
 from aesara.graph.basic import (
     Apply,
+    NominalVariable,
     Variable,
     ancestors,
     applys_between,
@@ -51,6 +52,9 @@ class MyType(Type):
 
     def __eq__(self, other):
         return isinstance(other, MyType) and other.thingy == self.thingy
+
+    def __hash__(self):
+        return hash((type(self), self.thingy))
 
     def __str__(self):
         return f"R{self.thingy}"
@@ -694,3 +698,76 @@ def test_clone_new_inputs():
     assert z_node_new.outputs[0].type.shape == (1,)
     assert z_node_new.inputs[0].type.shape == (1,)
     assert z_node_new.inputs[1].type.shape == (1,)
+
+
+def test_NominalVariable():
+
+    type1 = MyType(1)
+
+    nv1 = NominalVariable(1, type1)
+    nv2 = NominalVariable(1, type1)
+
+    assert nv1 is nv2
+    assert nv1.equals(nv2)
+    assert hash(nv1) == hash(nv2)
+
+    type2 = MyType(2)
+    nv3 = NominalVariable(1, type2)
+
+    assert not nv1.equals(nv3)
+    assert hash(nv1) != hash(nv3)
+
+    type3 = MyType(1)
+
+    assert type3 == type1
+
+    nv4 = NominalVariable(1, type3)
+
+    assert nv1 is nv4
+    assert nv1.equals(nv4)
+    assert hash(nv1) == hash(nv4)
+
+    nv5 = NominalVariable(2, type3)
+    assert not nv4.equals(nv5)
+    assert hash(nv4) != hash(nv5)
+
+    assert repr(nv5) == f"NominalVariable(2, {repr(type3)})"
+
+    assert nv5.signature() == (type3, 2)
+
+    nv5_pkld = pickle.dumps(nv5)
+    nv5_unpkld = pickle.loads(nv5_pkld)
+
+    assert type(nv5_unpkld) is type(nv5)
+    assert nv5_unpkld.equals(nv5)
+    assert nv5_unpkld is nv5
+
+    nv5_clone = nv5.clone()
+    assert type(nv5_clone) is type(nv5)
+    assert nv5_clone.equals(nv5)
+    assert nv5_clone is nv5
+
+
+def test_NominalVariable_create_variable_type():
+
+    ttype = TensorType("float64", (None, None))
+    ntv = NominalVariable(0, ttype)
+
+    assert isinstance(ntv, TensorVariable)
+    assert isinstance(ntv, NominalVariable)
+    assert ntv.ndim == 2
+    assert ntv.broadcastable == (False, False)
+    assert ntv.dtype == "float64"
+
+    ntv2 = NominalVariable(0, ttype)
+
+    assert type(ntv2) is type(ntv)
+    assert ntv2.equals(ntv)
+    assert ntv2 is ntv
+
+    ntv_pkld = pickle.dumps(ntv)
+    ntv_unpkld = pickle.loads(ntv_pkld)
+
+    assert type(ntv_unpkld) is type(ntv)
+    assert ntv_unpkld.equals(ntv)
+    assert ntv_unpkld is ntv

--- a/tests/graph/test_fg.py
+++ b/tests/graph/test_fg.py
@@ -4,9 +4,19 @@ import numpy as np
 import pytest
 
 from aesara.configdefaults import config
+from aesara.graph.basic import NominalVariable
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.utils import MissingInputError
-from tests.graph.utils import MyConstant, MyOp, MyVariable, MyVariable2, op1, op2, op3
+from tests.graph.utils import (
+    MyConstant,
+    MyOp,
+    MyType,
+    MyVariable,
+    MyVariable2,
+    op1,
+    op2,
+    op3,
+)
 
 
 class TestFunctionGraph:
@@ -683,3 +693,18 @@ class TestFunctionGraph:
         assert not fg.variables
         assert not fg.apply_nodes
         assert fg.clients == {var1: [], var2: []}
+
+    def test_nominals(self):
+        t1 = MyType()
+
+        nm = NominalVariable(1, t1)
+        nm2 = NominalVariable(2, t1)
+
+        v1 = op1(nm, nm2)
+
+        fg = FunctionGraph(outputs=[v1], clone=False)
+
+        assert nm not in fg.inputs
+        assert nm2 not in fg.inputs
+        assert nm in fg.variables
+        assert nm2 in fg.variables

--- a/tests/graph/utils.py
+++ b/tests/graph/utils.py
@@ -46,19 +46,20 @@ def MyVariable2(name):
 
 
 class MyOp(Op):
-    def __init__(self, name, dmap=None, x=None):
+    def __init__(self, name, dmap=None, x=None, n_outs=1):
         self.name = name
         if dmap is None:
             dmap = {}
         self.destroy_map = dmap
         self.x = x
+        self.n_outs = n_outs
 
     def make_node(self, *inputs):
         inputs = list(map(is_variable, inputs))
         for input in inputs:
             if not isinstance(input.type, MyType):
                 raise Exception("Error 1")
-        outputs = [MyType()()]
+        outputs = [MyType()() for i in range(self.n_outs)]
         return Apply(self, inputs, outputs)
 
     def perform(self, node, inputs, outputs):
@@ -71,18 +72,19 @@ class MyOp(Op):
         return self.name
 
     def __eq__(self, other):
-        # rval = (self is other) or (isinstance(other, MyOp) and self.x is not None and self.x == other.x and self.name == other.name)
         rval = (self is other) or (
-            isinstance(other, MyOp) and self.x is not None and self.x == other.x
+            isinstance(other, MyOp)
+            and self.x is not None
+            and self.x == other.x
+            and self.n_outs == other.n_outs
         )
         return rval
 
     def __hash__(self):
-        # return hash(self.x if self.x is not None else id(self)) ^ hash(self.name)
         if self.x is not None:
-            return hash(self.x)
+            return hash((self.x, self.n_outs))
         else:
-            return id(self)
+            return hash((id(self), self.n_outs))
 
 
 class MyOpCastType2(MyOp):

--- a/tests/graph/utils.py
+++ b/tests/graph/utils.py
@@ -157,3 +157,6 @@ class MyInnerGraphOp(Op, HasInnerGraph):
     @property
     def inner_outputs(self):
         return self.fgraph.outputs
+
+    def clone(self):
+        return type(self)(self.fgraph.inputs, self.fgraph.outputs)

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -3505,7 +3505,7 @@ def test_config_options_parallel():
 
     with config.change_flags(numba__vectorize_target="parallel"):
         aesara_numba_fn = function([x], x * 2, mode=numba_mode)
-        numba_mul_fn = aesara_numba_fn.fn.jit_fn.py_func.__globals__["mul"]
+        numba_mul_fn = aesara_numba_fn.vm.jit_fn.py_func.__globals__["mul"]
         assert numba_mul_fn.targetoptions["parallel"] is True
 
 
@@ -3514,7 +3514,7 @@ def test_config_options_fastmath():
 
     with config.change_flags(numba__fastmath=True):
         aesara_numba_fn = function([x], x * 2, mode=numba_mode)
-        numba_mul_fn = aesara_numba_fn.fn.jit_fn.py_func.__globals__["mul"]
+        numba_mul_fn = aesara_numba_fn.vm.jit_fn.py_func.__globals__["mul"]
         assert numba_mul_fn.targetoptions["fastmath"] is True
 
 
@@ -3523,12 +3523,12 @@ def test_config_options_cached():
 
     with config.change_flags(numba__cache=True):
         aesara_numba_fn = function([x], x * 2, mode=numba_mode)
-        numba_mul_fn = aesara_numba_fn.fn.jit_fn.py_func.__globals__["mul"]
+        numba_mul_fn = aesara_numba_fn.vm.jit_fn.py_func.__globals__["mul"]
         assert not isinstance(
             numba_mul_fn._dispatcher.cache, numba.core.caching.NullCache
         )
 
     with config.change_flags(numba__cache=False):
         aesara_numba_fn = function([x], x * 2, mode=numba_mode)
-        numba_mul_fn = aesara_numba_fn.fn.jit_fn.py_func.__globals__["mul"]
+        numba_mul_fn = aesara_numba_fn.vm.jit_fn.py_func.__globals__["mul"]
         assert isinstance(numba_mul_fn._dispatcher.cache, numba.core.caching.NullCache)

--- a/tests/link/test_numba_performance.py
+++ b/tests/link/test_numba_performance.py
@@ -52,11 +52,11 @@ def test_careduce_performance(careduce_fn, numpy_fn, axis, inputs, input_vals):
 
     assert np.array_equal(numba_res, numpy_res)
 
-    # FYI: To test the Numba JITed function directly, use `aesara_numba_fn.fn.jit_fn`
+    # FYI: To test the Numba JITed function directly, use `aesara_numba_fn.vm.jit_fn`
 
     numpy_timer = timeit.Timer("numpy_fn(*input_vals)", "pass", globals=locals())
     numba_timer = timeit.Timer(
-        "aesara_numba_fn.fn.jit_fn(*input_vals)", "pass", globals=locals()
+        "aesara_numba_fn.vm.jit_fn(*input_vals)", "pass", globals=locals()
     )
     # c_timer = timeit.Timer("aesara_c_fn(*input_vals)", "pass", globals=locals())
 

--- a/tests/sandbox/test_rng_mrg.py
+++ b/tests/sandbox/test_rng_mrg.py
@@ -916,7 +916,7 @@ def test_multMatVect():
 
     r_a1 = rng_mrg.matVecModM(A1, s1, m1)
     r_a2 = rng_mrg.matVecModM(A2, s2, m2)
-    f0.fn()
+    f0.vm()
     r_b = f0.output_storage[0].value
 
     assert np.allclose(r_a1, r_b[:3])

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -2355,9 +2355,11 @@ def test_compute_test_values():
     assert np.array_equal(z_grad.tag.test_value, np.r_[9.0, 9.0, 9.0])
 
 
+@pytest.mark.xfail(reason="NominalVariables don't support test values")
 def test_compute_test_value_grad():
-    # Test case originally reported by Bitton Tenessi
-    # https://groups.google.com/d/msg/theano-users/fAP3i2CbskQ/3OgBf4yjqiQJ
+    """
+    See https://groups.google.com/d/msg/theano-users/fAP3i2CbskQ/3OgBf4yjqiQJ
+    """
     WEIGHT = np.array([1, 2, 1, 3, 4, 1, 5, 6, 1, 7, 8, 1], dtype="float32")
 
     with config.change_flags(compute_test_value="raise", exception_verbosity="high"):
@@ -2395,10 +2397,12 @@ def test_compute_test_value_grad():
         grad(loss, W_flat)
 
 
+@pytest.mark.xfail(reason="NominalVariables don't support test values")
 def test_compute_test_value_grad_cast():
-    # Test for test values when variables have to be casted
-    # Reported by Daniel Renshaw at
-    # https://groups.google.com/d/topic/theano-users/o4jK9xDe5WI/discussion
+    """Test for test values when variables have to be casted.
+
+    See https://groups.google.com/d/topic/theano-users/o4jK9xDe5WI/discussion
+    """
     with config.change_flags(compute_test_value="raise"):
         h = matrix("h")
         h.tag.test_value = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=config.floatX)
@@ -2434,7 +2438,7 @@ def test_constant_folding_n_steps():
 
 
 def test_outputs_taps_check():
-    # Checks that errors are raised with bad output_info taps.
+    """Checks that errors are raised with bad output_info taps."""
     x = fvector("x")
     y = fvector("y")
 
@@ -2462,7 +2466,6 @@ def test_inconsistent_broadcast_error():
         grad(y.sum(), x)
 
 
-@pytest.mark.xfail(raises=MissingInputError)
 def test_missing_input_error():
     c = shared(0.0)
     inc = scalar("inc")
@@ -2470,8 +2473,8 @@ def test_missing_input_error():
     def count_up():
         return at.zeros(()), {c: c + inc}
 
-    _, updates = scan(count_up, n_steps=20)
-    function(inputs=[inc], outputs=[], updates=updates)
+    with pytest.raises(MissingInputError):
+        _, updates = scan(count_up, n_steps=20)
 
 
 class TestGradUntil:

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -1110,6 +1110,23 @@ class TestScan:
 
         utt.assert_allclose(out, vR)
 
+    @pytest.mark.parametrize(
+        "mode", [Mode(linker="cvm", optimizer=None), Mode(linker="cvm")]
+    )
+    def test_sequence_is_scan(self, mode):
+        """Make sure that a `Scan` can be used as a sequence input to another `Scan`."""
+        x0 = scalar("x0")
+        scan_1, _ = scan(lambda x: x + 1, outputs_info={"initial": x0}, n_steps=10)
+        scan_2, _ = scan(lambda x: x + 1, sequences=[scan_1])
+
+        with config.change_flags(mode=mode):
+            scan_2_fn = function([x0], scan_2)
+
+        scan_2_val = scan_2_fn(0.0)
+        exp_res = np.arange(1, 11) + 1.0
+
+        assert np.array_equal(scan_2_val, exp_res)
+
     def test_grad_sitsot(self):
         def get_sum_of_grad(inp):
 

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -4087,5 +4087,7 @@ def test_n_non_seqs(fn, sequences, outputs_info, non_sequences, n_steps, op_chec
 
     _ = op_check(scan_op)
 
-    assert scan_op.n_outer_inputs == len(res.owner.inputs)
-    assert scan_op.n_outer_outputs == len(res.owner.outputs)
+    assert scan_op.info.n_outer_inputs == len(res.owner.inputs)
+    assert scan_op.info.n_outer_outputs == len(res.owner.outputs)
+    assert scan_op.info.n_inner_inputs == len(res.owner.op.inputs)
+    assert scan_op.info.n_inner_outputs == len(res.owner.op.outputs)

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -29,7 +29,9 @@ from aesara.compile.sharedvalue import shared
 from aesara.configdefaults import config
 from aesara.gradient import NullTypeGradError, Rop, disconnected_grad, grad, hessian
 from aesara.graph.basic import Apply, ancestors
+from aesara.graph.fg import FunctionGraph
 from aesara.graph.op import Op
+from aesara.graph.opt import MergeOptimizer
 from aesara.graph.utils import MissingInputError
 from aesara.misc.safe_asarray import _asarray
 from aesara.raise_op import assert_op
@@ -792,6 +794,27 @@ class TestScan:
         scan2, updates = scan(lambda _x: _x + 1, y)
         assert scan1.owner.op == scan2.owner.op
         assert hash(scan1.owner.op) == hash(scan2.owner.op)
+
+    def test_can_merge(self):
+        """Make sure that equivalent `Scan` nodes can be merged."""
+
+        x = vector("x")
+        y = vector("y")
+        c = scalar("c")
+
+        scan_a, _ = scan(lambda x, y, c: x + y + c, sequences=[x, y], non_sequences=[c])
+        scan_b, _ = scan(lambda x, y, c: x + y + c, sequences=[x, y], non_sequences=[c])
+        scan_c, _ = scan(lambda x, y, c: x + y + c, sequences=[y, x], non_sequences=[c])
+
+        assert scan_b is not scan_a
+        assert scan_c is not scan_a
+
+        g = FunctionGraph([x, y, c], [2 * scan_a, 2 * scan_b, 2 * scan_c], clone=False)
+        MergeOptimizer().optimize(g)
+        scan_a_out, scan_b_out, scan_c_out = g.outputs
+
+        assert scan_a_out is scan_b_out
+        assert scan_c_out is not scan_a_out
 
     def test_using_negative_taps_sequence(self):
         # This test refers to a bug reported on github on May 22 2015 by

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -1482,6 +1482,14 @@ class TestScan:
 
     @pytest.mark.slow
     def test_grad_multiple_outs_taps_backwards(self):
+        """
+        This test is special because when the inner-graph compilation is set to
+        "fast_compile", and the `Loop` `VM` is used, its inner-graph will
+        reallocate storage cells, which is a good test for correct, direct
+        storage use in `Scan.perform`.
+
+        TODO: Create a much more direct test.
+        """
         n = 5
         rng = np.random.default_rng(utt.fetch_seed())
         vW_in2 = asarrayX(rng.uniform(-0.2, 0.2, size=(2,)))
@@ -1591,6 +1599,7 @@ class TestScan:
         )
 
         def reset_rng_fn(fn, *args):
+            # TODO: Get rid of all this `expanded_inputs` nonsense
             for idx, arg in enumerate(fn.maker.expanded_inputs):
                 if arg.value and isinstance(arg.value.data, np.random.Generator):
                     obj = fn.maker.expanded_inputs[idx].value
@@ -1673,6 +1682,7 @@ class TestScan:
         )
 
         def reset_rng_fn(fn, *args):
+            # TODO: Get rid of all this `expanded_inputs` nonsense
             for idx, arg in enumerate(fn.maker.expanded_inputs):
                 if arg.value and isinstance(arg.value.data, np.random.Generator):
                     obj = fn.maker.expanded_inputs[idx].value

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -2702,8 +2702,8 @@ def test_profile_info():
     assert profile.callcount == 0
     assert profile.nbsteps == 0
     assert profile.call_time == 0.0
-    assert fn.fn.call_times == [0.0]
-    assert fn.fn.call_counts == [0]
+    assert fn.vm.call_times == [0.0]
+    assert fn.vm.call_counts == [0]
 
     z_fn = function([], z)
 
@@ -2716,8 +2716,8 @@ def test_profile_info():
 
     # Confirm that `VM.update_profile` was called
     assert profile.apply_time
-    assert fn.fn.call_times == [0.0]
-    assert fn.fn.call_counts == [0]
+    assert fn.vm.call_times == [0.0]
+    assert fn.vm.call_counts == [0]
 
 
 class TestExamples:

--- a/tests/scan/test_opt.py
+++ b/tests/scan/test_opt.py
@@ -95,7 +95,7 @@ class TestRemoveConstantsAndUnusedInputsScan:
 
             scan_node = scan_nodes[0]
             assert len(scan_node.inputs[1:]) == len(set(scan_node.inputs[1:]))
-            inp = scan_node.op.inner_non_seqs(scan_node.op.inputs)
+            inp = scan_node.op.inner_non_seqs(scan_node.op.inner_inputs)
             assert len(inp) == 1
             assert len(inp) == len(set(inp))
 
@@ -170,11 +170,11 @@ class TestRemoveConstantsAndUnusedInputsScan:
             scan_node = scan_nodes[0]
 
             assert len(scan_node.inputs[1:]) == len(set(scan_node.inputs[1:]))
-            inp = scan_node.op.inner_seqs(scan_node.op.inputs)
+            inp = scan_node.op.inner_seqs(scan_node.op.inner_inputs)
             assert len(inp) == 1
             inp = scan_node.op.outer_seqs(scan_node.inputs)
             assert len(inp) == 1
-            inp = scan_node.op.inner_non_seqs(scan_node.op.inputs)
+            inp = scan_node.op.inner_non_seqs(scan_node.op.inner_inputs)
             assert len(inp) == 1
             inp = scan_node.op.outer_non_seqs(scan_node.inputs)
             assert len(inp) == 1
@@ -445,8 +445,8 @@ class TestPushOutNonSeqScan:
         scan_node = [
             node for node in f_opt.maker.fgraph.toposort() if isinstance(node.op, Scan)
         ][0]
-        assert len(scan_node.op.outputs) == 1
-        assert not isinstance(scan_node.op.outputs[0], Dot)
+        assert len(scan_node.op.inner_outputs) == 1
+        assert not isinstance(scan_node.op.inner_outputs[0], Dot)
 
         # Ensure that the function compiled with the optimization produces
         # the same results as the function compiled without
@@ -491,8 +491,8 @@ class TestPushOutNonSeqScan:
         ][0]
         # NOTE: WHEN INFER_SHAPE IS RE-ENABLED, BELOW THE SCAN MUST
         # HAVE ONLY 1 OUTPUT.
-        assert len(scan_node.op.outputs) == 2
-        assert not isinstance(scan_node.op.outputs[0], Dot)
+        assert len(scan_node.op.inner_outputs) == 2
+        assert not isinstance(scan_node.op.inner_outputs[0], Dot)
 
         # Ensure that the function compiled with the optimization produces
         # the same results as the function compiled without
@@ -537,8 +537,8 @@ class TestPushOutNonSeqScan:
         scan_node = [
             node for node in f_opt.maker.fgraph.toposort() if isinstance(node.op, Scan)
         ][0]
-        assert len(scan_node.op.outputs) == 2
-        assert not isinstance(scan_node.op.outputs[0], Dot)
+        assert len(scan_node.op.inner_outputs) == 2
+        assert not isinstance(scan_node.op.inner_outputs[0], Dot)
 
         # Ensure that the function compiled with the optimization produces
         # the same results as the function compiled without
@@ -725,7 +725,7 @@ class TestPushOutAddScan:
             node for node in f_opt.maker.fgraph.toposort() if isinstance(node.op, Scan)
         ][1]
 
-        for output in scan_node_grad.op.outputs:
+        for output in scan_node_grad.op.inner_outputs:
             assert not (
                 isinstance(output.owner.op, Elemwise)
                 and any(isinstance(i, Dot) for i in output.owner.inputs)
@@ -1466,7 +1466,7 @@ def test_alloc_inputs3():
     f = function([_h0, _W1, _W2], o, mode="FAST_RUN")
     scan_node = [x for x in f.maker.fgraph.toposort() if isinstance(x.op, Scan)][0]
 
-    assert len(scan_node.op.inputs) == 1
+    assert len(scan_node.op.inner_inputs) == 1
 
 
 def test_opt_order():

--- a/tests/scan/test_utils.py
+++ b/tests/scan/test_utils.py
@@ -97,8 +97,8 @@ def test_ScanArgs():
     # Check the properties that allow us to use
     # `Scan.get_oinp_iinp_iout_oout_mappings` as-is to implement
     # `ScanArgs.var_mappings`
-    assert scan_args.n_nit_sot == scan_op.n_nit_sot
-    assert scan_args.n_mit_mot == scan_op.n_mit_mot
+    assert scan_args.n_nit_sot == scan_op.info.n_nit_sot
+    assert scan_args.n_mit_mot == scan_op.info.n_mit_mot
     # The `scan_args` base class always clones the inner-graph;
     # here we make sure it doesn't (and that all the inputs are the same)
     assert scan_args.inputs == scan_op.inner_inputs

--- a/tests/scan/test_utils.py
+++ b/tests/scan/test_utils.py
@@ -101,18 +101,18 @@ def test_ScanArgs():
     assert scan_args.n_mit_mot == scan_op.n_mit_mot
     # The `scan_args` base class always clones the inner-graph;
     # here we make sure it doesn't (and that all the inputs are the same)
-    assert scan_args.inputs == scan_op.inputs
+    assert scan_args.inputs == scan_op.inner_inputs
     assert scan_args.info == scan_op.info
 
     # Check that `ScanArgs.find_among_fields` works
-    test_v = scan_op.inner_seqs(scan_op.inputs)[1]
+    test_v = scan_op.inner_seqs(scan_op.inner_inputs)[1]
     field_info = scan_args.find_among_fields(test_v)
     assert field_info.name == "inner_in_seqs"
     assert field_info.index == 1
     assert field_info.inner_index is None
     assert scan_args.inner_inputs[field_info.agg_index] == test_v
 
-    test_l = scan_op.inner_non_seqs(scan_op.inputs)
+    test_l = scan_op.inner_non_seqs(scan_op.inner_inputs)
     # We didn't index this argument, so it's a `list` (i.e. bad input)
     field_info = scan_args.find_among_fields(test_l)
     assert field_info is None

--- a/tests/tensor/nnet/test_conv.py
+++ b/tests/tensor/nnet/test_conv.py
@@ -616,7 +616,7 @@ class TestConv2D(utt.InferShapeTester):
                         )
                         aesara_conv = aesara.function([], output, mode=mode)
                         t1 = time.time()
-                        aesara_conv.fn(n_calls=n_calls)
+                        aesara_conv.vm(n_calls=n_calls)
                         t2 = time.time()
                         print(t2 - t1, end=" ")
                     print()

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -326,8 +326,8 @@ Inner graphs:
 
 MyInnerGraphOp [id A]
  >op2 [id D] 'igo1'
- > |4 [id E]
- > |5 [id F]
+ > |*0-<MyType()> [id E]
+ > |*1-<MyType()> [id F]
     """
 
     for exp_line, res_line in zip(exp_res.split("\n"), lines):
@@ -349,13 +349,13 @@ Inner graphs:
 
 MyInnerGraphOp [id A]
  >MyInnerGraphOp [id C]
- > |3 [id D]
- > |4 [id E]
+ > |*0-<MyType()> [id D]
+ > |*1-<MyType()> [id E]
 
 MyInnerGraphOp [id C]
  >op2 [id F] 'igo1'
- > |4 [id G]
- > |5 [id H]
+ > |*0-<MyType()> [id D]
+ > |*1-<MyType()> [id E]
     """
 
     for exp_line, res_line in zip(exp_res.split("\n"), lines):
@@ -368,7 +368,6 @@ def test_get_var_by_id():
     o1 = MyOp("op1")(r1, r2)
     o1.name = "o1"
 
-    # Inner graph
     igo_in_1 = MyVariable("v4")
     igo_in_2 = MyVariable("v5")
     igo_out_1 = MyOp("op2")(igo_in_1, igo_in_2)
@@ -378,21 +377,6 @@ def test_get_var_by_id():
 
     r3 = MyVariable("v3")
     o2 = igo(r3, o1)
-
-    # import aesara; aesara.dprint([o1, o2])
-    # op1 [id A] 'o1'
-    #  |1 [id B]
-    #  |2 [id C]
-    # MyInnerGraphOp [id D]
-    #  |3 [id E]
-    #  |op1 [id A] 'o1'
-    #
-    # Inner graphs:
-    #
-    # MyInnerGraphOp [id D]
-    #  >op2 [id F] 'igo1'
-    #  > |4 [id G]
-    #  > |5 [id H]
 
     res = get_node_by_id(o1, "blah")
 
@@ -404,7 +388,8 @@ def test_get_var_by_id():
 
     res = get_node_by_id([o1, o2], "F")
 
-    assert res == igo_out_1.owner
+    exp_res = igo.fgraph.outputs[0].owner
+    assert res == exp_res
 
 
 def test_PatternPrinter():


### PR DESCRIPTION
This PR consists of independent `FunctionGraph`, `Scan`, and `Function` construction changes that have been split off from #824.

One of the main results of these changes is that `Scan`'s inner-graph is handled almost exclusively as a single coherent `FunctionGraph`, and the inner-graph compilation and `Scan.perform` logic is much more concise.  

For instance, when pre-allocation is applied, `Scan` currently removes/reorders some of its inner-graph outputs just before compiling.  This is necessary because the `Function` compilation pipeline is somewhat rigid with respect to the way it handles updates (e.g. it assumes that all update steps are at the end of the outputs list of a `FunctionGraph`).  Those issues have been fixed in this PR and, now, a `Scan`'s inner-graph is consistent for the lifetime of the `Scan` and requires no manipulation before compilation.

This PR also adds some long-overdue refactoring of the `VM` interface and implementations.  Previously, the `CVM` was the only `VM` that would perform updates, and `Function` would perform the updates for all other `VM`s.  This meant that the updating logic needed to be reproduced in `Scan.perform` (see below)&mdash;mostly because `Scan.perform` was (perhaps unnecessarily) designed to use a `Function`'s `VM` and not the `Function` itself.  Now, every `VM` implementation performs updates, so there's no need for that logic/scope leak in `Scan` (or `Function` for that matter, but I've left it in for now).

- [x] Look into removing the [manual update logic](https://github.com/aesara-devs/aesara/blob/4ab08dea1e70e7ecbac65ae1dead415f95e8360d/aesara/scan/op.py#L1837) from `Scan.perform` (and its Cython implementation).
    This would be another big step toward simplifying the `Op.perform` logic in `Scan`.