### PR TITLE
Add JAX implementation for BroadcastTo

### DIFF
--- a/aesara/link/jax/dispatch.py
+++ b/aesara/link/jax/dispatch.py
@@ -37,6 +37,7 @@ from aesara.tensor.blas import BatchedDot
 from aesara.tensor.elemwise import CAReduce, DimShuffle, Elemwise
 from aesara.tensor.extra_ops import (
     Bartlett,
+    BroadcastTo,
     CumOp,
     DiffOp,
     FillDiagonal,
@@ -1157,3 +1158,11 @@ def jax_funcify_Psi(op, node, **kwargs):
         return jax.scipy.special.digamma(x)
 
     return psi
+
+
+@jax_funcify.register(BroadcastTo)
+def jax_funcify_BroadcastTo(op, **kwargs):
+    def broadcast_to(x, *shape):
+        return jnp.broadcast_to(x, shape)
+
+    return broadcast_to

--- a/tests/link/test_jax.py
+++ b/tests/link/test_jax.py
@@ -1214,6 +1214,34 @@ def test_extra_ops():
     )
 
 
+def set_test_value(x, v):
+    x.tag.test_value = v
+    return x
+
+
+@pytest.mark.parametrize(
+    "x, shape",
+    [
+        (
+            set_test_value(
+                vector("x"), np.random.random(size=(2,)).astype(config.floatX)
+            ),
+            [at.as_tensor(3, dtype=np.int64), at.as_tensor(2, dtype=np.int64)],
+        ),
+        (
+            set_test_value(
+                vector("x"), np.random.random(size=(2,)).astype(config.floatX)
+            ),
+            [at.as_tensor(3, dtype=np.int8), at.as_tensor(2, dtype=np.int64)],
+        ),
+    ],
+)
+def test_BroadcastTo(x, shape):
+    out = at_extra_ops.broadcast_to(x, shape)
+    fgraph = FunctionGraph(outputs=[out])
+    compare_jax_and_py(fgraph, [get_test_value(i) for i in fgraph.inputs])
+
+
 @pytest.mark.xfail(
     version_parse(jax.__version__) >= version_parse("0.2.12"),
     reason="Omnistaging cannot be disabled",


### PR DESCRIPTION
This PR adds a JAX dispatch for the BroadcastTo Op. Closes #859  

Re-run with updated `pre-commit` setting.

The unit tests are similar to Numba's tests, but only cover cases with `shape` is `TensorConstant`, as JAX does not support dynamic shapes yet.

UPDATED: keep #883 and close this one. Thanks