### PR TITLE
Add basic sub-package-level test ordering

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pytest
 
@@ -22,6 +23,15 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
 
 
+subpackage_ordering = [
+    Path("tests/graph"),
+    Path("tests/compile"),
+    Path("tests/link"),
+    Path("tests/scalar"),
+    Path("tests/tensor"),
+]
+
+
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--runslow"):
         # --runslow given in cli: do not skip slow tests
@@ -30,3 +40,15 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
+
+    rootdir = Path(config.rootdir)
+
+    def package_order(item):
+        rel_path = Path(item.fspath).relative_to(rootdir)
+
+        try:
+            return subpackage_ordering.index(rel_path.parent)
+        except ValueError:
+            return len(subpackage_ordering)
+
+    items[:] = sorted(items, key=package_order)


### PR DESCRIPTION
This PR adds simple sub-package-based test ordering, so that&mdash;for instance&mdash;tests in `tests.graph` are run first, then `tests.compile`, etc.

Since `pytest-order` doesn't appear to have a straightforward way to order tests based on directories/sub-packages (at least not without adding marks to every module in a sub-package), the approach taken here doesn't use it; however, we definitely want the granularity offered by `pytest-order`, because it would be better if we could order tests within and across sub-packages and modules.  Nevertheless, these changes are minimal and at least an improvement over the current order-less approach, so we can easily revert, follow-up, and/or augment them with `pytest-order` in the near future.


Closes #730