### PR TITLE
Add Numba implementation for `DirichletRV` and fix `BroadcastTo` bug

### DIFF
--- a/aesara/link/numba/dispatch/extra_ops.py
+++ b/aesara/link/numba/dispatch/extra_ops.py
@@ -2,6 +2,7 @@ import warnings
 
 import numba
 import numpy as np
+from numba.misc.special import literal_unroll
 from numpy.core.multiarray import normalize_axis_index
 
 from aesara import config
@@ -367,10 +368,12 @@ def numba_funcify_BroadcastTo(op, node, **kwargs):
     def broadcast_to(x, *shape):
         scalars_shape = create_zeros_tuple()
 
-        for i in range(len(shape)):
+        i = 0
+        for s_i in literal_unroll(shape):
             scalars_shape = numba_basic.tuple_setitem(
-                scalars_shape, i, numba_basic.to_scalar(shape[i])
+                scalars_shape, i, numba_basic.to_scalar(s_i)
             )
+            i += 1
 
         return np.broadcast_to(x, scalars_shape)
 

--- a/aesara/link/numba/dispatch/random.py
+++ b/aesara/link/numba/dispatch/random.py
@@ -319,7 +319,7 @@ def numba_funcify_CategoricalRV(op, node, **kwargs):
     size_len = int(get_vector_length(node.inputs[1]))
 
     @numba_basic.numba_njit
-    def sampler(rng, size, dtype, p):
+    def categorical_rv(rng, size, dtype, p):
 
         size_tpl = numba_ndarray.to_fixed_tuple(size, size_len)
         ind_shape = p.shape[:-1]
@@ -342,4 +342,4 @@ def numba_funcify_CategoricalRV(op, node, **kwargs):
 
         return (rng, res)
 
-    return sampler
+    return categorical_rv

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -1924,6 +1924,10 @@ def test_Searchsorted(a, v, side, sorter, exc):
             set_test_value(at.vector(), rng.random(size=(2,)).astype(config.floatX)),
             at.as_tensor([set_test_value(at.lscalar(), np.array(v)) for v in [3, 2]]),
         ),
+        (
+            set_test_value(at.vector(), rng.random(size=(2,)).astype(config.floatX)),
+            [at.as_tensor(3, dtype=np.int8), at.as_tensor(2, dtype=np.int64)],
+        ),
     ],
 )
 def test_BroadcastTo(x, shape):

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -3165,10 +3165,9 @@ def test_unaligned_RandomVariable(rv_op, dist_args, base_size, cdf_name, params_
 
 
 @pytest.mark.parametrize(
-    "rv_op, dist_args, size, cm",
+    "dist_args, size, cm",
     [
         pytest.param(
-            aer.categorical,
             [
                 set_test_value(
                     at.dvector(),
@@ -3179,7 +3178,6 @@ def test_unaligned_RandomVariable(rv_op, dist_args, base_size, cdf_name, params_
             contextlib.suppress(),
         ),
         pytest.param(
-            aer.categorical,
             [
                 set_test_value(
                     at.dmatrix(),
@@ -3193,7 +3191,6 @@ def test_unaligned_RandomVariable(rv_op, dist_args, base_size, cdf_name, params_
             contextlib.suppress(),
         ),
         pytest.param(
-            aer.categorical,
             [
                 set_test_value(
                     at.dmatrix(),
@@ -3208,9 +3205,9 @@ def test_unaligned_RandomVariable(rv_op, dist_args, base_size, cdf_name, params_
         ),
     ],
 )
-def test_CategoricalRV(rv_op, dist_args, size, cm):
+def test_CategoricalRV(dist_args, size, cm):
     rng = shared(np.random.RandomState(29402))
-    g = rv_op(*dist_args, size=size, rng=rng)
+    g = aer.categorical(*dist_args, size=size, rng=rng)
     g_fg = FunctionGraph(outputs=[g])
 
     with cm:


### PR DESCRIPTION
This PR adds a Numba implementation for `DirichletRV` and fixes a bug that occurs in Numba's `BroadcastTo` implementation when the shape values are not the same NumPy types.