### PR TITLE
Convert SciPy scalar function inputs to acceptable dtypes in Numba implementations

### DIFF
--- a/aesara/link/utils.py
+++ b/aesara/link/utils.py
@@ -765,7 +765,7 @@ def fgraph_to_python(
         node_output_names = [unique_name(v) for v in node.outputs]
 
         body_assigns.append(
-            f"{', '.join(node_output_names)} = {local_compiled_func_name}({', '.join(node_input_names)})"
+            f"# {node}\n{', '.join(node_output_names)} = {local_compiled_func_name}({', '.join(node_input_names)})"
         )
 
     fgraph_input_names = [unique_name(v) for v in fgraph.inputs]

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -322,6 +322,12 @@ def test_numba_box_unbox(input, wrapper_fn, check_fn):
     "inputs, input_vals, output_fn, exc",
     [
         (
+            [at.lvector()],
+            [rng.poisson(10, size=100).astype(np.int64)],
+            lambda x: at.gammaln(x),
+            None,
+        ),
+        (
             [at.vector()],
             [rng.standard_normal(100).astype(config.floatX)],
             lambda x: at.sigmoid(x),


### PR DESCRIPTION
This PR converts the inputs of SciPy scalar ufuncs to dtypes that match the ufunc signatures.  This is necessary for some functions provided by the `numba-scipy` package.