### PR TITLE
Raise when SharedVariables are used as inputs of OpFromGraph

### DIFF
--- a/aesara/compile/builders.py
+++ b/aesara/compile/builders.py
@@ -334,8 +334,11 @@ class OpFromGraph(Op, HasInnerGraph):
                 raise TypeError(
                     f"Inputs and outputs must be Variable instances; got {i}"
                 )
-            if i in inputs and isinstance(i, Constant):
-                raise TypeError(f"Constants not allowed as inputs; {i}")
+            if i in inputs:
+                if isinstance(i, Constant):
+                    raise TypeError(f"Constants not allowed as inputs; {i}")
+                if isinstance(i, SharedVariable):
+                    raise TypeError(f"SharedVariables not allowed as inputs; {i}")
 
         if "updates" in kwargs or "givens" in kwargs:
             raise NotImplementedError("Updates and givens are not allowed here")

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -38,6 +38,9 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         with pytest.raises(TypeError):
             OpFromGraph([x, as_tensor(1)], [x])
 
+        with pytest.raises(TypeError):
+            OpFromGraph([shared(1)], [1])
+
         with pytest.raises(NotImplementedError):
             OpFromGraph([x], [x], updates={})
 


### PR DESCRIPTION
Like `function` this is not allowed in `OpFromGraph`, otherwise the number of inputs is duplicated.