### PR TITLE
Fix Numba CAReduce infinite identity values for non-floats

### DIFF
--- a/aesara/link/numba/dispatch/elemwise.py
+++ b/aesara/link/numba/dispatch/elemwise.py
@@ -487,7 +487,15 @@ def numba_funcify_CAReduce(op, node, **kwargs):
 
     np_acc_dtype = np.dtype(acc_dtype)
 
-    scalar_op_identity = np.asarray(op.scalar_op.identity, dtype=np_acc_dtype)
+    scalar_op_identity = op.scalar_op.identity
+    if np_acc_dtype.kind == "i" and not np.isfinite(scalar_op_identity):
+        if np.isposinf(scalar_op_identity):
+            scalar_op_identity = np.iinfo(np_acc_dtype).max
+        else:
+            scalar_op_identity = np.iinfo(np_acc_dtype).min
+
+    # Make sure it has the correct dtype
+    scalar_op_identity = np.array(scalar_op_identity, dtype=np_acc_dtype)
 
     input_name = get_name_for_object(node.inputs[0])
     ndim = node.inputs[0].ndim

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -1165,10 +1165,24 @@ def test_ARange(start, stop, step, dtype):
             ),
         ),
         (
+            lambda x, axis=None, dtype=None, acc_dtype=None: Max(axis)(x),
+            None,
+            set_test_value(
+                at.lmatrix(), np.arange(3 * 2, dtype=np.int64).reshape((3, 2))
+            ),
+        ),
+        (
             lambda x, axis=None, dtype=None, acc_dtype=None: Min(axis)(x),
             None,
             set_test_value(
                 at.matrix(), np.arange(3 * 2, dtype=config.floatX).reshape((3, 2))
+            ),
+        ),
+        (
+            lambda x, axis=None, dtype=None, acc_dtype=None: Min(axis)(x),
+            None,
+            set_test_value(
+                at.lmatrix(), np.arange(3 * 2, dtype=np.int64).reshape((3, 2))
             ),
         ),
     ],


### PR DESCRIPTION
This PR fixes an issue with the Numba implementation of `CAReduce` when the identity values is `inf` and the accumulation dtype is an integer/non-float.