### PR TITLE
Load the sparse shared constructor support at package-level

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
           )$
       - id: check-merge-conflict
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/aesara/__init__.py
+++ b/aesara/__init__.py
@@ -176,6 +176,7 @@ def get_scalar_constant_value(v):
 
 # isort: off
 import aesara.tensor.random.var
+import aesara.sparse
 from aesara.scan import checkpoints
 from aesara.scan.basic import scan
 from aesara.scan.views import foldl, foldr, map, reduce

--- a/aesara/compile/profiling.py
+++ b/aesara/compile/profiling.py
@@ -186,7 +186,7 @@ class ProfileStats:
     """
 
     def reset(self):
-        """ Ignore previous function call"""
+        """Ignore previous function call"""
         # self.compile_time = 0.
         self.fct_call_time = 0.0
         self.fct_callcount = 0

--- a/aesara/configparser.py
+++ b/aesara/configparser.py
@@ -27,7 +27,7 @@ class AesaraConfigWarning(Warning):
 
 
 class ConfigAccessViolation(AttributeError):
-    """ Raised when a config setting is accessed through the wrong config instance. """
+    """Raised when a config setting is accessed through the wrong config instance."""
 
 
 class _ChangeFlagsDecorator:
@@ -87,7 +87,7 @@ class _SectionRedirect:
 
 
 class AesaraConfigParser:
-    """ Object that holds configuration settings. """
+    """Object that holds configuration settings."""
 
     def __init__(self, flags_dict: dict, aesara_cfg, aesara_raw_cfg):
         self._flags_dict = flags_dict

--- a/aesara/gradient.py
+++ b/aesara/gradient.py
@@ -243,7 +243,7 @@ def Rop(f, wrt, eval_points, disconnected_outputs="raise", return_disconnected="
     seen_nodes = OrderedDict()
 
     def _traverse(node):
-        """ TODO: writeme """
+        """TODO: writeme"""
 
         if node is None:
             return
@@ -1050,7 +1050,7 @@ def _populate_grad_dict(var_to_app_to_idx, grad_dict, wrt, cost_name=None):
     term_dict = OrderedDict()
 
     def access_term_cache(node):
-        """ Populates term_dict[node] and returns it """
+        """Populates term_dict[node] and returns it"""
 
         if node not in term_dict:
 

--- a/aesara/ifelse.py
+++ b/aesara/ifelse.py
@@ -577,7 +577,7 @@ def cond_merge_ifs_false(fgraph, node):
 
 
 class CondMerge(GlobalOptimizer):
-    """ Graph Optimizer that merges different cond ops """
+    """Graph Optimizer that merges different cond ops"""
 
     def add_requirements(self, fgraph):
         from aesara.graph.features import ReplaceValidate

--- a/aesara/link/c/cvm.py
+++ b/aesara/link/c/cvm.py
@@ -18,7 +18,6 @@ try:
             # skip VM.__init__
             CLazyLinker.__init__(self, *args, **kwargs)
 
-
 except ImportError:
     pass
 except (OSError, MissingGXX):

--- a/aesara/link/c/op.py
+++ b/aesara/link/c/op.py
@@ -575,7 +575,7 @@ class ExternalCOp(COp):
         return "\n".join(define_macros), "\n".join(undef_macros)
 
     def c_init_code_struct(self, node, name, sub):
-        r""" Stitches all the macros and ``init_code_*``\s together."""
+        r"""Stitches all the macros and ``init_code_*``\s together."""
         if "init_code_struct" in self.code_sections:
             op_code = self.code_sections["init_code_struct"]
 

--- a/aesara/misc/may_share_memory.py
+++ b/aesara/misc/may_share_memory.py
@@ -17,7 +17,6 @@ try:
     def _is_sparse(a):
         return scipy.sparse.issparse(a)
 
-
 except ImportError:
     # scipy not imported, their can be only ndarray and gpuarray
     def _is_sparse(a):
@@ -31,7 +30,6 @@ if gpuarray.pygpu:
 
     def _is_gpua(a):
         return isinstance(a, gpuarray.pygpu.gpuarray.GpuArray)
-
 
 else:
 

--- a/aesara/sandbox/rng_mrg.py
+++ b/aesara/sandbox/rng_mrg.py
@@ -808,7 +808,7 @@ class MRG_RandomStream:
 
         """
         assert isinstance(dtype, str)
-        assert n_streams < 2 ** 72
+        assert n_streams < 2**72
         assert n_streams > 0
         rval = np.zeros((n_streams, 6), dtype="int32")
         rval[0] = self.rstate
@@ -1212,7 +1212,7 @@ class MRG_RandomStream:
             to_fix0 = at.nonzero(to_fix0)[0]
             to_fix1 = at.nonzero(to_fix1)[0]
             n_fix_samples = to_fix0.size + to_fix1.size
-            lower = at.constant(1.0 / np.e ** 2, dtype=dtype)
+            lower = at.constant(1.0 / np.e**2, dtype=dtype)
             u_fix = self.uniform(
                 (n_fix_samples,),
                 low=lower,

--- a/aesara/scalar/basic.py
+++ b/aesara/scalar/basic.py
@@ -2268,7 +2268,7 @@ class Pow(BinaryScalarOp):
     nfunc_spec = ("power", 2, 1)
 
     def impl(self, x, y):
-        return x ** y
+        return x**y
 
     def c_code(self, node, name, inputs, outputs, sub):
         (x, y) = inputs
@@ -2291,7 +2291,7 @@ class Pow(BinaryScalarOp):
 
         first_part = gz * y * x ** (y - 1)
 
-        second_part = gz * log(x) * x ** y
+        second_part = gz * log(x) * x**y
         second_part = switch(eq(x, 0), 0, second_part)
 
         return (first_part, second_part)
@@ -3902,7 +3902,7 @@ class Angle(UnaryScalarOp):
         y = imag(c)
         r = _abs(c)
 
-        gr = -gtheta * y / (r ** 2 * sqrt(1 - (y / r) ** 2))
+        gr = -gtheta * y / (r**2 * sqrt(1 - (y / r) ** 2))
         gx = gr * x / r
         gy = gr * y / r
         if c in complex_types:

--- a/aesara/scalar/math.py
+++ b/aesara/scalar/math.py
@@ -659,7 +659,7 @@ class GammaIncDer(BinaryScalarOp):
         if x == 0:
             return 0
 
-        sqrt_exp = -756 - x ** 2 + 60 * x
+        sqrt_exp = -756 - x**2 + 60 * x
         if (
             (k < 0.8 and x > 15)
             or (k < 12 and x > 30)
@@ -1301,7 +1301,7 @@ class BetaIncDer(ScalarOp):
                 return p * f * (q - 1) / (q * (p + 1))
 
             p2n = p + 2 * n
-            F1 = p ** 2 * f ** 2 * (n - 1) / (q ** 2)
+            F1 = p**2 * f**2 * (n - 1) / (q**2)
             F2 = (
                 (p + q + n - 2)
                 * (p + n - 1)
@@ -1332,18 +1332,18 @@ class BetaIncDer(ScalarOp):
             if n == 1:
                 return -p * f * (q - 1) / (q * (p + 1) ** 2)
 
-            pp = p ** 2
+            pp = p**2
             ppp = pp * p
             p2n = p + 2 * n
 
-            N1 = -(n - 1) * f ** 2 * pp * (q - n)
-            N2a = (-8 + 8 * p + 8 * q) * n ** 3
-            N2b = (16 * pp + (-44 + 20 * q) * p + 26 - 24 * q) * n ** 2
+            N1 = -(n - 1) * f**2 * pp * (q - n)
+            N2a = (-8 + 8 * p + 8 * q) * n**3
+            N2b = (16 * pp + (-44 + 20 * q) * p + 26 - 24 * q) * n**2
             N2c = (10 * ppp + (14 * q - 46) * pp + (-40 * q + 66) * p - 28 + 24 * q) * n
-            N2d = 2 * pp ** 2 + (-13 + 3 * q) * ppp + (-14 * q + 30) * pp
+            N2d = 2 * pp**2 + (-13 + 3 * q) * ppp + (-14 * q + 30) * pp
             N2e = (-29 + 19 * q) * p + 10 - 8 * q
 
-            D1 = q ** 2 * (p2n - 3) ** 2
+            D1 = q**2 * (p2n - 3) ** 2
             D2 = (p2n - 2) ** 3 * (p2n - 1) ** 2
 
             return (N1 / D1) * (N2a + N2b + N2c + N2d + N2e) / D2
@@ -1356,7 +1356,7 @@ class BetaIncDer(ScalarOp):
                 return p * f / (q * (p + 1))
 
             p2n = p + 2 * n
-            F1 = (p ** 2 * f ** 2 / (q ** 2)) * (n - 1) * (p + n - 1) * (2 * q + p - 2)
+            F1 = (p**2 * f**2 / (q**2)) * (n - 1) * (p + n - 1) * (2 * q + p - 2)
             D1 = (p2n - 3) * (p2n - 2) ** 2 * (p2n - 1)
 
             return F1 / D1
@@ -1366,14 +1366,14 @@ class BetaIncDer(ScalarOp):
             Derivative of b_n wrt p
             """
             p2n = p + 2 * n
-            pp = p ** 2
+            pp = p**2
             q4 = 4 * q
             p4 = 4 * p
 
             F1 = (p * f / q) * (
-                (-p4 - q4 + 4) * n ** 2 + (p4 - 4 + q4 - 2 * pp) * n + pp * q
+                (-p4 - q4 + 4) * n**2 + (p4 - 4 + q4 - 2 * pp) * n + pp * q
             )
-            D1 = (p2n - 2) ** 2 * p2n ** 2
+            D1 = (p2n - 2) ** 2 * p2n**2
 
             return F1 / D1
 
@@ -1382,7 +1382,7 @@ class BetaIncDer(ScalarOp):
             Derivative of b_n wrt to q
             """
             p2n = p + 2 * n
-            return -(p ** 2 * f) / (q * (p2n - 2) * p2n)
+            return -(p**2 * f) / (q * (p2n - 2) * p2n)
 
         # Input validation
         if not (0 <= x <= 1) or p < 0 or q < 0:

--- a/aesara/scan/checkpoints.py
+++ b/aesara/scan/checkpoints.py
@@ -153,13 +153,9 @@ def scan_checkpoints(
         i_sequences = list(args[: len(o_sequences)])
         i_prev_outputs = list(args[len(o_sequences) : -len(o_nonsequences)])
         i_non_sequences = list(args[-len(o_nonsequences) :])
-        i_outputs_infos = (
-            i_prev_outputs
-            + [
-                None,
-            ]
-            * len(new_nitsots)
-        )
+        i_outputs_infos = i_prev_outputs + [
+            None,
+        ] * len(new_nitsots)
 
         # Call the user-provided function with the proper arguments
         results, updates = scan(

--- a/aesara/tensor/math.py
+++ b/aesara/tensor/math.py
@@ -1676,10 +1676,10 @@ def var(input, axis=None, ddof=0, keepdims=False, corrected=False):
     # return the mean sqr
     two = constant(2, dtype=centered_input.dtype)
     if ddof == 0:
-        v = mean((centered_input ** two), axis, keepdims=keepdims)
+        v = mean((centered_input**two), axis, keepdims=keepdims)
     else:
         shp = shape(input) - ddof
-        v = sum((centered_input ** two), axis=axis, keepdims=keepdims)
+        v = sum((centered_input**two), axis=axis, keepdims=keepdims)
         for i in axis:
             v = true_div(v, shp[i])
 
@@ -2787,7 +2787,7 @@ def ptp(a, axis=None):
 
 
 def power(x, y):
-    return x ** y
+    return x**y
 
 
 def logaddexp(*xs):

--- a/aesara/tensor/math_opt.py
+++ b/aesara/tensor/math_opt.py
@@ -1139,7 +1139,7 @@ def local_sum_prod_mul_by_scalar(fgraph, node):
             # the power of the number of elements in the input to the `Prod`
             if isinstance(node.op, Prod) and new_op_input_nb_elements != 1:
 
-                scalars = [s ** new_op_input_nb_elements for s in scalars]
+                scalars = [s**new_op_input_nb_elements for s in scalars]
 
             # Scale the output of the op by the scalars and return as
             # replacement for the original output
@@ -1376,7 +1376,7 @@ def local_useless_elemwise_comparison(fgraph, node):
         """
 
     def investigate(node):
-        " Return True if values will be shapes, so >= 0"
+        "Return True if values will be shapes, so >= 0"
         if isinstance(node.op, (Shape, Shape_i)):
             return True
         elif isinstance(node.op, Subtensor) and node.inputs[0].owner:
@@ -1649,7 +1649,7 @@ def local_reduce_join(fgraph, node):
 @register_useless("local_cut_useless_reduce")
 @local_optimizer(ALL_REDUCE)
 def local_useless_reduce(fgraph, node):
-    """Sum(a, axis=[]) -> a  """
+    """Sum(a, axis=[]) -> a"""
     if isinstance(node.op, CAReduce):
         (summed,) = node.inputs
         # if reduce were doing anything, the output ndim would be reduced
@@ -1733,7 +1733,7 @@ def local_opt_alloc(fgraph, node):
                     if isinstance(node.op, Sum):
                         val = val * size
                     else:
-                        val = val ** size
+                        val = val**size
                     # Sum can change the input dtype (upcast or bool
                     # -> float32) by default or by user request.
                     # We can ignore the acc_dtype, as there is only 1
@@ -1749,7 +1749,7 @@ def local_opt_alloc(fgraph, node):
                     if isinstance(node.op, Sum):
                         val *= size
                     else:
-                        val = val ** size
+                        val = val**size
                 # See comments above.
                 val = val.astype(node.outputs[0].dtype)
                 return [
@@ -1980,7 +1980,7 @@ def local_pow_specialize_device(fgraph, node):
                     else:
                         rval1 = pow2[log_to_do]
                         rval1_scal = pow2_scal[log_to_do]
-                    y_to_do -= 2 ** log_to_do
+                    y_to_do -= 2**log_to_do
 
                 if abs(y) > 2:
                     # We fuse all the pow together here to make
@@ -2130,7 +2130,7 @@ mul_canonizer = in2out(
 
 
 def check_for_x_over_absX(numerators, denominators):
-    """Convert x/abs(x) into sign(x). """
+    """Convert x/abs(x) into sign(x)."""
     # TODO: this function should dig/search through dimshuffles
     # This won't catch a dimshuffled absolute value
     for den in list(denominators):
@@ -2644,10 +2644,10 @@ def local_log_erfc(fgraph, node):
 
     x = node.inputs[0].owner.inputs[0]
     stab_value = (
-        -(x ** 2)
+        -(x**2)
         - log(x)
         - 0.5 * log(np.pi)
-        + log(1 - 1 / (2 * x ** 2) + 3 / (4 * x ** 4) - 15 / (8 * x ** 6))
+        + log(1 - 1 / (2 * x**2) + 3 / (4 * x**4) - 15 / (8 * x**6))
     )
 
     if node.outputs[0].dtype == "float32" or node.outputs[0].dtype == "float16":
@@ -2821,7 +2821,7 @@ def local_grad_log_erfc_neg(fgraph, node):
     # aaron value
     stab_value = (
         x
-        * at_pow(1 - 1 / (2 * (x ** 2)) + 3 / (4 * (x ** 4)) - 15 / (8 * (x ** 6)), -1)
+        * at_pow(1 - 1 / (2 * (x**2)) + 3 / (4 * (x**4)) - 15 / (8 * (x**6)), -1)
         * cast(sqrt(np.pi), dtype=x.dtype)
     )
 

--- a/aesara/tensor/nlinalg.py
+++ b/aesara/tensor/nlinalg.py
@@ -670,7 +670,7 @@ def norm(x, ord):
         raise ValueError("'axis' entry is out of bounds.")
     elif ndim == 1:
         if ord is None:
-            return tm.sum(x ** 2) ** 0.5
+            return tm.sum(x**2) ** 0.5
         elif ord == "inf":
             return tm.max(abs(x))
         elif ord == "-inf":
@@ -679,13 +679,13 @@ def norm(x, ord):
             return x[x.nonzero()].shape[0]
         else:
             try:
-                z = tm.sum(abs(x ** ord)) ** (1.0 / ord)
+                z = tm.sum(abs(x**ord)) ** (1.0 / ord)
             except TypeError:
                 raise ValueError("Invalid norm order for vectors.")
             return z
     elif ndim == 2:
         if ord is None or ord == "fro":
-            return tm.sum(abs(x ** 2)) ** (0.5)
+            return tm.sum(abs(x**2)) ** (0.5)
         elif ord == "inf":
             return tm.max(tm.sum(abs(x), 1))
         elif ord == "-inf":

--- a/aesara/tensor/nnet/abstract_conv.py
+++ b/aesara/tensor/nnet/abstract_conv.py
@@ -2308,7 +2308,7 @@ class BaseAbstractConv(Op):
         return False
 
     def flops(self, inp, outp):
-        """ Useful with the hack in profiling to print the MFlops"""
+        """Useful with the hack in profiling to print the MFlops"""
         if self.convdim == 2:
             # if the output shape is correct, then this gives the correct
             # flops for any direction, sampling, padding, and border mode

--- a/aesara/tensor/nnet/batchnorm.py
+++ b/aesara/tensor/nnet/batchnorm.py
@@ -683,7 +683,7 @@ class AbstractBatchNormTrainGrad(Op):
 
         if not isinstance(ddinputs.type, aesara.gradient.DisconnectedType):
             ccc = scale * (ddinputs - mean(ddinputs, axis=self.axes, keepdims=True))
-            ddd = (x_invstd ** 3) * (
+            ddd = (x_invstd**3) * (
                 ccc * mean(dy * x_diff, axis=self.axes, keepdims=True)
                 + dy * mean(ccc * x_diff, axis=self.axes, keepdims=True)
             )
@@ -692,13 +692,13 @@ class AbstractBatchNormTrainGrad(Op):
             g_wrt_dy = g_wrt_dy + (
                 (ccc * x_invstd)
                 - (
-                    (x_invstd ** 3)
+                    (x_invstd**3)
                     * x_diff
                     * mean(ccc * x_diff, axis=self.axes, keepdims=True)
                 )
             )
 
-            eee = (dy * x_invstd) - ((x_invstd ** 3) * x_diff * mean_dy_x_diff)
+            eee = (dy * x_invstd) - ((x_invstd**3) * x_diff * mean_dy_x_diff)
             g_wrt_scale = g_wrt_scale + at_sum(
                 ddinputs * (eee - mean(eee, axis=self.axes, keepdims=True)),
                 axis=self.axes,
@@ -707,7 +707,7 @@ class AbstractBatchNormTrainGrad(Op):
 
             g_wrt_x_mean = g_wrt_x_mean + at_sum(ddd, axis=self.axes, keepdims=True)
             g_wrt_x_invstd = g_wrt_x_invstd + at_sum(
-                ccc * (dy - 3 * (x_invstd ** 2) * x_diff * mean_dy_x_diff),
+                ccc * (dy - 3 * (x_invstd**2) * x_diff * mean_dy_x_diff),
                 axis=self.axes,
                 keepdims=True,
             )
@@ -765,7 +765,7 @@ class AbstractBatchNormTrainGrad(Op):
 
         x_diff = x - x_mean
         mean_dy_x_diff = np.mean(dy * x_diff, axis=axes, keepdims=True)
-        c = (dy * x_invstd) - (x_diff * mean_dy_x_diff * (x_invstd ** 3))
+        c = (dy * x_invstd) - (x_diff * mean_dy_x_diff * (x_invstd**3))
 
         g_wrt_inputs = scale * (c - np.mean(c, axis=axes, keepdims=True))
         g_wrt_scale = np.sum(dy * x_invstd * x_diff, axis=axes, keepdims=True)
@@ -856,7 +856,7 @@ def local_abstract_batch_norm_train_grad(fgraph, node):
 
     x_diff = x - x_mean
     mean_dy_x_diff = mean(dy * x_diff, axis=axes, keepdims=True)
-    c = (dy * x_invstd) - x_diff * (mean_dy_x_diff * (x_invstd ** 3))
+    c = (dy * x_invstd) - x_diff * (mean_dy_x_diff * (x_invstd**3))
 
     g_wrt_inputs = scale * (c - mean(c, axis=axes, keepdims=True))
     g_wrt_scale = at_sum(dy * x_invstd * x_diff, axis=axes, keepdims=True)

--- a/aesara/tensor/random/utils.py
+++ b/aesara/tensor/random/utils.py
@@ -221,7 +221,7 @@ class RandomStream:
         self.gen_seedgen = np.random.default_rng(seed)
 
         for old_r, new_r in self.state_updates:
-            old_r_seed = self.gen_seedgen.integers(2 ** 30)
+            old_r_seed = self.gen_seedgen.integers(2**30)
             old_r.set_value(self.rng_ctor(int(old_r_seed)), borrow=True)
 
     def gen(self, op, *args, **kwargs):
@@ -250,7 +250,7 @@ class RandomStream:
             )
 
         # Generate a new random state
-        seed = int(self.gen_seedgen.integers(2 ** 30))
+        seed = int(self.gen_seedgen.integers(2**30))
         random_state_variable = shared(self.rng_ctor(seed))
 
         # Distinguish it from other shared variables (why?)

--- a/tests/compile/function/test_function.py
+++ b/tests/compile/function/test_function.py
@@ -167,7 +167,7 @@ class TestFunctionIn:
             f([3], np.array([6], dtype="int16"), 1)
 
         # Value too big for a, silently ignored
-        assert np.all(f([2 ** 20], np.ones(1, dtype="int8"), 1) == 2)
+        assert np.all(f([2**20], np.ones(1, dtype="int8"), 1) == 2)
 
         # Value too big for b, raises TypeError
         with pytest.raises(TypeError):
@@ -246,7 +246,7 @@ def test_pickle_unpickle_with_reoptimization():
     x2 = fmatrix("x2")
     x3 = shared(np.ones((10, 10), dtype=floatX))
     x4 = shared(np.ones((10, 10), dtype=floatX))
-    y = at_sum(at_sum(at_sum(x1 ** 2 + x2) + x3) + x4)
+    y = at_sum(at_sum(at_sum(x1**2 + x2) + x3) + x4)
 
     updates = OrderedDict()
     updates[x3] = x3 + 1
@@ -278,7 +278,7 @@ def test_pickle_unpickle_without_reoptimization():
     x2 = fmatrix("x2")
     x3 = shared(np.ones((10, 10), dtype=floatX))
     x4 = shared(np.ones((10, 10), dtype=floatX))
-    y = at_sum(at_sum(at_sum(x1 ** 2 + x2) + x3) + x4)
+    y = at_sum(at_sum(at_sum(x1**2 + x2) + x3) + x4)
 
     updates = OrderedDict()
     updates[x3] = x3 + 1

--- a/tests/compile/function/test_pfunc.py
+++ b/tests/compile/function/test_pfunc.py
@@ -217,7 +217,7 @@ class TestPfunc:
             f([3], np.array([6], dtype="int16"), 1)
 
         # Value too big for a, silently ignored
-        assert np.all(f([2 ** 20], np.ones(1, dtype="int8"), 1) == 2)
+        assert np.all(f([2**20], np.ones(1, dtype="int8"), 1) == 2)
 
         # Value too big for b, raises TypeError
         with pytest.raises(TypeError):
@@ -294,7 +294,7 @@ class TestPfunc:
 
         f = pfunc([a, b, c], (a + b + c), allow_input_downcast=True)
         # Value too big for a, b, or c, silently ignored
-        assert f([2 ** 20], [1], 0) == 1
+        assert f([2**20], [1], 0) == 1
         assert f([3], [312], 0) == 59
         assert f([3], [1], 806) == 42
 
@@ -422,7 +422,7 @@ class TestPfunc:
         up()
         assert np.all(x.get_value() == 20)
         assert np.all(y.get_value() == 24)
-        assert np.all(z.get_value() == (24 ** 2))
+        assert np.all(z.get_value() == (24**2))
 
     def test_default_updates(self):
         x = shared(0)

--- a/tests/compile/function/test_types.py
+++ b/tests/compile/function/test_types.py
@@ -832,7 +832,7 @@ class TestPicklefunction:
 
     def test_output_keys(self):
         x = vector()
-        f = function([x], {"vec": x ** 2})
+        f = function([x], {"vec": x**2})
         o = f([2, 3, 4])
         assert isinstance(o, dict)
         assert np.allclose(o["vec"], [4, 9, 16])

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -441,7 +441,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
     def test_compute_test_value(self):
         x = scalar("x")
         x.tag.test_value = np.array(1.0, dtype=config.floatX)
-        op = OpFromGraph([x], [x ** 3])
+        op = OpFromGraph([x], [x**3])
         y = scalar("y")
         y.tag.test_value = np.array(1.0, dtype=config.floatX)
         f = op(y)

--- a/tests/diverse_tests.py
+++ b/tests/diverse_tests.py
@@ -18,13 +18,13 @@ from tests import unittest_tools as utt
 class TestScipy:
     def test_scipy_paper_example1(self):
         a = vector("a")  # declare variable
-        b = a + a ** 10  # build expression
+        b = a + a**10  # build expression
         f = function([a], b)  # compile function
         assert np.all(f([0, 1, 2]) == np.array([0, 2, 1026]))
 
     @config.change_flags(floatX="float64")
     def test_scipy_paper_example2(self):
-        """ This just sees if things compile well and if they run """
+        """This just sees if things compile well and if they run"""
         rng = numpy.random.default_rng(utt.fetch_seed())
 
         x = matrix()
@@ -36,7 +36,7 @@ class TestScipy:
         p_1 = 1 / (1 + exp(-dot(x, w) - b))
         xent = -y * log(p_1) - (1 - y) * log(1 - p_1)
         prediction = p_1 > 0.5
-        cost = xent.mean() + 0.01 * (w ** 2).sum()
+        cost = xent.mean() + 0.01 * (w**2).sum()
         gw, gb = grad(cost, [w, b])
 
         # Compile expressions to functions

--- a/tests/gpuarray/check_dnn_conv.py
+++ b/tests/gpuarray/check_dnn_conv.py
@@ -597,7 +597,7 @@ class BaseTestDnnConv:
             m_a = self._next_ten_exponent(max_a)
             m_b = self._next_ten_exponent(max_b)
             max_m = max(m_a, m_b)
-            scale_factor *= 10 ** max_m
+            scale_factor *= 10**max_m
         if scale_factor != 1:
             A /= scale_factor
             B /= scale_factor

--- a/tests/gpuarray/test_dnn.py
+++ b/tests/gpuarray/test_dnn.py
@@ -1276,7 +1276,7 @@ def run_conv_small_batched_vs_multicall(inputs_shape, filters_shape, batch_sub):
         # Then check last outputs.
         p = batch_size - batch_sub + i
         # It seems there is a limit batch size of 65536  with algorithm `small`.
-        checked_limit = 2 ** 16
+        checked_limit = 2**16
         if p >= checked_limit:
             # It seems results are repeated in the entire conv.
             # It should not happen.
@@ -1631,14 +1631,14 @@ def test_dnn_reduction_opt():
 def test_dnn_reduction_sum_squares():
     M = matrix()
     for axis in (None, 0, 1):
-        out = (M ** 2).sum(axis=axis)
+        out = (M**2).sum(axis=axis)
         f = aesara.function([M], out, mode=mode_with_gpu)
         assert any(
             isinstance(node.op, dnn.GpuDnnReduction) and node.op.red_op == "norm2"
             for node in f.maker.fgraph.apply_nodes
         )
         M_val = np.random.random((4, 5)).astype(aesara.config.floatX)
-        utt.assert_allclose((M_val ** 2).sum(axis=axis), f(M_val))
+        utt.assert_allclose((M_val**2).sum(axis=axis), f(M_val))
 
 
 @pytest.mark.skipif(dnn.version(raises=False) < 6000, reason=dnn.dnn_available.msg)
@@ -1682,7 +1682,7 @@ def test_dnn_reduction_axis_size_one():
 
             x = TensorType(dtype=dtype, broadcastable=[False] * len(shape))()
             sum = x.sum(axis=axis)
-            sum_squares = (x ** 2).sum(axis=axis)
+            sum_squares = (x**2).sum(axis=axis)
             sum_abs = abs(x).sum(axis=axis)
             absmax = abs(x).max(axis=axis)
 
@@ -1730,7 +1730,7 @@ def test_dnn_reduction_axis_size_one():
             utt.assert_allclose(cpu_val_sum_abs, val_sum_abs)
             utt.assert_allclose(cpu_val_absmax, val_absmax)
             utt.assert_allclose(xval_reshaped, val_sum)
-            utt.assert_allclose(test_val ** 2, val_sum_squares)
+            utt.assert_allclose(test_val**2, val_sum_squares)
             utt.assert_allclose(test_val, val_sum_abs)
             utt.assert_allclose(test_val, val_absmax)
 
@@ -2474,7 +2474,7 @@ def test_dnn_rnn_gru():
         if out:
             cost += mean((Y - out) ** 2)
         if hy:
-            cost += mean(hy ** 2)
+            cost += mean(hy**2)
         grad = aesara.grad(cost, [X, h0] + params)
         grad_fn = aesara.function(
             [X, Y, h0], grad, mode=mode_with_gpu, on_unused_input="ignore"
@@ -2571,7 +2571,7 @@ def test_dnn_rnn_gru_bidi():
         if out:
             cost += mean((Y - out) ** 2)
         if hy:
-            cost += mean(hy ** 2)
+            cost += mean(hy**2)
         grad = aesara.grad(cost, [X, h0] + params)
         grad_fn = aesara.function(
             [X, Y, h0], grad, mode=mode_with_gpu, on_unused_input="ignore"

--- a/tests/gpuarray/test_elemwise.py
+++ b/tests/gpuarray/test_elemwise.py
@@ -71,7 +71,7 @@ def test_elemwise_pow():
             base = vector(dtype=dtype_base)
             exp = gpuarray_shared_constructor(exp_val)
             assert exp.dtype == dtype_exp
-            output = base ** exp
+            output = base**exp
             f = aesara.function([base], output, mode=mode_with_gpu)
             # We don't transfer to the GPU when the output dtype is int*
             n = len(
@@ -81,7 +81,7 @@ def test_elemwise_pow():
 
             # Call the function to make sure the output is valid
             out = f(base_val)
-            expected_out = base_val ** exp_val
+            expected_out = base_val**exp_val
             assert_allclose(out, expected_out)
 
 
@@ -209,7 +209,7 @@ class TestFloat16:
         cz = tanh(x + at.cast(y, "float16"))
         o = (
             cz
-            - cz ** 2
+            - cz**2
             + at.cast(x, "int16")
             + at.cast(x, "float32")
             + at.cast(w, "float16")

--- a/tests/gpuarray/test_fft.py
+++ b/tests/gpuarray/test_fft.py
@@ -156,7 +156,7 @@ class TestFFT:
         f_irfft = aesara.function([], irfft, mode=mode_with_gpu)
         res_irfft = f_irfft()
 
-        utt.assert_allclose(irfft_ref * N ** 2, res_irfft, atol=1e-4, rtol=1e-4)
+        utt.assert_allclose(irfft_ref * N**2, res_irfft, atol=1e-4, rtol=1e-4)
 
     def test_grad(self):
         # The numerical gradient of the FFT is sensitive, must set large

--- a/tests/gpuarray/test_opt.py
+++ b/tests/gpuarray/test_opt.py
@@ -402,7 +402,7 @@ def test_pdbbreakpoint_op():
     # some computation
     condition = gt(b.sum(), 0)
     b_monitored = PdbBreakpoint(name="TestBreakpoint")(condition, b)
-    output = b_monitored ** 2
+    output = b_monitored**2
 
     f = aesara.function([b], output, mode=mode_with_gpu)
 
@@ -761,7 +761,7 @@ def test_local_lift_cholesky():
 @pytest.mark.skipif(not cusolver_available, reason="No cuSolver or SciPy")
 def test_gpu_cholesky_not_inplace():
     A = fmatrix()
-    A_squared = A ** 2
+    A_squared = A**2
     B = slinalg.cholesky(A_squared)
     D = B + A_squared
     f_cpu = aesara.function([A], D, mode=mode_without_gpu)

--- a/tests/gpuarray/test_pool.py
+++ b/tests/gpuarray/test_pool.py
@@ -182,7 +182,7 @@ def test_pool2d():
                 )
                 assert np.allclose(gr(), gr2()), (shp, ws, st, pad, mode, ignore_border)
 
-                ggf = Lop(grad((a_pooled ** 2).sum(), a), a, a)
+                ggf = Lop(grad((a_pooled**2).sum(), a), a, a)
 
                 gg = aesara.function([], ggf, mode=gpu_mode)
                 gg2 = aesara.function([], ggf, mode=ref_mode)
@@ -308,7 +308,7 @@ def test_pool3d():
                 )
                 assert np.allclose(gr(), gr2()), (shp, ws, st, pad, mode, ignore_border)
 
-                ggf = Lop(grad((a_pooled ** 2).sum(), a), a, a)
+                ggf = Lop(grad((a_pooled**2).sum(), a), a, a)
 
                 gg = aesara.function([], ggf, mode=gpu_mode)
                 gg2 = aesara.function([], ggf, mode=ref_mode)

--- a/tests/gpuarray/test_rng_mrg.py
+++ b/tests/gpuarray/test_rng_mrg.py
@@ -141,20 +141,20 @@ def test_overflow_gpu_new_backend():
     fct = functools.partial(GPUA_mrg_uniform.new, rstate, ndim=None, dtype="float32")
     # should raise error as the size overflows
     sizes = [
-        (2 ** 31,),
-        (2 ** 32,),
+        (2**31,),
+        (2**32,),
         (
-            2 ** 15,
-            2 ** 16,
+            2**15,
+            2**16,
         ),
-        (2, 2 ** 15, 2 ** 15),
+        (2, 2**15, 2**15),
     ]
     rng_mrg_overflow(sizes, fct, mode, should_raise_error=True)
     # should not raise error
-    sizes = [(2 ** 5,), (2 ** 5, 2 ** 5), (2 ** 5, 2 ** 5, 2 ** 5)]
+    sizes = [(2**5,), (2**5, 2**5), (2**5, 2**5, 2**5)]
     rng_mrg_overflow(sizes, fct, mode, should_raise_error=False)
     # should support int32 sizes
-    sizes = [(np.int32(2 ** 10),), (np.int32(2), np.int32(2 ** 10), np.int32(2 ** 10))]
+    sizes = [(np.int32(2**10),), (np.int32(2), np.int32(2**10), np.int32(2**10))]
     rng_mrg_overflow(sizes, fct, mode, should_raise_error=False)
 
 

--- a/tests/link/c/test_params_type.py
+++ b/tests/link/c/test_params_type.py
@@ -34,7 +34,7 @@ class QuadraticOpFunc(COp):
     def perform(self, node, inputs, output_storage, coefficients):
         x = inputs[0]
         y = output_storage[0]
-        y[0] = coefficients.a * (x ** 2) + coefficients.b * x + coefficients.c
+        y[0] = coefficients.a * (x**2) + coefficients.b * x + coefficients.c
 
     def c_code_cache_version(self):
         return (1, 5)
@@ -120,7 +120,7 @@ class QuadraticCOpFunc(ExternalCOp):
     def perform(self, node, inputs, output_storage, coefficients):
         x = inputs[0]
         y = output_storage[0]
-        y[0] = coefficients.a * (x ** 2) + coefficients.b * x + coefficients.c
+        y[0] = coefficients.a * (x**2) + coefficients.b * x + coefficients.c
 
 
 class TestParamsType:
@@ -352,6 +352,6 @@ class TestParamsType:
         )
         vy1 = f1(vx)
         vy2 = f2(vx)
-        ref = a * (vx ** 2) + b * vx + c
+        ref = a * (vx**2) + b * vx + c
         utt.assert_allclose(vy1, vy2)
         utt.assert_allclose(ref, vy1)

--- a/tests/link/test_jax.py
+++ b/tests/link/test_jax.py
@@ -228,7 +228,7 @@ def test_jax_basic():
     b = vector("b")
 
     # `ScalarOp`
-    z = cosh(x ** 2 + y / 3.0)
+    z = cosh(x**2 + y / 3.0)
 
     # `[Inc]Subtensor`
     out = at_subtensor.set_subtensor(z[0], -10.0)
@@ -982,8 +982,8 @@ def test_jax_multioutput():
     y = vector("y")
     y.tag.test_value = np.r_[3.0, 4.0].astype(config.floatX)
 
-    w = cosh(x ** 2 + y / 3.0)
-    v = cosh(x / 3.0 + y ** 2)
+    w = cosh(x**2 + y / 3.0)
+    v = cosh(x / 3.0 + y**2)
 
     fgraph = FunctionGraph([x, y], [w, v])
 

--- a/tests/link/test_vm.py
+++ b/tests/link/test_vm.py
@@ -205,7 +205,7 @@ def test_partial_function():
 
     def check_partial_function(linker_name):
         x = scalar("input")
-        y = x ** 2
+        y = x**2
         f = function(
             [x], [y + 7, y - 9, y / 14.0], mode=Mode(optimizer=None, linker=linker_name)
         )

--- a/tests/sandbox/test_rng_mrg.py
+++ b/tests/sandbox/test_rng_mrg.py
@@ -970,20 +970,20 @@ def test_overflow_cpu():
     with config.change_flags(compute_test_value="off"):
         # should raise error as the size overflows
         sizes = [
-            (2 ** 31,),
-            (2 ** 32,),
+            (2**31,),
+            (2**32,),
             (
-                2 ** 15,
-                2 ** 16,
+                2**15,
+                2**16,
             ),
-            (2, 2 ** 15, 2 ** 15),
+            (2, 2**15, 2**15),
         ]
         rng_mrg_overflow(sizes, fct, config.mode, should_raise_error=True)
     # should not raise error
-    sizes = [(2 ** 5,), (2 ** 5, 2 ** 5), (2 ** 5, 2 ** 5, 2 ** 5)]
+    sizes = [(2**5,), (2**5, 2**5), (2**5, 2**5, 2**5)]
     rng_mrg_overflow(sizes, fct, config.mode, should_raise_error=False)
     # should support int32 sizes
-    sizes = [(np.int32(2 ** 10),), (np.int32(2), np.int32(2 ** 10), np.int32(2 ** 10))]
+    sizes = [(np.int32(2**10),), (np.int32(2), np.int32(2**10), np.int32(2**10))]
     rng_mrg_overflow(sizes, fct, config.mode, should_raise_error=False)
 
 

--- a/tests/scalar/test_basic.py
+++ b/tests/scalar/test_basic.py
@@ -158,7 +158,7 @@ class TestComposite:
         e3 = x // 5
         e4 = -x
         e5 = x - y
-        e6 = x ** y + (-z)
+        e6 = x**y + (-z)
         e7 = x % 3
         C = Composite([x, y, z], [e0, e1, e2, e3, e4, e5, e6, e7])
         c = C.make_node(x, y, z)

--- a/tests/scalar/test_basic_sympy.py
+++ b/tests/scalar/test_basic_sympy.py
@@ -27,15 +27,15 @@ def test_SymPyCCode():
 
 
 def test_grad():
-    op = SymPyCCode([xs], xs ** 2)
+    op = SymPyCCode([xs], xs**2)
     zt = op(xt)
     ztprime = aesara.grad(zt, xt)
     assert ztprime.owner.op.expr == 2 * xs
 
 
 def test_multivar_grad():
-    op = SymPyCCode([xs, ys], xs ** 2 + ys ** 3)
+    op = SymPyCCode([xs, ys], xs**2 + ys**3)
     zt = op(xt, yt)
     dzdx, dzdy = aesara.grad(zt, [xt, yt])
     assert dzdx.owner.op.expr == 2 * xs
-    assert dzdy.owner.op.expr == 3 * ys ** 2
+    assert dzdy.owner.op.expr == 3 * ys**2

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -839,7 +839,7 @@ class TestScan:
         )
         my_f = function([], values, updates=updates, allow_input_downcast=True)
 
-        rng_seed = np.random.default_rng(utt.fetch_seed()).integers(2 ** 30)
+        rng_seed = np.random.default_rng(utt.fetch_seed()).integers(2**30)
         rng = np.random.default_rng(int(rng_seed))  # int() is for 32bit
 
         numpy_v = np.zeros((10, 2))
@@ -1058,7 +1058,7 @@ class TestScan:
     def test_grad_mitsot(self):
         def inner_fct(mitsot_m2, sitsot):
             total = mitsot_m2 + sitsot
-            output = total ** 1.02
+            output = total**1.02
             return output, output
 
         def get_sum_of_grad(input0, input1):
@@ -1164,7 +1164,7 @@ class TestScan:
 
         def inner_fct(mitsot_m2, mitsot_m1, sitsot):
             total = mitsot_m2 + mitsot_m1 + sitsot
-            output = total ** 1.05
+            output = total**1.05
             return output, output
 
         inputs = [matrix(), vector()]
@@ -1739,7 +1739,7 @@ class TestScan:
         _max_coefficients_supported = 1000
         full_range = at.arange(_max_coefficients_supported)
         components, updates = scan(
-            fn=lambda coeff, power, free_var: coeff * (free_var ** power),
+            fn=lambda coeff, power, free_var: coeff * (free_var**power),
             outputs_info=None,
             sequences=[c, full_range],
             non_sequences=x,
@@ -1759,7 +1759,7 @@ class TestScan:
         _max_coefficients_supported = 1000
         full_range = at.arange(_max_coefficients_supported)
         components, updates = scan(
-            fn=lambda coeff, power, free_var: coeff * (free_var ** power),
+            fn=lambda coeff, power, free_var: coeff * (free_var**power),
             outputs_info=None,
             sequences=[c, full_range],
             non_sequences=x,
@@ -2650,10 +2650,10 @@ class TestExamples:
         )
 
         _rng = np.random.default_rng(utt.fetch_seed())
-        rng_seed = _rng.integers(2 ** 30)
+        rng_seed = _rng.integers(2**30)
         nrng1 = np.random.default_rng(int(rng_seed))  # int() is for 32bit
 
-        rng_seed = _rng.integers(2 ** 30)
+        rng_seed = _rng.integers(2**30)
         nrng2 = np.random.default_rng(int(rng_seed))  # int() is for 32bit
 
         def numpy_implementation(vsample):
@@ -3082,7 +3082,7 @@ class TestExamples:
         def loss_outer(sum_outer, W):
             def loss_inner(sum_inner, W):
 
-                return sum_inner + (W ** 2).sum()
+                return sum_inner + (W**2).sum()
 
             result_inner, _ = scan(
                 fn=loss_inner,
@@ -3112,7 +3112,7 @@ class TestExamples:
             x_tm1.name = "x"
             y_tm1.name = "y"
             z_tm1.name = "z"
-            return x_tm1 ** 2, y_tm1, x_tm1 + 1
+            return x_tm1**2, y_tm1, x_tm1 + 1
 
         x0 = vector("X")
         y0 = vector("y0")
@@ -3375,13 +3375,13 @@ class TestExamples:
         # Generate the components of the polynomial
         full_range = at.arange(max_coefficients_supported)
         components, updates = scan(
-            fn=lambda coeff, power, free_var: coeff * (free_var ** power),
+            fn=lambda coeff, power, free_var: coeff * (free_var**power),
             sequences=[coefficients, full_range],
             non_sequences=x,
         )
         polynomial1 = components.sum()
         polynomial2, updates = scan(
-            fn=lambda coeff, power, prev, free_var: prev + coeff * (free_var ** power),
+            fn=lambda coeff, power, prev, free_var: prev + coeff * (free_var**power),
             outputs_info=at.constant(0, dtype="floatX"),
             sequences=[coefficients, full_range],
             non_sequences=x,
@@ -3389,7 +3389,7 @@ class TestExamples:
 
         # python int
         polynomial3, updates = scan(
-            fn=lambda coeff, power, prev, free_var: prev + coeff * (free_var ** power),
+            fn=lambda coeff, power, prev, free_var: prev + coeff * (free_var**power),
             outputs_info=0,
             sequences=[coefficients, full_range],
             non_sequences=x,
@@ -3397,7 +3397,7 @@ class TestExamples:
 
         # python float
         polynomial4, updates = scan(
-            fn=lambda coeff, power, prev, free_var: prev + coeff * (free_var ** power),
+            fn=lambda coeff, power, prev, free_var: prev + coeff * (free_var**power),
             outputs_info=0.0,
             sequences=[coefficients, full_range],
             non_sequences=x,

--- a/tests/scan/test_opt.py
+++ b/tests/scan/test_opt.py
@@ -467,7 +467,7 @@ class TestPushOutNonSeqScan:
         b = matrix()
 
         def inner_fct(vect, mat):
-            vect_squared = vect ** 2
+            vect_squared = vect**2
             return dot(vect_squared, mat), vect_squared
 
         outputs, updates = aesara.scan(

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -71,7 +71,7 @@ def test_scan_debugprint2():
     # Generate the components of the polynomial
     components, updates = aesara.scan(
         fn=lambda coefficient, power, free_variable: coefficient
-        * (free_variable ** power),
+        * (free_variable**power),
         outputs_info=None,
         sequences=[coefficients, at.arange(max_coefficients_supported)],
         non_sequences=x,

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -138,7 +138,7 @@ def as_ndarray(val):
 
 def random_lil(shape, dtype, nnz):
     rval = sp.sparse.lil_matrix(shape, dtype=dtype)
-    huge = 2 ** 30
+    huge = 2**30
     for k in range(nnz):
         # set non-zeros in random locations (row x, col y)
         idx = np.random.default_rng().integers(1, huge + 1, size=2) % shape

--- a/tests/sparse/test_sparse.py
+++ b/tests/sparse/test_sparse.py
@@ -1,0 +1,14 @@
+import numpy as np
+import pytest
+
+import aesara
+from aesara.compile import SharedVariable
+
+
+sp = pytest.importorskip("scipy", minversion="0.7.0")
+
+
+def test_shared_basic():
+    x = aesara.shared(sp.sparse.csr_matrix(np.eye(100)), name="blah", borrow=True)
+
+    assert isinstance(x, SharedVariable)

--- a/tests/tensor/nnet/test_abstract_conv.py
+++ b/tests/tensor/nnet/test_abstract_conv.py
@@ -1615,7 +1615,7 @@ class TestBilinearUpsampling:
             # getting the normalized kernel
             kernel = bilinear_kernel_2D(ratio=ratio, normalize=True)
             f = aesara.function([], kernel)
-            kernel_2D = kernel_2D / float(ratio ** 2)
+            kernel_2D = kernel_2D / float(ratio**2)
             utt.assert_allclose(kernel_2D, f())
 
     def test_bilinear_kernel_1D(self):

--- a/tests/tensor/nnet/test_conv.py
+++ b/tests/tensor/nnet/test_conv.py
@@ -745,7 +745,7 @@ def test_broadcast_grad():
 
     filter_1d = at.arange(-window_radius, window_radius + 1)
     filter_1d = filter_1d.astype(aesara.config.floatX)
-    filter_1d = exp(-0.5 * filter_1d ** 2 / sigma ** 2)
+    filter_1d = exp(-0.5 * filter_1d**2 / sigma**2)
     filter_1d = filter_1d / filter_1d.sum()
 
     filter_W = filter_1d.dimshuffle(["x", "x", 0, "x"])

--- a/tests/tensor/random/test_utils.py
+++ b/tests/tensor/random/test_utils.py
@@ -121,7 +121,7 @@ class TestSharedRandomStream:
         fn_val0 = fn()
         fn_val1 = fn()
 
-        rng_seed = np.random.default_rng(utt.fetch_seed()).integers(2 ** 30)
+        rng_seed = np.random.default_rng(utt.fetch_seed()).integers(2**30)
         rng = rng_ctor(int(rng_seed))  # int() is for 32bit
 
         numpy_val0 = rng.uniform(0, 1, size=(2, 2))
@@ -165,7 +165,7 @@ class TestSharedRandomStream:
         # Now, change the seed when there are state updates
         random.seed(new_seed)
 
-        update_seed = np.random.default_rng(new_seed).integers(2 ** 30)
+        update_seed = np.random.default_rng(new_seed).integers(2**30)
         ref_rng = rng_ctor(update_seed)
         state_rng = random.state_updates[0][0].get_value(borrow=True)
 
@@ -190,7 +190,7 @@ class TestSharedRandomStream:
         fn_val0 = fn()
         fn_val1 = fn()
 
-        rng_seed = np.random.default_rng(utt.fetch_seed()).integers(2 ** 30)
+        rng_seed = np.random.default_rng(utt.fetch_seed()).integers(2**30)
         rng = rng_ctor(int(rng_seed))  # int() is for 32bit
         numpy_val0 = rng.uniform(-1, 1, size=(2, 2))
         numpy_val1 = rng.uniform(-1, 1, size=(2, 2))

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -3105,7 +3105,7 @@ def _test_autocast_numpy():
         assert constant(z).dtype == np.asarray(z).dtype
 
     for x in (
-        [2 ** i for i in range(63)] + [0, 0, 1, 2 ** 63 - 1] + [0.0, 1.0, 1.1, 1.5]
+        [2**i for i in range(63)] + [0, 0, 1, 2**63 - 1] + [0.0, 1.0, 1.1, 1.5]
     ):
         n_x = np.asarray(x)
         # Make sure the data type is the same as the one found by numpy.
@@ -3134,8 +3134,8 @@ def _test_autocast_numpy_floatX():
         # into int64, as that is the maximal integer type that Aesara
         # supports, and that is the maximal type in Python indexing.
         for x in (
-            [2 ** i - 1 for i in range(64)]
-            + [0, 0, 1, 2 ** 63 - 1]
+            [2**i - 1 for i in range(64)]
+            + [0, 0, 1, 2**63 - 1]
             + [0.0, 1.0, 1.1, 1.5]
         ):
             with config.change_flags(floatX=floatX):
@@ -3151,7 +3151,7 @@ class TestLongTensor:
     def test_fit_int64(self):
         bitwidth = PYTHON_INT_BITWIDTH
         for exponent in range(bitwidth):
-            val = 2 ** exponent - 1
+            val = 2**exponent - 1
             scalar_ct = constant(val)
 
             assert scalar_ct.dtype in int_dtypes, (
@@ -3182,7 +3182,7 @@ class TestLongTensor:
             assert np.all(matrix_ct.value == val)
 
     def test_too_big(self):
-        val = 2 ** 64
+        val = 2**64
         # This fail for all NumPy version.
         with pytest.raises(Exception):
             constant(val)

--- a/tests/tensor/test_basic_opt.py
+++ b/tests/tensor/test_basic_opt.py
@@ -666,11 +666,11 @@ class TestFusion:
                 "float32",
             ),
             (
-                fx + fy ** fz,
+                fx + fy**fz,
                 (fx, fy, fz),
                 (fxv, fyv, fzv),
                 1,
-                fxv + fyv ** fzv,
+                fxv + fyv**fzv,
                 "float32",
             ),  # pow
             (
@@ -928,11 +928,11 @@ class TestFusion:
                 "float32",
             ),
             (
-                fv + fy ** fz,
+                fv + fy**fz,
                 (fv, fy, fz),
                 (fvv, fyv, fzv),
                 2,
-                fvv + fyv ** fzv,
+                fvv + fyv**fzv,
                 "float32",
             ),  # fused with a dimshuffle #65
             (
@@ -1074,8 +1074,8 @@ class TestFusion:
             n = 10
 
         for i in range(n):
-            f = cst_m05 * sd ** cst_m2 * (ones - means[i]) ** cst_2 + cst_05 * log(
-                cst_05 * (sd ** cst_m2) / np.pi
+            f = cst_m05 * sd**cst_m2 * (ones - means[i]) ** cst_2 + cst_05 * log(
+                cst_05 * (sd**cst_m2) / np.pi
             )
             factors.append(at_sum(f))
 
@@ -2868,7 +2868,7 @@ class TestLiftTransposeThroughDot:
 
 def test_local_upcast_elemwise_constant_inputs():
     s = dvector("s")
-    x = at_sum(log(10 ** s))
+    x = at_sum(log(10**s))
     f = function([s], [aesara.gradient.grad(x, s)])
     f([-42, -2.1, -1, -0.5, 0, 0.2, 1, 2, 12])
 

--- a/tests/tensor/test_blas_c.py
+++ b/tests/tensor/test_blas_c.py
@@ -201,7 +201,7 @@ class TestCGemv(OptimizationTestMixin):
             )
 
     def t_gemv1(self, m_shp):
-        """ test vector2 + dot(matrix, vector1) """
+        """test vector2 + dot(matrix, vector1)"""
         rng = np.random.default_rng(unittest_tools.fetch_seed())
         v1 = aesara.shared(np.array(rng.uniform(size=(m_shp[1],)), dtype="float32"))
         v2_orig = np.array(rng.uniform(size=(m_shp[0],)), dtype="float32")

--- a/tests/tensor/test_elemwise.py
+++ b/tests/tensor/test_elemwise.py
@@ -170,7 +170,7 @@ class TestDimShuffle(unittest_tools.InferShapeTester):
             _ = gc.collect()
             blocks_i, _ = tracemalloc.get_traced_memory()
             if blocks_last is not None:
-                blocks_diff = (blocks_i - blocks_last) // 10 ** 3
+                blocks_diff = (blocks_i - blocks_last) // 10**3
                 block_diffs.append(blocks_diff)
             blocks_last = blocks_i
 
@@ -706,7 +706,7 @@ class TestElemwise(unittest_tools.InferShapeTester):
         a, b, c, d, e, f = vectors("abcdef")
         s = a + b + c + d + e + f
         g = aesara.function([a, b, c, d, e, f], s, mode=Mode(linker="py"))
-        g(*[np.zeros(2 ** 11, config.floatX) for i in range(6)])
+        g(*[np.zeros(2**11, config.floatX) for i in range(6)])
 
     def check_input_dimensions_match(self, mode):
         """Make sure that our input validation works correctly and doesn't

--- a/tests/tensor/test_fft.py
+++ b/tests/tensor/test_fft.py
@@ -155,7 +155,7 @@ class TestFFT:
         f_irfft = aesara.function([], irfft)
         res_irfft = f_irfft()
 
-        utt.assert_allclose(irfft_ref * N ** 2, res_irfft, atol=1e-4, rtol=1e-4)
+        utt.assert_allclose(irfft_ref * N**2, res_irfft, atol=1e-4, rtol=1e-4)
 
     def test_params(self):
         inputs_val = np.random.random((1, N)).astype(aesara.config.floatX)

--- a/tests/tensor/test_inplace.py
+++ b/tests/tensor/test_inplace.py
@@ -163,7 +163,7 @@ TestModInplaceBroadcast = makeBroadcastTester(
 
 TestPowInplaceBroadcast = makeBroadcastTester(
     op=pow_inplace,
-    expected=lambda x, y: x ** y,
+    expected=lambda x, y: x**y,
     good=_good_broadcast_pow_normal_float_pow,
     inplace=True,
     mode=ignore_isfinite_mode,

--- a/tests/tensor/test_io.py
+++ b/tests/tensor/test_io.py
@@ -41,11 +41,11 @@ class TestLoadTensor:
         # file.
         x = load(path, "int32", (False,), "c")
         # x ** 2 has been chosen because it will work inplace.
-        y = (x ** 2).sum()
+        y = (x**2).sum()
         fn = function([path], y)
         # Call fn() twice, to check that inplace ops do not cause trouble
-        assert (fn(self.filename) == (self.data ** 2).sum()).all()
-        assert (fn(self.filename) == (self.data ** 2).sum()).all()
+        assert (fn(self.filename) == (self.data**2).sum()).all()
+        assert (fn(self.filename) == (self.data**2).sum()).all()
 
     def test_memmap(self):
         path = Variable(Generic())

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -362,7 +362,7 @@ TestModBroadcast = makeBroadcastTester(
 # Disable NAN checking for pow operator per issue #1780
 TestPowBroadcast = makeBroadcastTester(
     op=pow,
-    expected=lambda x, y: check_floatX((x, y), x ** y),
+    expected=lambda x, y: check_floatX((x, y), x**y),
     good=_good_broadcast_pow_normal_float,
     grad=_grad_broadcast_pow_normal,
     name="Pow",
@@ -1736,7 +1736,7 @@ class TestBitwise:
                 [0, 1, 0, 1],
                 [0, 0, 1, 1],
                 [0, 1, 0, 1],
-                [-1, 2 ** 16, 2 ** 16 - 1],
+                [-1, 2**16, 2**16 - 1],
             ]:
                 l = _asarray([0, 0, 1, 1], dtype=dtype)
                 v = fn(l)
@@ -2208,7 +2208,7 @@ def test_var():
     f = function([a], var(a, ddof=0, corrected=True))
     mean_a = np.mean(a_val)
     centered_a = a_val - mean_a
-    v = np.mean(centered_a ** 2)
+    v = np.mean(centered_a**2)
     error = (np.mean(centered_a)) ** 2
     v = v - error
     assert np.allclose(v, f(a_val))
@@ -2860,18 +2860,15 @@ class TestSumProdReduceDtype:
                 axis = self.axes[idx % len(self.axes)]
                 x = matrix(dtype=dtype)
                 s = getattr(x, method)(axis=axis)
-                assert (
-                    s.dtype
-                    == dict(
-                        bool="int64",
-                        int8="int64",
-                        int16="int64",
-                        int32="int64",
-                        uint8="uint64",
-                        uint16="uint64",
-                        uint32="uint64",
-                    ).get(dtype, dtype)
-                )
+                assert s.dtype == dict(
+                    bool="int64",
+                    int8="int64",
+                    int16="int64",
+                    int32="int64",
+                    uint8="uint64",
+                    uint16="uint64",
+                    uint32="uint64",
+                ).get(dtype, dtype)
                 f = function([x], s, mode=self.mode)
                 topo = f.maker.fgraph.toposort()
                 assert [n for n in topo if isinstance(n.op, self.op)], (topo, dtype)
@@ -2889,21 +2886,18 @@ class TestSumProdReduceDtype:
                 axis = self.axes[idx % len(self.axes)]
                 x = matrix(dtype=dtype)
                 s = getattr(x, method)(axis=axis)
-                assert (
-                    s.owner.op.acc_dtype
-                    == dict(
-                        bool="int64",
-                        int8="int64",
-                        int16="int64",
-                        int32="int64",
-                        uint8="uint64",
-                        uint16="uint64",
-                        uint32="uint64",
-                        float16="float32",
-                        float32="float64",
-                        complex64="complex128",
-                    ).get(dtype, dtype)
-                )
+                assert s.owner.op.acc_dtype == dict(
+                    bool="int64",
+                    int8="int64",
+                    int16="int64",
+                    int32="int64",
+                    uint8="uint64",
+                    uint16="uint64",
+                    uint32="uint64",
+                    float16="float32",
+                    float32="float64",
+                    complex64="complex128",
+                ).get(dtype, dtype)
                 f = function([x], s, mode=self.mode)
                 topo = f.maker.fgraph.toposort()
                 assert [n for n in topo if isinstance(n.op, self.op)], (topo, dtype)
@@ -3098,18 +3092,15 @@ class TestProdWithoutZerosDtype:
         for idx, dtype in enumerate(map(str, aes.all_types)):
             axis = axes[idx % len(axes)]
             x = ProdWithoutZeros(axis=axis)(matrix(dtype=dtype))
-            assert (
-                x.dtype
-                == dict(
-                    bool="int64",
-                    int8="int64",
-                    int16="int64",
-                    int32="int64",
-                    uint8="uint64",
-                    uint16="uint64",
-                    uint32="uint64",
-                ).get(dtype, dtype)
-            )
+            assert x.dtype == dict(
+                bool="int64",
+                int8="int64",
+                int16="int64",
+                int32="int64",
+                uint8="uint64",
+                uint16="uint64",
+                uint32="uint64",
+            ).get(dtype, dtype)
 
     def test_prod_without_zeros_default_acc_dtype(self):
         # Test the default dtype of a ProdWithoutZeros().
@@ -3120,21 +3111,18 @@ class TestProdWithoutZerosDtype:
             axis = axes[idx % len(axes)]
             x = matrix(dtype=dtype)
             p = ProdWithoutZeros(axis=axis)(x)
-            assert (
-                p.owner.op.acc_dtype
-                == dict(
-                    bool="int64",
-                    int8="int64",
-                    int16="int64",
-                    int32="int64",
-                    uint8="uint64",
-                    uint16="uint64",
-                    uint32="uint64",
-                    float16="float32",
-                    float32="float64",
-                    complex64="complex128",
-                ).get(dtype, dtype)
-            )
+            assert p.owner.op.acc_dtype == dict(
+                bool="int64",
+                int8="int64",
+                int16="int64",
+                int32="int64",
+                uint8="uint64",
+                uint16="uint64",
+                uint32="uint64",
+                float16="float32",
+                float32="float64",
+                complex64="complex128",
+            ).get(dtype, dtype)
 
             if "complex" in dtype:
                 continue

--- a/tests/tensor/test_math_opt.py
+++ b/tests/tensor/test_math_opt.py
@@ -212,7 +212,7 @@ class TestGreedyDistribute:
         # r = mul((x/a+y) , a, z)
         r = mul(s - 1, eps + x / s, eps + y / s, s)
 
-        f = function([s, eps, x, y], r ** 2)
+        f = function([s, eps, x, y], r**2)
 
         s_val = np.asarray(4, dtype=config.floatX)
         eps_val = np.asarray(1.0e-6, dtype=config.floatX)
@@ -1403,11 +1403,11 @@ class TestFusion:
                 "float32",
             ),
             (
-                fx + fy ** fz,
+                fx + fy**fz,
                 (fx, fy, fz),
                 (fxv, fyv, fzv),
                 1,
-                fxv + fyv ** fzv,
+                fxv + fyv**fzv,
                 "float32",
             ),  # pow
             (
@@ -1665,11 +1665,11 @@ class TestFusion:
                 "float32",
             ),
             (
-                fv + fy ** fz,
+                fv + fy**fz,
                 (fv, fy, fz),
                 (fvv, fyv, fzv),
                 2,
-                fvv + fyv ** fzv,
+                fvv + fyv**fzv,
                 "float32",
             ),  # fused with a dimshuffle #65
             (
@@ -2336,8 +2336,8 @@ def speed_local_pow_specialize_range():
     mode = get_default_mode()
     mode_without_pow_opt = mode.excluding("local_pow_specialize")
     for i in range(500, 513):
-        f1 = function([v], v ** i, mode=mode)
-        f2 = function([v], v ** i, mode=mode_without_pow_opt)
+        f1 = function([v], v**i, mode=mode)
+        f2 = function([v], v**i, mode=mode_without_pow_opt)
         assert len(f1.maker.fgraph.toposort()) == 1
         t1 = time.time()
         f1(val)
@@ -2348,8 +2348,8 @@ def speed_local_pow_specialize_range():
         if not t2 - t1 < t3 - t2:
             print("WARNING WE ARE SLOWER")
     for i in range(-3, -1500, -1):
-        f1 = function([v], v ** i, mode=mode)
-        f2 = function([v], v ** i, mode=mode_without_pow_opt)
+        f1 = function([v], v**i, mode=mode)
+        f2 = function([v], v**i, mode=mode_without_pow_opt)
         assert len(f1.maker.fgraph.toposort()) == 1
         t1 = time.time()
         f1(val)
@@ -2372,25 +2372,25 @@ def test_local_pow_specialize():
     val = np.arange(10, dtype=config.floatX)
     val_no0 = np.arange(1, 10, dtype=config.floatX)
 
-    f = function([v], v ** 0, mode=mode)
+    f = function([v], v**0, mode=mode)
     nodes = [node.op for node in f.maker.fgraph.toposort()]
     assert nodes == [Shape_i(0), at.alloc]
-    utt.assert_allclose(f(val), val ** 0)
+    utt.assert_allclose(f(val), val**0)
 
-    f = function([v], v ** 1, mode=mode)
+    f = function([v], v**1, mode=mode)
     nodes = [node.op for node in f.maker.fgraph.toposort()]
     nodes == [deep_copy_op]
-    utt.assert_allclose(f(val), val ** 1)
+    utt.assert_allclose(f(val), val**1)
 
     f = function([v], v ** (-1), mode=mode)
     nodes = [node.op for node in f.maker.fgraph.toposort()]
     assert nodes == [reciprocal]
     utt.assert_allclose(f(val_no0), val_no0 ** (-1))
 
-    f = function([v], v ** 2, mode=mode)
+    f = function([v], v**2, mode=mode)
     nodes = [node.op for node in f.maker.fgraph.toposort()]
     assert nodes == [sqr]
-    utt.assert_allclose(f(val), val ** 2)
+    utt.assert_allclose(f(val), val**2)
 
     f = function([v], v ** (-2), mode=mode)
     nodes = [node.op for node in f.maker.fgraph.toposort()]
@@ -2427,7 +2427,7 @@ def test_local_pow_specialize_device_more_aggressive_on_cpu():
     assert len(nodes) == 1
     assert len(f.maker.fgraph.toposort()[0].op.scalar_op.fgraph.apply_nodes) == 6
     assert isinstance(nodes[0].scalar_op, aes.Composite)
-    utt.assert_allclose(f(val), val ** 15)
+    utt.assert_allclose(f(val), val**15)
 
     f = function([v], v ** (-15), mode=mode)
     nodes = [node.op for node in f.maker.fgraph.toposort()]
@@ -2442,7 +2442,7 @@ def test_local_pow_specialize_device_more_aggressive_on_cpu():
     assert len(nodes) == 1
     assert len(f.maker.fgraph.toposort()[0].op.scalar_op.fgraph.apply_nodes) == 4
     assert isinstance(nodes[0].scalar_op, aes.Composite)
-    utt.assert_allclose(f(val), val ** 16)
+    utt.assert_allclose(f(val), val**16)
 
     f = function([v], v ** (-16), mode=mode)
     nodes = [node.op for node in f.maker.fgraph.toposort()]
@@ -4592,7 +4592,7 @@ def test_log1mexp_stabilization():
     assert nodes == [at.log1mexp]
 
     # Check values that would under or overflow without optimization
-    assert f([-(2.0 ** -55)]) != -np.inf
+    assert f([-(2.0**-55)]) != -np.inf
     overflow_value = -500.0 if config.floatX == "float64" else -100.0
     assert f([overflow_value]) < 0
 

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -500,7 +500,7 @@ def test_expm_grad_2():
     # Always test in float64 for better numerical stability.
     A = rng.standard_normal((5, 5))
     w = rng.standard_normal((5)) ** 2
-    A = (np.diag(w ** 0.5)).dot(A + A.T).dot(np.diag(w ** (-0.5)))
+    A = (np.diag(w**0.5)).dot(A + A.T).dot(np.diag(w ** (-0.5)))
     assert not np.allclose(A, A.T)
 
     utt.verify_grad(expm, [A], rng=rng)

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -525,7 +525,7 @@ class TestSubtensor(utt.OptimizationTestMixin):
         # This test checks that using a long that does not fit raises an error.
         n = self.shared(np.arange(12, dtype=self.dtype).reshape((4, 3)))
         with pytest.raises(Exception):
-            n[: (2 ** 63)]
+            n[: (2**63)]
 
     def test_list_slice(self):
         x = at.arange(100).reshape((5, 5, 4))

--- a/tests/test_dictionary_output.py
+++ b/tests/test_dictionary_output.py
@@ -123,7 +123,7 @@ class TestDictionaryOutput:
             function([x], outputs={1.0: x})
 
         with pytest.raises(AssertionError):
-            function([x], outputs={1.0: x, "a": x ** 2})
+            function([x], outputs={1.0: x, "a": x**2})
 
         with pytest.raises(AssertionError):
-            function([x], outputs={(1, "b"): x, 1.0: x ** 2})
+            function([x], outputs={(1, "b"): x, 1.0: x**2})

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -621,7 +621,7 @@ def test_known_grads():
     coeffs = vector("c")
     ct = coeffs[t]
     ct.name = "ct"
-    p = x ** ft
+    p = x**ft
     p.name = "p"
     y = ct * p
     y.name = "y"
@@ -791,7 +791,7 @@ class TestConsiderConstant:
             (x * consider_constant(x), x),
             (x * consider_constant(exp(x)), exp(x)),
             (consider_constant(x), at.constant(0.0)),
-            (x ** 2 * consider_constant(x), 2 * x ** 2),
+            (x**2 * consider_constant(x), 2 * x**2),
         ]
 
         for expr, expr_grad in expressions_gradients:
@@ -825,7 +825,7 @@ class TestZeroGrad:
             (x * zero_grad(x), x),
             (x * zero_grad(exp(x)), exp(x)),
             (zero_grad(x), at.constant(0.0)),
-            (x ** 2 * zero_grad(x), 2 * x ** 2),
+            (x**2 * zero_grad(x), 2 * x**2),
         ]
 
         for expr, expr_grad in expressions_gradients:
@@ -871,7 +871,7 @@ class TestDisconnectedGrad:
         expressions_gradients = [
             (x * disconnected_grad(x), x),
             (x * disconnected_grad(exp(x)), exp(x)),
-            (x ** 2 * disconnected_grad(x), 2 * x ** 2),
+            (x**2 * disconnected_grad(x), 2 * x**2),
         ]
 
         for expr, expr_grad in expressions_gradients:
@@ -921,7 +921,7 @@ def test_grad_clip():
     x = scalar()
 
     z = grad(grad_clip(x, -1, 1) ** 2, x)
-    z2 = grad(x ** 2, x)
+    z2 = grad(x**2, x)
 
     f = aesara.function([x], outputs=[z, z2])
 
@@ -937,7 +937,7 @@ def test_grad_scale():
     x = scalar()
 
     z = grad(grad_scale(x, 2) ** 2, x)
-    z2 = grad(x ** 2, x)
+    z2 = grad(x**2, x)
 
     f = aesara.function([x], outputs=[z, z2])
 
@@ -1097,7 +1097,7 @@ def test_jacobian_scalar():
 
 def test_hessian():
     x = vector()
-    y = at_sum(x ** 2)
+    y = at_sum(x**2)
     Hx = hessian(y, x)
     f = aesara.function([x], Hx)
     vx = np.arange(10).astype(aesara.config.floatX)

--- a/tests/typed_list/test_basic.py
+++ b/tests/typed_list/test_basic.py
@@ -39,7 +39,7 @@ def rand_ranged_matrix(minimum, maximum, shape):
 def random_lil(shape, dtype, nnz):
     sp = pytest.importorskip("scipy")
     rval = sp.sparse.lil_matrix(shape, dtype=dtype)
-    huge = 2 ** 30
+    huge = 2**30
     for k in range(nnz):
         # set non-zeros in random locations (row x, col y)
         idx = np.random.randint(1, huge + 1, size=2) % shape


### PR DESCRIPTION
This fixes an issue with `aesara.shared` when it's used with sparse matrices and `aesara.shared` isn't loaded first.