### PR TITLE
Convert shapes to scalar tuples in the Numba `BroadcastTo` implementation

### DIFF
--- a/aesara/link/numba/dispatch/basic.py
+++ b/aesara/link/numba/dispatch/basic.py
@@ -11,6 +11,7 @@ import scipy.special
 from llvmlite.llvmpy.core import Type as llvm_Type
 from numba import types
 from numba.core.errors import TypingError
+from numba.cpython.unsafe.tuple import tuple_setitem  # noqa: F401
 from numba.extending import box
 
 from aesara import config

--- a/aesara/link/numba/dispatch/elemwise.py
+++ b/aesara/link/numba/dispatch/elemwise.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Optional, Union
 
 import numba
 import numpy as np
-from numba.cpython.unsafe.tuple import tuple_setitem
 
 from aesara import config
 from aesara.graph.basic import Apply
@@ -519,10 +518,10 @@ def numba_funcify_DimShuffle(op, **kwargs):
         @numba_basic.numba_njit
         def populate_new_shape(i, j, new_shape, shuffle_shape):
             if i in augment:
-                new_shape = tuple_setitem(new_shape, i, 1)
+                new_shape = numba_basic.tuple_setitem(new_shape, i, 1)
                 return j, new_shape
             else:
-                new_shape = tuple_setitem(new_shape, i, shuffle_shape[j])
+                new_shape = numba_basic.tuple_setitem(new_shape, i, shuffle_shape[j])
                 return j + 1, new_shape
 
     else:
@@ -532,7 +531,7 @@ def numba_funcify_DimShuffle(op, **kwargs):
         # To avoid this compile-time error, we omit the expression altogether.
         @numba_basic.numba_njit(inline="always")
         def populate_new_shape(i, j, new_shape, shuffle_shape):
-            return j, tuple_setitem(new_shape, i, 1)
+            return j, numba_basic.tuple_setitem(new_shape, i, 1)
 
     if ndim_new_shape > 0:
         create_zeros_tuple = numba_basic.create_tuple_creator(

--- a/aesara/tensor/extra_ops.py
+++ b/aesara/tensor/extra_ops.py
@@ -1590,7 +1590,6 @@ class BroadcastTo(Op):
 
     def make_node(self, a, *shape):
         a = at.as_tensor_variable(a)
-        shape = at.as_tensor_variable(shape, ndim=1)
 
         shape, bcast = at.infer_broadcastable(shape)
 
@@ -1658,7 +1657,6 @@ def broadcast_to(
 
     """
     x = at.as_tensor(x)
-    shape = at.as_tensor(shape, ndim=1, dtype="int64")
     shape_len = get_vector_length(shape)
 
     if x.ndim == 0 and shape_len == 0:

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -1857,6 +1857,14 @@ def test_Searchsorted(a, v, side, sorter, exc):
             set_test_value(at.vector(), rng.random(size=(2,)).astype(config.floatX)),
             [set_test_value(at.lscalar(), np.array(v)) for v in [3, 2]],
         ),
+        (
+            set_test_value(at.vector(), rng.random(size=(2,)).astype(config.floatX)),
+            [at.as_tensor(3, dtype=np.int64), at.as_tensor(2, dtype=np.int64)],
+        ),
+        (
+            set_test_value(at.vector(), rng.random(size=(2,)).astype(config.floatX)),
+            at.as_tensor([set_test_value(at.lscalar(), np.array(v)) for v in [3, 2]]),
+        ),
     ],
 )
 def test_BroadcastTo(x, shape):

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -156,17 +156,15 @@ def eval_python_only(fn_inputs, fgraph, inputs):
     mocks = [
         mock.patch("numba.njit", njit_noop),
         mock.patch("numba.vectorize", vectorize_noop),
-        mock.patch(
-            "aesara.link.numba.dispatch.elemwise.tuple_setitem", py_tuple_setitem
-        ),
+        mock.patch("aesara.link.numba.dispatch.basic.tuple_setitem", py_tuple_setitem),
         mock.patch("aesara.link.numba.dispatch.basic.numba_njit", njit_noop),
         mock.patch("aesara.link.numba.dispatch.basic.numba_vectorize", vectorize_noop),
         mock.patch("aesara.link.numba.dispatch.basic.direct_cast", lambda x, dtype: x),
+        mock.patch("aesara.link.numba.dispatch.basic.to_scalar", py_to_scalar),
         mock.patch(
             "aesara.link.numba.dispatch.basic.numba.np.numpy_support.from_dtype",
             lambda dtype: dtype,
         ),
-        mock.patch("aesara.link.numba.dispatch.basic.to_scalar", py_to_scalar),
         mock.patch("numba.np.unsafe.ndarray.to_fixed_tuple", lambda x, n: tuple(x)),
     ]
 

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -1123,6 +1123,14 @@ class TestBroadcastTo(utt.InferShapeTester):
         y = broadcast_to(x, ())
         assert y is x
 
+    def test_avoid_useless_subtensors(self):
+        x = scalar()
+        y = broadcast_to(x, (1, 2))
+        # There shouldn't be any unnecessary `Subtensor` operations
+        # (e.g. from `at.as_tensor((1, 2))[0]`)
+        assert y.owner.inputs[1].owner is None
+        assert y.owner.inputs[2].owner is None
+
     @config.change_flags(compute_test_value="raise")
     def test_perform(self):
         a = scalar()


### PR DESCRIPTION
This PR converts each element of the varargs `shape` argument of `BroadcastTo` to scalar integers, which enables use of `BroadcastTo` in Numba when the shape inputs aren't already scalars (e.g. when the shape values are `Subtensor` outputs and&mdash;as a result&mdash;scalar `np.ndarray`s).