### PR TITLE
Rename `Scalar` to `ScalarType`

### DIFF
--- a/aesara/gpuarray/dnn.py
+++ b/aesara/gpuarray/dnn.py
@@ -717,7 +717,7 @@ def ensure_dt(val, default, name, dtype):
         val = constant(val)
     if hasattr(val, "ndim") and val.ndim == 0:
         val = as_scalar(val)
-    if not isinstance(val.type, aesara.scalar.Scalar):
+    if not isinstance(val.type, aesara.scalar.ScalarType):
         raise TypeError(f"{name}: expected a scalar value")
     if val.type.dtype != dtype:
         val = val.astype(dtype)

--- a/aesara/gpuarray/elemwise.py
+++ b/aesara/gpuarray/elemwise.py
@@ -8,7 +8,7 @@ from aesara.graph.basic import Apply
 from aesara.graph.op import _NoPythonOp
 from aesara.graph.utils import MethodNotDefined
 from aesara.link.c.interface import HideC
-from aesara.scalar import Composite, Scalar
+from aesara.scalar import Composite, ScalarType
 from aesara.scalar.basic import complex_types, upgrade_to_float_no_complex
 from aesara.scalar.math import Erfcinv, Erfinv
 from aesara.tensor.elemwise import CAReduceDtype, DimShuffle, Elemwise
@@ -1083,7 +1083,7 @@ class GpuCAReduceCuda(GpuKernelBase, HideC, CAReduceDtype, _NoPythonOp):
             if self.pre_scalar_op:  # TODO: multiple dtypes
                 # dtype = node.inputs[0].dtype
 
-                dummy_var = aes.Scalar(dtype=dtype)()
+                dummy_var = aes.ScalarType(dtype=dtype)()
 
                 dummy_node = self.pre_scalar_op.make_node(dummy_var)
 
@@ -1128,8 +1128,8 @@ class GpuCAReduceCuda(GpuKernelBase, HideC, CAReduceDtype, _NoPythonOp):
         in_dtype = x.dtype
         out_dtype = node.outputs[0].dtype
 
-        dummy_left = Scalar(dtype=out_dtype)()
-        dummy_right = Scalar(dtype=in_dtype)()
+        dummy_left = ScalarType(dtype=out_dtype)()
+        dummy_right = ScalarType(dtype=in_dtype)()
 
         dummy_node = self.scalar_op.make_node(dummy_left, dummy_right)
 
@@ -1955,12 +1955,12 @@ class GpuCAReduceCuda(GpuKernelBase, HideC, CAReduceDtype, _NoPythonOp):
         # now we insert versions for the ops on which we depend...
         scalar_node = Apply(
             self.scalar_op,
-            [Scalar(dtype=input.type.dtype)() for input in node.inputs],
-            [Scalar(dtype=output.type.dtype)() for output in node.outputs],
+            [ScalarType(dtype=input.type.dtype)() for input in node.inputs],
+            [ScalarType(dtype=output.type.dtype)() for output in node.outputs],
         )
         version.extend(self.scalar_op.c_code_cache_version_apply(scalar_node))
         for i in node.inputs + node.outputs:
-            version.extend(Scalar(dtype=i.type.dtype).c_code_cache_version())
+            version.extend(ScalarType(dtype=i.type.dtype).c_code_cache_version())
         version.extend(self.kernel_version(node))
         if all(version):
             return tuple(version)

--- a/aesara/gpuarray/opt.py
+++ b/aesara/gpuarray/opt.py
@@ -161,7 +161,7 @@ from aesara.ifelse import IfElse
 from aesara.link.c.basic import CLinker
 from aesara.misc.ordered_set import OrderedSet
 from aesara.raise_op import Assert
-from aesara.scalar.basic import Cast, Pow, Scalar, log, neg, true_div
+from aesara.scalar.basic import Cast, Pow, ScalarType, log, neg, true_div
 from aesara.scalar.math import Erfcinv, Erfinv
 from aesara.scan.op import Scan
 from aesara.scan.opt import ScanInplaceOptimizer
@@ -811,7 +811,7 @@ def local_gpua_elemwise(fgraph, op, context_name, inputs, outputs):
         new_inputs = []
         for inp in inputs:
             if inp.dtype != out_dtype:
-                gpu_cast_op = GpuElemwise(Cast(Scalar(out_dtype)))
+                gpu_cast_op = GpuElemwise(Cast(ScalarType(out_dtype)))
                 new_inputs.append(gpu_cast_op(as_gpuarray_variable(inp, context_name)))
             else:
                 new_inputs.append(as_gpuarray_variable(inp, context_name))
@@ -1387,7 +1387,7 @@ def local_gpua_gemmbatch(fgraph, op, context_name, inputs, outputs):
     # In case of mismatched dtypes, we also have to upcast
     out_dtype = outputs[0].dtype
     if a.dtype != out_dtype or b.dtype != out_dtype:
-        gpu_cast_op = GpuElemwise(Cast(Scalar(out_dtype)))
+        gpu_cast_op = GpuElemwise(Cast(ScalarType(out_dtype)))
         if a.dtype != out_dtype:
             a = gpu_cast_op(a)
         if b.dtype != out_dtype:

--- a/aesara/link/c/basic.py
+++ b/aesara/link/c/basic.py
@@ -649,9 +649,9 @@ class CLinker(Linker):
             for r in self.variables
             if isinstance(r, Constant) and r not in self.inputs
         )
-        # C type constants (aesara.scalar.Scalar). They don't request an object
+        # C type constants (aesara.scalar.ScalarType). They don't request an object
         self.consts = []
-        # Move c type from orphans (aesara.scalar.Scalar) to self.consts
+        # Move c type from orphans (aesara.scalar.ScalarType) to self.consts
         for variable in self.orphans:
             if (
                 isinstance(variable, Constant)

--- a/aesara/link/c/params_type.py
+++ b/aesara/link/c/params_type.py
@@ -7,7 +7,7 @@ used to create a Params object that is compatible with the ParamsType defined.
 
 The Params object will be available in both Python code (as a standard Python object) and C code
 (as a specific struct with parameters as struct fields). To be fully-available in C code, Aesara
-types wrapped into a ParamsType must provide a C interface (e.g. TensorType, Scalar, GpuArrayType,
+types wrapped into a ParamsType must provide a C interface (e.g. TensorType, ScalarType, GpuArrayType,
 or your own type. See :ref:`extending_op_params` for more details).
 
 Example of usage
@@ -23,13 +23,13 @@ Importation:
     # If you want to use a tensor and a scalar as parameters,
     # you should import required Aesara types.
     from aesara.tensor.type import TensorType
-    from aesara.scalar import Scalar
+    from aesara.scalar import ScalarType
 
 In your Op sub-class:
 
 .. code-block:: python
 
-    params_type = ParamsType(attr1=TensorType('int32', (False, False)), attr2=Scalar('float64'))
+    params_type = ParamsType(attr1=TensorType('int32', (False, False)), attr2=ScalarType('float64'))
 
 If your op contains attributes ``attr1`` **and** ``attr2``, the default ``op.get_params()``
 implementation will automatically try to look for it and generate an appropriate Params object.
@@ -236,11 +236,11 @@ class Params(dict):
     .. code-block:: python
 
         from aesara.link.c.params_type import ParamsType, Params
-        from aesara.scalar import Scalar
+        from aesara.scalar import ScalarType
         # You must create a ParamsType first:
-        params_type = ParamsType(attr1=Scalar('int32'),
-                                 key2=Scalar('float32'),
-                                 field3=Scalar('int64'))
+        params_type = ParamsType(attr1=ScalarType('int32'),
+                                 key2=ScalarType('float32'),
+                                 field3=ScalarType('int64'))
         # Then you can create a Params object with
         # the params type defined above and values for attributes.
         params = Params(params_type, attr1=1, key2=2.0, field3=3)
@@ -498,9 +498,9 @@ class ParamsType(CType):
 
             from aesara.graph.params_type import ParamsType
             from aesara.link.c.type import EnumType, EnumList
-            from aesara.scalar import Scalar
+            from aesara.scalar import ScalarType
 
-            wrapper = ParamsType(scalar=Scalar('int32'),
+            wrapper = ParamsType(scalar=ScalarType('int32'),
                                  letters=EnumType(A=1, B=2, C=3),
                                  digits=EnumList('ZERO', 'ONE', 'TWO'))
             print(wrapper.get_enum('C'))  # 3
@@ -527,9 +527,9 @@ class ParamsType(CType):
 
             from aesara.graph.params_type import ParamsType
             from aesara.link.c.type import EnumType, EnumList
-            from aesara.scalar import Scalar
+            from aesara.scalar import ScalarType
 
-            wrapper = ParamsType(scalar=Scalar('int32'),
+            wrapper = ParamsType(scalar=ScalarType('int32'),
                                  letters=EnumType(A=(1, 'alpha'), B=(2, 'beta'), C=3),
                                  digits=EnumList(('ZERO', 'nothing'), ('ONE', 'unit'), ('TWO', 'couple')))
             print(wrapper.get_enum('C'))  # 3
@@ -574,14 +574,14 @@ class ParamsType(CType):
             import numpy
             from aesara.graph.params_type import ParamsType
             from aesara.tensor.type import dmatrix
-            from aesara.scalar import Scalar
+            from aesara.scalar import ScalarType
 
             class MyObject:
                 def __init__(self):
                     self.a = 10
                     self.b = numpy.asarray([[1, 2, 3], [4, 5, 6]])
 
-            params_type = ParamsType(a=Scalar('int32'), b=dmatrix, c=Scalar('bool'))
+            params_type = ParamsType(a=ScalarType('int32'), b=dmatrix, c=ScalarType('bool'))
 
             o = MyObject()
             value_for_c = False

--- a/aesara/link/numba/dispatch/basic.py
+++ b/aesara/link/numba/dispatch/basic.py
@@ -25,7 +25,7 @@ from aesara.link.utils import (
     fgraph_to_python,
     unique_name_generator,
 )
-from aesara.scalar.basic import Scalar
+from aesara.scalar.basic import ScalarType
 from aesara.scalar.math import Softplus
 from aesara.tensor.blas import BatchedDot
 from aesara.tensor.math import Dot
@@ -86,7 +86,7 @@ def get_numba_type(
         ):
             return numba_dtype
         return numba.types.Array(numba_dtype, aesara_type.ndim, layout)
-    elif isinstance(aesara_type, Scalar):
+    elif isinstance(aesara_type, ScalarType):
         dtype = np.dtype(aesara_type.dtype)
         numba_dtype = numba.from_dtype(dtype)
         return numba_dtype

--- a/aesara/sandbox/multinomial.py
+++ b/aesara/sandbox/multinomial.py
@@ -8,7 +8,7 @@ import aesara.tensor as at
 from aesara.configdefaults import config
 from aesara.graph.basic import Apply
 from aesara.link.c.op import COp
-from aesara.scalar import Scalar, as_scalar
+from aesara.scalar import ScalarType, as_scalar
 from aesara.tensor.type import discrete_dtypes
 
 
@@ -72,7 +72,7 @@ class MultinomialFromUniform(COp):
         if self.odtype == "auto":
             t = f"PyArray_TYPE({pvals})"
         else:
-            t = Scalar(self.odtype).dtype_specs()[1]
+            t = ScalarType(self.odtype).dtype_specs()[1]
             if t.startswith("aesara_complex"):
                 t = t.replace("aesara_complex", "NPY_COMPLEX")
             else:
@@ -264,7 +264,7 @@ class ChoiceFromUniform(MultinomialFromUniform):
         if self.odtype == "auto":
             t = "NPY_INT64"
         else:
-            t = Scalar(self.odtype).dtype_specs()[1]
+            t = ScalarType(self.odtype).dtype_specs()[1]
             if t.startswith("aesara_complex"):
                 t = t.replace("aesara_complex", "NPY_COMPLEX")
             else:

--- a/aesara/scalar/basic.py
+++ b/aesara/scalar/basic.py
@@ -28,6 +28,7 @@ from aesara.gradient import DisconnectedType, grad_undefined
 from aesara.graph.basic import Apply, Constant, Variable, clone, list_of_nodes
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.opt import MergeOptimizer
+from aesara.graph.type import HasDataType
 from aesara.graph.utils import MetaObject, MethodNotDefined
 from aesara.link.c.op import COp
 from aesara.link.c.type import CType
@@ -274,7 +275,7 @@ def convert(x, dtype=None):
     return x_
 
 
-class Scalar(CType):
+class Scalar(CType, HasDataType):
 
     """
     Internal class, should not be used by clients.

--- a/aesara/scalar/math.py
+++ b/aesara/scalar/math.py
@@ -202,13 +202,14 @@ class Erfinv(UnaryScalarOp):
         )
         return (gz * cst * exp(erfinv(x) ** 2),)
 
-    # TODO: erfinv() is not provided by the C standard library
-    # def c_code(self, node, name, inp, out, sub):
-    #    x, = inp
-    #    z, = out
-    #    if node.inputs[0].type in complex_types:
-    #        raise NotImplementedError('type not supported', type)
-    #    return "%(z)s = erfinv(%(x)s);" % locals()
+    def c_code(self, node, name, inp, out, sub):
+        # TODO: erfinv() is not provided by the C standard library
+        # x, = inp
+        # z, = out
+        # if node.inputs[0].type in complex_types:
+        #     raise NotImplementedError('type not supported', type)
+        # return "%(z)s = erfinv(%(x)s);" % locals()
+        raise NotImplementedError()
 
 
 erfinv = Erfinv(upgrade_to_float_no_complex, name="erfinv")
@@ -236,13 +237,14 @@ class Erfcinv(UnaryScalarOp):
         )
         return (-gz * cst * exp(erfcinv(x) ** 2),)
 
-    # TODO: erfcinv() is not provided by the C standard library
-    # def c_code(self, node, name, inp, out, sub):
-    #    x, = inp
-    #    z, = out
-    #    if node.inputs[0].type in complex_types:
-    #        raise NotImplementedError('type not supported', type)
-    #    return "%(z)s = erfcinv(%(x)s);" % locals()
+    def c_code(self, node, name, inp, out, sub):
+        # TODO: erfcinv() is not provided by the C standard library
+        # x, = inp
+        # z, = out
+        # if node.inputs[0].type in complex_types:
+        #     raise NotImplementedError('type not supported', type)
+        # return "%(z)s = erfcinv(%(x)s);" % locals()
+        raise NotImplementedError()
 
 
 erfcinv = Erfcinv(upgrade_to_float_no_complex, name="erfcinv")
@@ -712,6 +714,9 @@ class GammaIncDer(BinaryScalarOp):
         )
         return np.nan
 
+    def c_code(self, *args, **kwargs):
+        raise NotImplementedError()
+
 
 gammainc_der = GammaIncDer(upgrade_to_float, name="gammainc_der")
 
@@ -791,6 +796,9 @@ class GammaIncCDer(BinaryScalarOp):
 
     def impl(self, k, x):
         return self.st_impl(k, x)
+
+    def c_code(self, *args, **kwargs):
+        raise NotImplementedError()
 
 
 gammaincc_der = GammaIncCDer(upgrade_to_float, name="gammaincc_der")
@@ -900,6 +908,9 @@ class Jv(BinaryScalarOp):
             gz * (jv(v - 1, x) - jv(v + 1, x)) / 2.0,
         ]
 
+    def c_code(self, *args, **kwargs):
+        raise NotImplementedError()
+
 
 jv = Jv(upgrade_to_float, name="jv")
 
@@ -988,6 +999,9 @@ class Iv(BinaryScalarOp):
             gz * (iv(v - 1, x) + iv(v + 1, x)) / 2.0,
         ]
 
+    def c_code(self, *args, **kwargs):
+        raise NotImplementedError()
+
 
 iv = Iv(upgrade_to_float, name="iv")
 
@@ -1011,6 +1025,9 @@ class I1(UnaryScalarOp):
         (gz,) = grads
         return [gz * (i0(x) + iv(2, x)) / 2.0]
 
+    def c_code(self, *args, **kwargs):
+        raise NotImplementedError()
+
 
 i1 = I1(upgrade_to_float, name="i1")
 
@@ -1033,6 +1050,9 @@ class I0(UnaryScalarOp):
         (x,) = inp
         (gz,) = grads
         return [gz * i1(x)]
+
+    def c_code(self, *args, **kwargs):
+        raise NotImplementedError()
 
 
 i0 = I0(upgrade_to_float, name="i0")
@@ -1251,6 +1271,9 @@ class BetaInc(ScalarOp):
             ),
         ]
 
+    def c_code(self, *args, **kwargs):
+        raise NotImplementedError()
+
 
 betainc = BetaInc(upgrade_to_float_no_complex, name="betainc")
 
@@ -1435,6 +1458,9 @@ class BetaIncDer(ScalarOp):
             RuntimeWarning,
         )
         return np.nan
+
+    def c_code(self, *args, **kwargs):
+        raise NotImplementedError()
 
 
 betainc_der = BetaIncDer(upgrade_to_float_no_complex, name="betainc_der")

--- a/aesara/scalar/sharedvar.py
+++ b/aesara/scalar/sharedvar.py
@@ -19,11 +19,7 @@ way (as scan does) to create a shared variable of this kind.
 import numpy as np
 
 from aesara.compile import SharedVariable
-
-from .basic import Scalar, _scalar_py_operators
-
-
-__docformat__ = "restructuredtext en"
+from aesara.scalar.basic import ScalarType, _scalar_py_operators
 
 
 class ScalarSharedVariable(_scalar_py_operators, SharedVariable):
@@ -54,7 +50,7 @@ def shared(value, name=None, strict=False, allow_downcast=None):
 
     dtype = str(dtype)
     value = getattr(np, dtype)(value)
-    scalar_type = Scalar(dtype=dtype)
+    scalar_type = ScalarType(dtype=dtype)
     rval = ScalarSharedVariable(
         type=scalar_type,
         value=value,

--- a/aesara/scan/utils.py
+++ b/aesara/scan/utils.py
@@ -62,7 +62,7 @@ def safe_new(
             return nwx
         else:
             return x
-    # Note, `as_tensor_variable` will convert the `Scalar` into a
+    # Note, `as_tensor_variable` will convert the `ScalarType` into a
     # `TensorScalar` that will require a `ScalarFromTensor` `Op`, making the
     # push-out optimization fail
     elif isinstance(x, aes.ScalarVariable):

--- a/aesara/tensor/__init__.py
+++ b/aesara/tensor/__init__.py
@@ -12,7 +12,7 @@ def as_tensor_variable(
 ) -> "TensorVariable":
     """Convert `x` into an equivalent `TensorVariable`.
 
-    This function can be used to turn ndarrays, numbers, `Scalar` instances,
+    This function can be used to turn ndarrays, numbers, `ScalarType` instances,
     `Apply` instances and `TensorVariable` instances into valid input list
     elements.
 

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -12,6 +12,7 @@ from collections.abc import Sequence
 from functools import partial
 from numbers import Number
 from typing import Dict, Iterable, Optional, Tuple, Union
+from typing import cast as type_cast
 
 import numpy as np
 from numpy.core.multiarray import normalize_axis_index
@@ -573,6 +574,9 @@ tensor_from_scalar = TensorFromScalar()
 class ScalarFromTensor(COp):
 
     __props__ = ()
+
+    def __call__(self, *args, **kwargs) -> ScalarVariable:
+        return type_cast(ScalarVariable, super().__call__(*args, **kwargs))
 
     def make_node(self, t):
         if not isinstance(t.type, TensorType) or t.type.ndim > 0:

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -537,8 +537,8 @@ class TensorFromScalar(Op):
     __props__ = ()
 
     def make_node(self, s):
-        if not isinstance(s.type, aes.Scalar):
-            raise TypeError("Input must be a `Scalar` `Type`")
+        if not isinstance(s.type, aes.ScalarType):
+            raise TypeError("Input must be a `ScalarType` `Type`")
 
         return Apply(self, [s], [tensor(dtype=s.type.dtype, shape=())])
 

--- a/aesara/tensor/elemwise.py
+++ b/aesara/tensor/elemwise.py
@@ -16,7 +16,7 @@ from aesara.misc.frozendict import frozendict
 from aesara.misc.safe_asarray import _asarray
 from aesara.printing import FunctionPrinter, Printer, pprint
 from aesara.scalar import get_scalar_type
-from aesara.scalar.basic import Scalar
+from aesara.scalar.basic import ScalarType
 from aesara.scalar.basic import bool as scalar_bool
 from aesara.scalar.basic import identity as scalar_identity
 from aesara.scalar.basic import transfer_type, upcast
@@ -815,7 +815,7 @@ second dimension
                     # there must be some input that is not broadcastable in
                     # dimension 'dim'
                     for ishp, i in zip(i_shapes, node.inputs):
-                        if isinstance(i.type, Scalar):
+                        if isinstance(i.type, ScalarType):
                             continue  # we skip scalar
                         if not i.type.broadcastable[dim]:
                             # input i is not broadcastable in position dim

--- a/aesara/tensor/nnet/abstract_conv.py
+++ b/aesara/tensor/nnet/abstract_conv.py
@@ -1811,7 +1811,7 @@ def bilinear_kernel_2D(ratio, normalize=True):
 
     Parameters
     ----------
-    ratio: int or Constant/Scalar Aesara tensor of int* dtype
+    ratio: int or Constant/ScalarType Aesara tensor of int* dtype
         the ratio by which an image will be upsampled by the returned filter
         in the 2D space.
 
@@ -1847,7 +1847,7 @@ def bilinear_kernel_1D(ratio, normalize=True):
 
     Parameters
     ----------
-    ratio: int or Constant/Scalar Aesara tensor of int* dtype
+    ratio: int or Constant/ScalarType Aesara tensor of int* dtype
         the ratio by which an image will be upsampled by the returned filter
         in the 2D space.
 
@@ -1998,7 +1998,7 @@ def bilinear_upsampling(
     input: symbolic 4D tensor
         mini-batch of feature map stacks, of shape (batch size,
         input channels, input rows, input columns) that will be upsampled.
-    ratio: `int or Constant or Scalar Tensor of int* dtype`
+    ratio: `int or Constant or ScalarType Tensor of int* dtype`
         the ratio by which the input is upsampled in the 2D space (row and
         col size).
     frac_ratio: None, tuple of int or tuple of tuples of int

--- a/aesara/tensor/nnet/basic.py
+++ b/aesara/tensor/nnet/basic.py
@@ -30,7 +30,6 @@ from aesara.link.c.op import COp
 from aesara.raise_op import Assert
 from aesara.scalar import UnaryScalarOp
 from aesara.tensor import basic as at
-from aesara.tensor import extra_ops, math_opt
 from aesara.tensor.basic import ARange, as_tensor_variable
 from aesara.tensor.basic_opt import (
     register_canonicalize,
@@ -39,6 +38,7 @@ from aesara.tensor.basic_opt import (
 )
 from aesara.tensor.elemwise import DimShuffle, Elemwise
 from aesara.tensor.exceptions import NotScalarConstantError
+from aesara.tensor.extra_ops import Unique
 from aesara.tensor.math import (
     MaxAndArgmax,
     Sum,
@@ -57,6 +57,7 @@ from aesara.tensor.math import (
 )
 from aesara.tensor.math import sum as at_sum
 from aesara.tensor.math import tanh, tensordot, true_div
+from aesara.tensor.math_opt import local_mul_canonizer
 from aesara.tensor.nnet.blocksparse import sparse_block_dot
 from aesara.tensor.shape import Shape, shape_padleft
 from aesara.tensor.subtensor import AdvancedIncSubtensor, AdvancedSubtensor
@@ -1291,7 +1292,7 @@ def softmax_simplifier(numerators, denominators):
     return numerators, denominators
 
 
-math_opt.local_mul_canonizer.add_simplifier(softmax_simplifier, "softmax_simplifier")
+local_mul_canonizer.add_simplifier(softmax_simplifier, "softmax_simplifier")
 
 
 class CrossentropySoftmaxArgmax1HotWithBias(COp):
@@ -2974,7 +2975,7 @@ def confusion_matrix(actual, pred):
     if pred.ndim != 1:
         raise ValueError("pred must be 1-d tensor variable")
 
-    order = extra_ops.Unique(False, False, False)(at.concatenate([actual, pred]))
+    order = Unique(False, False, False)(at.concatenate([actual, pred]))
 
     colA = actual.dimshuffle(0, "x")
     colP = pred.dimshuffle(0, "x")

--- a/aesara/tensor/nnet/batchnorm.py
+++ b/aesara/tensor/nnet/batchnorm.py
@@ -21,11 +21,11 @@ class BNComposite(Composite):
     @config.change_flags(compute_test_value="off")
     def __init__(self, dtype):
         self.dtype = dtype
-        x = aesara.scalar.Scalar(dtype=dtype).make_variable()
-        mean = aesara.scalar.Scalar(dtype=dtype).make_variable()
-        std = aesara.scalar.Scalar(dtype=dtype).make_variable()
-        gamma = aesara.scalar.Scalar(dtype=dtype).make_variable()
-        beta = aesara.scalar.Scalar(dtype=dtype).make_variable()
+        x = aesara.scalar.ScalarType(dtype=dtype).make_variable()
+        mean = aesara.scalar.ScalarType(dtype=dtype).make_variable()
+        std = aesara.scalar.ScalarType(dtype=dtype).make_variable()
+        gamma = aesara.scalar.ScalarType(dtype=dtype).make_variable()
+        beta = aesara.scalar.ScalarType(dtype=dtype).make_variable()
         o = add(mul(true_div(sub(x, mean), std), gamma), beta)
         inputs = [x, mean, std, gamma, beta]
         outputs = [o]

--- a/aesara/tensor/nnet/sigm.py
+++ b/aesara/tensor/nnet/sigm.py
@@ -150,7 +150,7 @@ def hard_sigmoid(x):
     """
     # Use the same dtype as determined by "upgrade_to_float",
     # and perform computation in that dtype.
-    out_dtype = aes.upgrade_to_float(aes.Scalar(dtype=x.dtype))[0].dtype
+    out_dtype = aes.upgrade_to_float(aes.ScalarType(dtype=x.dtype))[0].dtype
     slope = constant(0.2, dtype=out_dtype)
     shift = constant(0.5, dtype=out_dtype)
     x = (x * slope) + shift

--- a/aesara/tensor/subtensor.py
+++ b/aesara/tensor/subtensor.py
@@ -624,7 +624,7 @@ def get_constant_idx(
     Example usage where `v` and `a` are appropriately typed Aesara variables :
     >>> b = a[v, 1:3]
     >>> b.owner.op.idx_list
-    (Scalar(int64), slice(Scalar(int64), Scalar(int64), None))
+    (ScalarType(int64), slice(ScalarType(int64), ScalarType(int64), None))
     >>> get_constant_idx(b.owner.op.idx_list, b.owner.inputs, allow_partial=True)
     [v, slice(1, 3, None)]
     >>> get_constant_idx(b.owner.op.idx_list, b.owner.inputs)
@@ -656,7 +656,7 @@ def get_constant_idx(
 
 
 def as_nontensor_scalar(a: Variable) -> aes.ScalarVariable:
-    """Convert a value to a `Scalar` variable."""
+    """Convert a value to a `ScalarType` variable."""
     # Since aes.as_scalar does not know about tensor types (it would
     # create a circular import) , this method converts either a
     # TensorVariable or a ScalarVariable to a scalar.
@@ -1196,7 +1196,7 @@ class SubtensorPrinter(Printer):
         sidxs = []
         getattr(pstate, "precedence", None)
         for entry in idxs:
-            if isinstance(entry, aes.Scalar):
+            if isinstance(entry, aes.ScalarType):
                 with set_precedence(pstate):
                     sidxs.append(pstate.pprinter.process(inputs.pop()))
             elif isinstance(entry, slice):

--- a/aesara/tensor/subtensor_opt.py
+++ b/aesara/tensor/subtensor_opt.py
@@ -562,8 +562,8 @@ def local_subtensor_remove_broadcastable_index(fgraph, node):
     remove_dim = []
     node_inputs_idx = 1
     for dim, elem in enumerate(idx):
-        if isinstance(elem, (aes.Scalar)):
-            # The idx is a Scalar, ie a Type. This means the actual index
+        if isinstance(elem, (aes.ScalarType)):
+            # The idx is a ScalarType, ie a Type. This means the actual index
             # is contained in node.inputs[1]
             dim_index = node.inputs[node_inputs_idx]
             if isinstance(dim_index, aes.ScalarConstant):
@@ -741,7 +741,7 @@ def local_subtensor_make_vector(fgraph, node):
     if isinstance(node.op, Subtensor):
         (idx,) = node.op.idx_list
 
-        if isinstance(idx, (aes.Scalar, TensorType)):
+        if isinstance(idx, (aes.ScalarType, TensorType)):
             old_idx, idx = idx, node.inputs[1]
             assert idx.type.is_super(old_idx)
     elif isinstance(node.op, AdvancedSubtensor1):

--- a/doc/extending/ctype.rst
+++ b/doc/extending/ctype.rst
@@ -130,7 +130,7 @@ prefix. The complete list can be found in the documentation for
        for the variables handled by this Aesara type. For example,
        for a matrix of 32-bit signed NumPy integers, it should return
        ``"npy_int32"``. If C type may change from an instance to another
-       (e.g. ``Scalar('int32')`` vs ``Scalar('int64')``), consider
+       (e.g. ``ScalarType('int32')`` vs ``ScalarType('int64')``), consider
        implementing this method. If C type is fixed across instances,
        this method may be useless (as you already know the C type
        when you work with the C code).

--- a/doc/extending/other_ops.rst
+++ b/doc/extending/other_ops.rst
@@ -222,7 +222,7 @@ along with pointers to the relevant documentation.
         type). Variables of this Aesara type are represented in C as objects
         of class `PyListObject <https://docs.python.org/2/c-api/list.html>`_.
 
-*       :ref:`Scalar <libdoc_scalar>` : Aesara type that represents a C
+*       :ref:`ScalarType <libdoc_scalar>` : Aesara type that represents a C
         primitive type. The C type associated with this Aesara type is the
         represented C primitive itself.
 

--- a/doc/sandbox/how_to_make_ops.rst
+++ b/doc/sandbox/how_to_make_ops.rst
@@ -64,17 +64,17 @@ Example:
 	class Add(Op):
 	    #...
 	    def make_node(self, x, y):
-	        # note 1: constant, int64 and Scalar are defined in aesara.scalar
+	        # note 1: constant, int64 and ScalarType are defined in aesara.scalar
 	        # note 2: constant(x) is equivalent to Constant(type = int64, data = x)
-	        # note 3: the call int64() is equivalent to Variable(type = int64) or Variable(type = Scalar(dtype = 'int64'))
+	        # note 3: the call int64() is equivalent to Variable(type = int64) or Variable(type = ScalarType(dtype = 'int64'))
 	        if isinstance(x, int):
 	            x = constant(x)
 	        elif not isinstance(x, Variable) or not x.type == int64:
-	            raise TypeError("expected an int64 Scalar")
+	            raise TypeError("expected an int64 ScalarType")
 	        if isinstance(y, int):
 	            y = constant(y)
 	        elif not isinstance(y, Variable) or not x.type == int64:
-	            raise TypeError("expected an int64 Scalar")
+	            raise TypeError("expected an int64 ScalarType")
 	        inputs = [x, y]
 	        outputs = [int64()]
 	        node = Apply(op = self, inputs = inputs, outputs = outputs)

--- a/setup.cfg
+++ b/setup.cfg
@@ -139,10 +139,6 @@ check_untyped_defs = False
 ignore_errors = True
 check_untyped_defs = False
 
-[mypy-aesara.scalar.math]
-ignore_errors = True
-check_untyped_defs = False
-
 [mypy-aesara.tensor.type]
 ignore_errors = True
 check_untyped_defs = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -139,10 +139,6 @@ check_untyped_defs = False
 ignore_errors = True
 check_untyped_defs = False
 
-[mypy-aesara.scalar.basic]
-ignore_errors = True
-check_untyped_defs = False
-
 [mypy-aesara.scalar.math]
 ignore_errors = True
 check_untyped_defs = False

--- a/tests/graph/test_unify.py
+++ b/tests/graph/test_unify.py
@@ -258,10 +258,10 @@ def test_unify_Type():
     s = unify(t1, etuple(TensorType, "float64", (1, None)))
     assert s == {}
 
-    from aesara.scalar.basic import Scalar
+    from aesara.scalar.basic import ScalarType
 
-    st1 = Scalar(np.float64)
-    st2 = Scalar(np.float64)
+    st1 = ScalarType(np.float64)
+    st2 = ScalarType(np.float64)
 
     s = unify(st1, st2)
     assert s == {}

--- a/tests/link/c/c_code/test_quadratic_function.c
+++ b/tests/link/c/c_code/test_quadratic_function.c
@@ -28,7 +28,7 @@ int APPLY_SPECIFIC(quadratic_function)(PyArrayObject* tensor, DTYPE_INPUT_0 a, D
 
 int APPLY_SPECIFIC(compute_quadratic)(PyArrayObject* X, PyArrayObject** Y, PARAMS_TYPE* coeff) {
     DTYPE_INPUT_0 a = (DTYPE_INPUT_0) (*(DTYPE_PARAM_a*) PyArray_GETPTR1(coeff->a, 0)); // 0-D TensorType.
-    DTYPE_INPUT_0 b =                                                    coeff->b;      // Scalar.
+    DTYPE_INPUT_0 b =                                                    coeff->b;      // ScalarType.
     DTYPE_INPUT_0 c =                   (DTYPE_INPUT_0) PyFloat_AsDouble(coeff->c);     // Generic.
     Py_XDECREF(*Y);
     *Y = (PyArrayObject*)PyArray_EMPTY(PyArray_NDIM(X), PyArray_DIMS(X), TYPENUM_INPUT_0, PyArray_IS_F_CONTIGUOUS(X));

--- a/tests/link/c/test_params_type.py
+++ b/tests/link/c/test_params_type.py
@@ -7,13 +7,13 @@ from aesara.graph.basic import Apply
 from aesara.link.c.op import COp, ExternalCOp
 from aesara.link.c.params_type import Params, ParamsType
 from aesara.link.c.type import EnumList, Generic
-from aesara.scalar import Scalar
+from aesara.scalar import ScalarType
 from aesara.tensor.type import TensorType, matrix
 from tests import unittest_tools as utt
 
 
 tensor_type_0d = TensorType("float64", tuple())
-scalar_type = Scalar("float64")
+scalar_type = ScalarType("float64")
 generic_type = Generic()
 
 
@@ -77,7 +77,7 @@ class QuadraticOpFunc(COp):
     def c_code(self, node, name, inputs, outputs, sub):
         return """
         %(float_type)s a = (%(float_type)s) (*(npy_float64*) PyArray_GETPTR1(%(coeff)s->a, 0)); // 0-D TensorType.
-        %(float_type)s b =                                                   %(coeff)s->b;      // Scalar.
+        %(float_type)s b =                                                   %(coeff)s->b;      // ScalarType.
         %(float_type)s c =                 (%(float_type)s) PyFloat_AsDouble(%(coeff)s->c);     // Generic.
         Py_XDECREF(%(Y)s);
         %(Y)s = (PyArrayObject*)PyArray_EMPTY(PyArray_NDIM(%(X)s), PyArray_DIMS(%(X)s), PyArray_TYPE(%(X)s), PyArray_IS_F_CONTIGUOUS(%(X)s));
@@ -128,13 +128,13 @@ class TestParamsType:
         wp1 = ParamsType(
             a=Generic(),
             array=TensorType("int64", (False,)),
-            floatting=Scalar("float64"),
+            floatting=ScalarType("float64"),
             npy_scalar=TensorType("float64", tuple()),
         )
         wp2 = ParamsType(
             a=Generic(),
             array=TensorType("int64", (False,)),
-            floatting=Scalar("float64"),
+            floatting=ScalarType("float64"),
             npy_scalar=TensorType("float64", tuple()),
         )
         w1 = Params(
@@ -158,7 +158,7 @@ class TestParamsType:
         wp2_other = ParamsType(
             other_name=Generic(),
             array=TensorType("int64", (False,)),
-            floatting=Scalar("float64"),
+            floatting=ScalarType("float64"),
             npy_scalar=TensorType("float64", tuple()),
         )
         w2 = Params(

--- a/tests/scalar/test_basic.py
+++ b/tests/scalar/test_basic.py
@@ -1,13 +1,3 @@
-"""
-These routines are not well-tested. They are also old.
-OB says that it is not important to test them well because Scalar Ops
-are rarely used by themselves, instead they are the basis for Tensor Ops
-(which should be checked thoroughly). Moreover, Scalar will be changed
-to use numpy's scalar routines.
-If you do want to rewrite these tests, bear in mind:
-  * You don't need to use Composite.
-  * FunctionGraph and DualLinker are old, use aesara.compile.function.function instead.
-"""
 import numpy as np
 import pytest
 
@@ -20,7 +10,7 @@ from aesara.scalar.basic import (
     ComplexError,
     Composite,
     InRange,
-    Scalar,
+    ScalarType,
     add,
     and_,
     arccos,
@@ -357,8 +347,8 @@ class TestUpgradeToFloat:
 
         xi = int8("xi")
         yi = int8("yi")
-        xf = Scalar(aesara.config.floatX)("xf")
-        yf = Scalar(aesara.config.floatX)("yf")
+        xf = ScalarType(aesara.config.floatX)("xf")
+        yf = ScalarType(aesara.config.floatX)("yf")
 
         ei = true_div(xi, yi)
         fi = aesara.function([xi, yi], ei)

--- a/tests/scalar/test_type.py
+++ b/tests/scalar/test_type.py
@@ -3,7 +3,7 @@ import numpy as np
 from aesara.configdefaults import config
 from aesara.scalar.basic import (
     IntDiv,
-    Scalar,
+    ScalarType,
     TrueDiv,
     complex64,
     float32,
@@ -14,7 +14,7 @@ from aesara.scalar.basic import (
 
 
 def test_numpy_dtype():
-    test_type = Scalar(np.int32)
+    test_type = ScalarType(np.int32)
     assert test_type.dtype == "int32"
 
 
@@ -37,9 +37,9 @@ def test_div_types():
 
 
 def test_filter_float_subclass():
-    """Make sure `Scalar.filter` can handle `float` subclasses."""
+    """Make sure `ScalarType.filter` can handle `float` subclasses."""
     with config.change_flags(floatX="float64"):
-        test_type = Scalar("float64")
+        test_type = ScalarType("float64")
 
         nan = np.array([np.nan], dtype="float64")[0]
         assert isinstance(nan, float)
@@ -49,7 +49,7 @@ def test_filter_float_subclass():
 
     with config.change_flags(floatX="float32"):
         # Try again, except this time `nan` isn't a `float`
-        test_type = Scalar("float32")
+        test_type = ScalarType("float32")
 
         nan = np.array([np.nan], dtype="float32")[0]
         assert isinstance(nan, np.floating)
@@ -63,6 +63,6 @@ def test_filter_float_subclass():
 
 
 def test_clone():
-    st = Scalar("int64")
+    st = ScalarType("int64")
     assert st == st.clone()
     assert st.clone("float64").dtype == "float64"

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -3448,7 +3448,7 @@ class TestGetScalarConstantValue:
         assert get_scalar_constant_value(mv[np.int32(0)]) == 1
         assert get_scalar_constant_value(mv[np.int64(1)]) == 2
         assert get_scalar_constant_value(mv[np.uint(2)]) == 3
-        t = aes.Scalar("int64")
+        t = aes.ScalarType("int64")
         with pytest.raises(NotScalarConstantError):
             get_scalar_constant_value(mv[t()])
 

--- a/tests/tensor/test_basic_opt.py
+++ b/tests/tensor/test_basic_opt.py
@@ -1971,7 +1971,7 @@ class TestCastCast:
 
     def test_consecutive(self):
         x = fmatrix()
-        o = Elemwise(aes.Cast(aes.Scalar("float64")))(x.astype("float64"))
+        o = Elemwise(aes.Cast(aes.ScalarType("float64")))(x.astype("float64"))
         f = function([x], o, mode=self.mode)
         dx = np.random.random((5, 4)).astype("float32")
         f(dx)
@@ -1980,7 +1980,7 @@ class TestCastCast:
         assert isinstance(topo[0].op.scalar_op, aes.basic.Cast)
 
         x = dmatrix()
-        o = Elemwise(aes.Cast(aes.Scalar("float32")))(x.astype("float32"))
+        o = Elemwise(aes.Cast(aes.ScalarType("float32")))(x.astype("float32"))
         f = function([x], o, mode=self.mode)
         dx = np.random.random((5, 4))
         f(dx)
@@ -1991,7 +1991,7 @@ class TestCastCast:
     def test_upcast(self):
         # Upcast followed by any other cast
         x = fmatrix()
-        o = Elemwise(aes.Cast(aes.Scalar("complex128")))(x.astype("complex64"))
+        o = Elemwise(aes.Cast(aes.ScalarType("complex128")))(x.astype("complex64"))
         f = function([x], o, mode=self.mode)
         dx = np.random.random((5, 4)).astype("float32")
         f(dx)
@@ -2001,7 +2001,7 @@ class TestCastCast:
 
         # Upcast followed by a downcast back to the base type
         x = fmatrix()
-        o = Elemwise(aes.Cast(aes.Scalar("float32")))(x.astype("float64"))
+        o = Elemwise(aes.Cast(aes.ScalarType("float32")))(x.astype("float64"))
         f = function([x], o, mode=self.mode)
         dx = np.random.random((5, 4)).astype("float32")
         f(dx)
@@ -2012,7 +2012,7 @@ class TestCastCast:
         # Downcast followed by an upcast back to the base type
         # Optimization shouldn't be applied
         x = dmatrix()
-        o = Elemwise(aes.Cast(aes.Scalar("float64")))(x.astype("float32"))
+        o = Elemwise(aes.Cast(aes.ScalarType("float64")))(x.astype("float32"))
         f = function([x], o, mode=self.mode)
         dx = np.random.random((5, 4))
         f(dx)
@@ -2641,7 +2641,7 @@ def test_local_tensor_scalar_tensor(dtype):
     ],
 )
 def test_local_scalar_tensor_scalar(dtype):
-    s_type = aes.Scalar(dtype=dtype)
+    s_type = aes.ScalarType(dtype=dtype)
     s = s_type()
     t = at.tensor_from_scalar(s)
     s2 = at.scalar_from_tensor(t)

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -2269,7 +2269,7 @@ class TestArithmeticCast:
             return np.array([1], dtype=dtype)
 
         def Aesara_i_scalar(dtype):
-            return aes.Scalar(str(dtype))()
+            return aes.ScalarType(str(dtype))()
 
         def numpy_i_scalar(dtype):
             return numpy_scalar(dtype)

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -2621,4 +2621,4 @@ def test_index_vars_to_types():
         index_vars_to_types(1)
 
     res = index_vars_to_types(iscalar)
-    assert isinstance(res, scal.Scalar)
+    assert isinstance(res, scal.ScalarType)


### PR DESCRIPTION
This PR renames `Scalar` to `ScalarType` and includes some typing fixes.