### PR TITLE
Fix `Variable.default_update` and `Variable.update` cloning issues

### DIFF
--- a/aesara/compile/function/pfunc.py
+++ b/aesara/compile/function/pfunc.py
@@ -97,7 +97,7 @@ def rebuild_collect_shared(
         elif isinstance(v, SharedVariable):
             if v not in shared_inputs:
                 shared_inputs.append(v)
-            if hasattr(v, "default_update"):
+            if hasattr(v.tag, "default_update"):
                 # Check that v should not be excluded from the default
                 # updates list
                 if no_default_updates is False or (
@@ -107,7 +107,7 @@ def rebuild_collect_shared(
                     # provided
                     if v not in update_d:
                         v_update = v.type.filter_variable(
-                            v.default_update, allow_convert=False
+                            v.tag.default_update, allow_convert=False
                         )
                         if not v.type.is_super(v_update.type):
                             raise TypeError(

--- a/aesara/compile/function/types.py
+++ b/aesara/compile/function/types.py
@@ -640,7 +640,7 @@ class Function:
 
         # Init new fgraph using copied variables and get memo
         # memo: a dict that map old variables to new variables
-        memo = clone_get_equiv(maker.fgraph.inputs, out_vars)
+        memo = clone_get_equiv(out_vars, inputs=maker.fgraph.inputs)
         fg_cpy = FunctionGraph(
             [memo[i] for i in maker.fgraph.inputs],
             [memo[o] for o in out_vars],

--- a/aesara/graph/basic.py
+++ b/aesara/graph/basic.py
@@ -838,172 +838,6 @@ def applys_between(
     )
 
 
-def clone(
-    inputs: List[Variable],
-    outputs: List[Variable],
-    copy_inputs: bool = True,
-    copy_orphans: Optional[bool] = None,
-) -> Tuple[Collection[Variable], Collection[Variable]]:
-    r"""Copies the sub-graph contained between inputs and outputs.
-
-    Parameters
-    ----------
-    inputs
-        Input `Variable`\s.
-    outputs
-        Output `Variable`\s.
-    copy_inputs
-        If ``True``, the inputs will be copied (defaults to ``True``).
-    copy_orphans
-        When ``None``, use the `copy_inputs` value.
-        When ``True``, new orphans nodes are created.
-        When ``False``, original orphans nodes are reused in the new graph.
-
-    Returns
-    -------
-    The inputs and outputs of that copy.
-
-    Notes
-    -----
-
-    A constant, if in the `inputs` list is not an orphan. So it will be copied
-    conditional on the `copy_inputs` parameter; otherwise, it will be copied
-    conditional on the `copy_orphans` parameter.
-
-    """
-    if copy_orphans is None:
-        copy_orphans = copy_inputs
-    equiv = clone_get_equiv(inputs, outputs, copy_inputs, copy_orphans)
-    return [cast(Variable, equiv[input]) for input in inputs], [
-        cast(Variable, equiv[output]) for output in outputs
-    ]
-
-
-def clone_get_equiv(
-    inputs: Sequence[Variable],
-    outputs: Sequence[Variable],
-    copy_inputs: bool = True,
-    copy_orphans: bool = True,
-    memo: Optional[Dict[Node, Node]] = None,
-) -> Dict[Node, Node]:
-    """
-    Return a dictionary that maps from `Variable` and `Apply` nodes in the
-    original graph to a new node (a clone) in a new graph.
-
-    This function works by recursively cloning inputs... rebuilding a directed
-    graph from the inputs up to eventually building new outputs.
-
-    Parameters
-    ----------
-    inputs : a list of Variables
-    outputs : a list of Variables
-    copy_inputs : bool
-        True means to create the cloned graph from new input
-        nodes (the bottom of a feed-upward graph).
-        False means to clone a graph that is rooted at the original input
-        nodes.
-    copy_orphans :
-        When ``True``, new constant nodes are created. When ``False``, original
-        constant nodes are reused in the new graph.
-    memo : None or dict
-        Optionally start with a partly-filled dictionary for the return value.
-        If a dictionary is passed, this function will work in-place on that
-        dictionary and return it.
-
-    """
-    if memo is None:
-        memo = {}
-
-    # clone the inputs if necessary
-    for input in inputs:
-        if copy_inputs:
-            cpy = input.clone()
-            cpy.owner = None
-            cpy.index = None
-            memo.setdefault(input, cpy)
-        else:
-            memo.setdefault(input, input)
-
-    # go through the inputs -> outputs graph cloning as we go
-    for apply in io_toposort(inputs, outputs):
-        for input in apply.inputs:
-            if input not in memo:
-                if copy_orphans:
-                    cpy = input.clone()
-                    memo[input] = cpy
-                else:
-                    memo[input] = input
-
-        new_apply = apply.clone_with_new_inputs([memo[i] for i in apply.inputs])
-        memo.setdefault(apply, new_apply)
-        for output, new_output in zip(apply.outputs, new_apply.outputs):
-            memo.setdefault(output, new_output)
-
-    # finish up by cloning any remaining outputs (it can happen)
-    for output in outputs:
-        if output not in memo:
-            memo[output] = output.clone()
-
-    return memo
-
-
-def clone_replace(
-    output: List[Variable],
-    replace: Optional[
-        Union[Iterable[Tuple[Variable, Variable]], Dict[Variable, Variable]]
-    ] = None,
-    strict: bool = True,
-    share_inputs: bool = True,
-) -> List[Variable]:
-    """Clone a graph and replace subgraphs within it.
-
-    It returns a copy of the initial subgraph with the corresponding
-    substitutions.
-
-    Parameters
-    ----------
-    output : Aesara Variables (or Aesara expressions)
-        Aesara expression that represents the computational graph.
-    replace : dict
-        Dictionary describing which subgraphs should be replaced by what.
-    share_inputs : bool
-        If ``True``, use the same inputs (and shared variables) as the original
-        graph. If ``False``, clone them. Note that cloned shared variables still
-        use the same underlying storage, so they will always have the same
-        value.
-
-    """
-    from aesara.compile.function.pfunc import rebuild_collect_shared
-
-    items: Union[List[Tuple[Variable, Variable]], Tuple[Tuple[Variable, Variable], ...]]
-    if isinstance(replace, dict):
-        items = list(replace.items())
-    elif isinstance(replace, (list, tuple)):
-        items = replace
-    elif replace is None:
-        items = []
-    else:
-        raise ValueError(
-            (
-                "replace is neither a dictionary, list, "
-                f"tuple or None ! The value provided is {replace},"
-                f"of type {type(replace)}"
-            )
-        )
-    tmp_replace = [(x, x.type()) for x, y in items]
-    new_replace = [(x, y) for ((_, x), (_, y)) in zip(tmp_replace, items)]
-    _, _outs, _ = rebuild_collect_shared(
-        output, [], tmp_replace, [], strict, share_inputs
-    )
-
-    # TODO Explain why we call it twice ?!
-    _, outs, _ = rebuild_collect_shared(
-        _outs, [], new_replace, [], strict, share_inputs
-    )
-
-    return cast(List[Variable], outs)
-
-
 def general_toposort(
     outputs: Iterable[T],
     deps: Callable[[T], Union[OrderedSet, List[T]]],
@@ -1206,6 +1040,172 @@ def io_toposort(
         clients=clients,
     )
     return [o for o in topo if isinstance(o, Apply)]
+
+
+def clone_get_equiv(
+    inputs: Sequence[Variable],
+    outputs: Sequence[Variable],
+    copy_inputs: bool = True,
+    copy_orphans: bool = True,
+    memo: Optional[Dict[Node, Node]] = None,
+) -> Dict[Node, Node]:
+    """
+    Return a dictionary that maps from `Variable` and `Apply` nodes in the
+    original graph to a new node (a clone) in a new graph.
+
+    This function works by recursively cloning inputs... rebuilding a directed
+    graph from the inputs up to eventually building new outputs.
+
+    Parameters
+    ----------
+    inputs : a list of Variables
+    outputs : a list of Variables
+    copy_inputs : bool
+        True means to create the cloned graph from new input
+        nodes (the bottom of a feed-upward graph).
+        False means to clone a graph that is rooted at the original input
+        nodes.
+    copy_orphans :
+        When ``True``, new constant nodes are created. When ``False``, original
+        constant nodes are reused in the new graph.
+    memo : None or dict
+        Optionally start with a partly-filled dictionary for the return value.
+        If a dictionary is passed, this function will work in-place on that
+        dictionary and return it.
+
+    """
+    if memo is None:
+        memo = {}
+
+    # clone the inputs if necessary
+    for input in inputs:
+        if copy_inputs:
+            cpy = input.clone()
+            cpy.owner = None
+            cpy.index = None
+            memo.setdefault(input, cpy)
+        else:
+            memo.setdefault(input, input)
+
+    # go through the inputs -> outputs graph cloning as we go
+    for apply in io_toposort(inputs, outputs):
+        for input in apply.inputs:
+            if input not in memo:
+                if copy_orphans:
+                    cpy = input.clone()
+                    memo[input] = cpy
+                else:
+                    memo[input] = input
+
+        new_apply = apply.clone_with_new_inputs([memo[i] for i in apply.inputs])
+        memo.setdefault(apply, new_apply)
+        for output, new_output in zip(apply.outputs, new_apply.outputs):
+            memo.setdefault(output, new_output)
+
+    # finish up by cloning any remaining outputs (it can happen)
+    for output in outputs:
+        if output not in memo:
+            memo[output] = output.clone()
+
+    return memo
+
+
+def clone(
+    inputs: List[Variable],
+    outputs: List[Variable],
+    copy_inputs: bool = True,
+    copy_orphans: Optional[bool] = None,
+) -> Tuple[Collection[Variable], Collection[Variable]]:
+    r"""Copies the sub-graph contained between inputs and outputs.
+
+    Parameters
+    ----------
+    inputs
+        Input `Variable`\s.
+    outputs
+        Output `Variable`\s.
+    copy_inputs
+        If ``True``, the inputs will be copied (defaults to ``True``).
+    copy_orphans
+        When ``None``, use the `copy_inputs` value.
+        When ``True``, new orphans nodes are created.
+        When ``False``, original orphans nodes are reused in the new graph.
+
+    Returns
+    -------
+    The inputs and outputs of that copy.
+
+    Notes
+    -----
+
+    A constant, if in the `inputs` list is not an orphan. So it will be copied
+    conditional on the `copy_inputs` parameter; otherwise, it will be copied
+    conditional on the `copy_orphans` parameter.
+
+    """
+    if copy_orphans is None:
+        copy_orphans = copy_inputs
+    equiv = clone_get_equiv(inputs, outputs, copy_inputs, copy_orphans)
+    return [cast(Variable, equiv[input]) for input in inputs], [
+        cast(Variable, equiv[output]) for output in outputs
+    ]
+
+
+def clone_replace(
+    output: List[Variable],
+    replace: Optional[
+        Union[Iterable[Tuple[Variable, Variable]], Dict[Variable, Variable]]
+    ] = None,
+    strict: bool = True,
+    share_inputs: bool = True,
+) -> List[Variable]:
+    """Clone a graph and replace subgraphs within it.
+
+    It returns a copy of the initial subgraph with the corresponding
+    substitutions.
+
+    Parameters
+    ----------
+    output : Aesara Variables (or Aesara expressions)
+        Aesara expression that represents the computational graph.
+    replace : dict
+        Dictionary describing which subgraphs should be replaced by what.
+    share_inputs : bool
+        If ``True``, use the same inputs (and shared variables) as the original
+        graph. If ``False``, clone them. Note that cloned shared variables still
+        use the same underlying storage, so they will always have the same
+        value.
+
+    """
+    from aesara.compile.function.pfunc import rebuild_collect_shared
+
+    items: Union[List[Tuple[Variable, Variable]], Tuple[Tuple[Variable, Variable], ...]]
+    if isinstance(replace, dict):
+        items = list(replace.items())
+    elif isinstance(replace, (list, tuple)):
+        items = replace
+    elif replace is None:
+        items = []
+    else:
+        raise ValueError(
+            (
+                "replace is neither a dictionary, list, "
+                f"tuple or None ! The value provided is {replace},"
+                f"of type {type(replace)}"
+            )
+        )
+    tmp_replace = [(x, x.type()) for x, y in items]
+    new_replace = [(x, y) for ((_, x), (_, y)) in zip(tmp_replace, items)]
+    _, _outs, _ = rebuild_collect_shared(
+        output, [], tmp_replace, [], strict, share_inputs
+    )
+
+    # TODO Explain why we call it twice ?!
+    _, outs, _ = rebuild_collect_shared(
+        _outs, [], new_replace, [], strict, share_inputs
+    )
+
+    return cast(List[Variable], outs)
 
 
 default_leaf_formatter = str

--- a/aesara/graph/fg.py
+++ b/aesara/graph/fg.py
@@ -105,8 +105,8 @@ class FunctionGraph(MetaObject):
 
         if clone:
             _memo = clone_get_equiv(
-                inputs,
                 outputs,
+                inputs=inputs,
                 copy_inputs=copy_inputs,
                 copy_orphans=copy_orphans,
                 memo=cast(Dict[Node, Node], memo),
@@ -740,7 +740,7 @@ class FunctionGraph(MetaObject):
         equiv
             A ``dict`` that maps old nodes to the new nodes.
         """
-        equiv = clone_get_equiv(self.inputs, self.outputs)
+        equiv = clone_get_equiv(self.outputs, inputs=self.inputs)
 
         if check_integrity:
             self.check_integrity()

--- a/aesara/sandbox/rng_mrg.py
+++ b/aesara/sandbox/rng_mrg.py
@@ -842,10 +842,10 @@ class MRG_RandomStream:
 
     def pretty_return(self, node_rstate, new_rstate, sample, size, nstreams):
         # TODO : need description for method, parameter and return
-        sample.rstate = node_rstate
-        sample.update = (node_rstate, new_rstate)
+        sample.tag.rstate = node_rstate
+        sample.tag.update = (node_rstate, new_rstate)
         self.state_updates.append((node_rstate, new_rstate, size, nstreams))
-        node_rstate.default_update = new_rstate
+        node_rstate.tag.default_update = new_rstate
         return sample
 
     def uniform(

--- a/aesara/tensor/random/utils.py
+++ b/aesara/tensor/random/utils.py
@@ -258,13 +258,13 @@ class RandomStream:
 
         # Generate the sample
         out = op(*args, **kwargs, rng=random_state_variable)
-        out.rng = random_state_variable
+        out.tag.rng = random_state_variable
 
         # Update the tracked states
         new_r = out.owner.outputs[0]
-        out.update = (random_state_variable, new_r)
-        self.state_updates.append(out.update)
+        out.tag.update = (random_state_variable, new_r)
+        self.state_updates.append(out.tag.update)
 
-        random_state_variable.default_update = new_r
+        random_state_variable.tag.default_update = new_r
 
         return out

--- a/doc/library/compile/function.rst
+++ b/doc/library/compile/function.rst
@@ -198,19 +198,18 @@ Reference
     if you give two update expressions for the same SharedVariable input (that
     doesn't make sense).
 
-    If a SharedVariable is not given an update expression, but has a
-    ``default_update`` member containing an expression, this expression
+    If a `SharedVariable` is not given an update expression, but has a
+    :attr:`SharedVariable.tag.default_update` member containing an expression, this expression
     will be used as the update expression for this variable.  Passing
     ``no_default_updates=True`` to ``function`` disables this behavior
     entirely, passing ``no_default_updates=[sharedvar1, sharedvar2]``
     disables it for the mentioned variables.
 
     Regarding givens: Be careful to make sure that these substitutions are
-    independent, because behaviour when Var1 of one pair appears in the graph leading
-    to Var2 in another expression is undefined (e.g. with ``{a: x, b: a + 1}``).
-    Replacements specified with
-    givens are different from optimizations in that Var2 is not expected to be
-    equivalent to Var1.
+    independent, because behavior when ``Var1`` of one pair appears in the graph leading
+    to ``Var2`` in another expression is undefined (e.g. with ``{a: x, b: a + 1}``).
+    Replacements specified with givens are different from optimizations in that
+    ``Var2`` is not expected to be equivalent to ``Var1``.
 
 .. autofunction:: aesara.compile.function.function_dump
 

--- a/doc/library/tensor/random/utils.rst
+++ b/doc/library/tensor/random/utils.rst
@@ -50,8 +50,8 @@ Reference
     .. method:: gen(op, *args, **kwargs)
 
         Return the random variable from `op(*args, **kwargs)`, but
-        also install special attributes (``.rng`` and ``update``, see
-        :class:`RandomVariable` ) into it.
+        also add special attributes (``.tag.rng`` and ``tag.update``, see
+        :class:`RandomVariable` ) to it.
 
         This function also adds the returned variable to an internal list so
         that it can be seeded later by a call to `seed`.

--- a/doc/tutorial/examples.rst
+++ b/doc/tutorial/examples.rst
@@ -365,7 +365,7 @@ Here's a brief example.  The setup code is:
     rv_u = srng.uniform(0, 1, size=(2,2))
     rv_n = srng.normal(0, 1, size=(2,2))
     f = function([], rv_u)
-    g = function([], rv_n, no_default_updates=True)    #Not updating rv_n.rng
+    g = function([], rv_n, no_default_updates=True)    #Not updating rv_n.tag.rng
     nearly_zeros = function([], rv_u + rv_u - 2 * rv_u)
 
 Here, ``rv_u`` represents a random stream of 2x2 matrices of draws from a uniform
@@ -403,11 +403,11 @@ Seeding Streams
 Random variables can be seeded individually or collectively.
 
 You can seed just one random variable by seeding or assigning to the
-``.rng`` attribute, using ``.rng.set_value()``.
+``.tag.rng`` attribute, using ``.tag.rng.set_value()``.
 
->>> rng_val = rv_u.rng.get_value(borrow=True)   # Get the rng for rv_u
+>>> rng_val = rv_u.tag.rng.get_value(borrow=True)   # Get the rng for rv_u
 >>> rng_val.seed(89234)                         # seeds the generator
->>> rv_u.rng.set_value(rng_val, borrow=True)    # Assign back seeded rng
+>>> rv_u.tag.rng.set_value(rng_val, borrow=True)    # Assign back seeded rng
 
 You can also seed *all* of the random variables allocated by a :class:`RandomStream`
 object by that object's ``seed`` method.  This seed will be used to seed a
@@ -425,14 +425,14 @@ update the state of the generators used in function *f* above.
 
 For example:
 
->>> state_after_v0 = rv_u.rng.get_value().get_state()
+>>> state_after_v0 = rv_u.tag.rng.get_value().get_state()
 >>> nearly_zeros()       # this affects rv_u's generator
 array([[ 0.,  0.],
        [ 0.,  0.]])
 >>> v1 = f()
->>> rng = rv_u.rng.get_value(borrow=True)
+>>> rng = rv_u.tag.rng.get_value(borrow=True)
 >>> rng.set_state(state_after_v0)
->>> rv_u.rng.set_value(rng, borrow=True)
+>>> rv_u.tag.rng.set_value(rng, borrow=True)
 >>> v2 = f()             # v2 != v1
 >>> v3 = f()             # v3 == v1
 

--- a/tests/compile/function/test_pfunc.py
+++ b/tests/compile/function/test_pfunc.py
@@ -426,13 +426,13 @@ class TestPfunc:
 
     def test_default_updates(self):
         x = shared(0)
-        x.default_update = x + 1
+        x.tag.default_update = x + 1
 
         f = pfunc([], [x])
         f()
         assert x.get_value() == 1
 
-        del x.default_update
+        del x.tag.default_update
         f()
         assert x.get_value() == 2
 
@@ -443,7 +443,7 @@ class TestPfunc:
     def test_no_default_updates(self):
         x = shared(0)
         y = shared(1)
-        x.default_update = x + 2
+        x.tag.default_update = x + 2
 
         # Test that the default update is taken into account in the right cases
         f1 = pfunc([], [x], no_default_updates=True)
@@ -508,7 +508,7 @@ class TestPfunc:
         a = lscalar("a")
 
         z = a * x
-        x.default_update = x + y
+        x.tag.default_update = x + y
 
         f1 = pfunc([a], z)
         f1(12)
@@ -526,8 +526,8 @@ class TestPfunc:
         x = shared(0)
         y = shared(1)
 
-        x.default_update = x - 1
-        y.default_update = y + 1
+        x.tag.default_update = x - 1
+        y.tag.default_update = y + 1
 
         f1 = pfunc([], [x, y])
         f1()
@@ -554,9 +554,9 @@ class TestPfunc:
         y = shared(1)
         z = shared(-1)
 
-        x.default_update = x - y
-        y.default_update = z
-        z.default_update = z - 1
+        x.tag.default_update = x - y
+        y.tag.default_update = z
+        z.tag.default_update = z - 1
 
         f1 = pfunc([], [x])
         f1()
@@ -596,8 +596,8 @@ class TestPfunc:
         else:
             a = lscalar("a")
 
-        x.default_update = y
-        y.default_update = y + a
+        x.tag.default_update = y
+        y.tag.default_update = y + a
 
         f1 = pfunc([], x, no_default_updates=True)
         f1()
@@ -624,13 +624,13 @@ class TestPfunc:
         assert x.get_value() == 3
         assert y.get_value() == 2
 
-        # a is needed as input if y.default_update is used
+        # a is needed as input if y.tag.default_update is used
         with pytest.raises(MissingInputError):
             pfunc([], x)
 
     def test_default_updates_partial_graph(self):
         a = shared(0)
-        a.default_update = a + 1  # Increment a each time it is used
+        a.tag.default_update = a + 1  # Increment a each time it is used
         b = 2 * a
         # Use only the tip of the graph, a is not used
         f = pfunc([b], b)
@@ -640,7 +640,7 @@ class TestPfunc:
 
     def test_givens_replaces_shared_variable(self):
         a = shared(1.0, "a")
-        a.default_update = a + 3.0
+        a.tag.default_update = a + 3.0
         b = dscalar("b")
         c = a + 10
         f = pfunc([b], c, givens={a: b})
@@ -650,7 +650,7 @@ class TestPfunc:
 
     def test_givens_replaces_shared_variable2(self):
         a = shared(1.0, "a")
-        a.default_update = a + 3
+        a.tag.default_update = a + 3
         c = a + 10
         f = pfunc([], c, givens={a: (a + 10)})
 

--- a/tests/sandbox/test_rng_mrg.py
+++ b/tests/sandbox/test_rng_mrg.py
@@ -117,10 +117,10 @@ def test_consistency_cpu_serial():
             )
             # Not really necessary, just mimicking
             # rng_mrg.MRG_RandomStream' behavior
-            sample.rstate = rstate
-            sample.update = (rstate, new_rstate)
+            sample.tag.rstate = rstate
+            sample.tag.update = (rstate, new_rstate)
 
-            rstate.default_update = new_rstate
+            rstate.tag.default_update = new_rstate
             f = function([], sample)
             for k in range(n_samples):
                 s = f()
@@ -161,10 +161,10 @@ def test_consistency_cpu_parallel():
         )
         # Not really necessary, just mimicking
         # rng_mrg.MRG_RandomStream' behavior
-        sample.rstate = rstate
-        sample.update = (rstate, new_rstate)
+        sample.tag.rstate = rstate
+        sample.tag.update = (rstate, new_rstate)
 
-        rstate.default_update = new_rstate
+        rstate.tag.default_update = new_rstate
         f = function([], sample)
 
         for k in range(n_samples):

--- a/tests/scan/test_utils.py
+++ b/tests/scan/test_utils.py
@@ -18,7 +18,7 @@ def create_test_hmm():
     rng_state = np.random.default_rng(23422)
     rng_tt = aesara.shared(rng_state, name="rng", borrow=True)
     rng_tt.tag.is_rng = True
-    rng_tt.default_update = rng_tt
+    rng_tt.tag.default_update = rng_tt
 
     N_tt = at.iscalar("N")
     N_tt.tag.test_value = 10
@@ -143,7 +143,7 @@ def test_ScanArgs_basics_mit_sot():
     rng_state = np.random.RandomState(np.random.MT19937(np.random.SeedSequence(1234)))
     rng_tt = aesara.shared(rng_state, name="rng", borrow=True)
     rng_tt.tag.is_rng = True
-    rng_tt.default_update = rng_tt
+    rng_tt.tag.default_update = rng_tt
 
     N_tt = at.iscalar("N")
     N_tt.tag.test_value = 10

--- a/tests/tensor/random/test_opt.py
+++ b/tests/tensor/random/test_opt.py
@@ -66,7 +66,7 @@ def apply_local_opt_to_rv(opt, op_fn, dist_op, dist_params, size, rng, name=None
 def test_inplace_optimization():
 
     out = normal(0, 1)
-    out.owner.inputs[0].default_update = out.owner.outputs[0]
+    out.owner.inputs[0].tag.default_update = out.owner.outputs[0]
 
     assert out.owner.op.inplace is False
 
@@ -107,7 +107,7 @@ def test_inplace_optimization_extra_props():
             return rng.normal(scale=sigma, size=size)
 
     out = Test(extra="some value")(1)
-    out.owner.inputs[0].default_update = out.owner.outputs[0]
+    out.owner.inputs[0].tag.default_update = out.owner.outputs[0]
 
     assert out.owner.op.inplace is False
 

--- a/tests/tensor/random/test_utils.py
+++ b/tests/tensor/random/test_utils.py
@@ -13,7 +13,7 @@ from tests import unittest_tools as utt
 def set_aesara_flags():
     opts = OptimizationQuery(include=[None], exclude=[])
     py_mode = Mode("py", opts)
-    with config.change_flags(mode=py_mode, compute_test_value="warn"):
+    with config.change_flags(mode=py_mode, compute_test_value="ignore"):
         yield
 
 
@@ -97,7 +97,7 @@ class TestSharedRandomStream:
         assert np.all(f() != f())
         assert np.all(g() == g())
         assert np.all(abs(nearly_zeros()) < 1e-5)
-        assert isinstance(rv_u.rng.get_value(borrow=True), np.random.Generator)
+        assert isinstance(rv_u.tag.rng.get_value(borrow=True), np.random.Generator)
 
     @pytest.mark.parametrize("rng_ctor", [np.random.RandomState, np.random.default_rng])
     def test_basics(self, rng_ctor):
@@ -223,7 +223,7 @@ class TestSharedRandomStream:
         # Explicit updates #2
         random_c = RandomStream(utt.fetch_seed(), rng_ctor=rng_ctor)
         out_c = random_c.uniform(0, 1, size=(2, 2))
-        fn_c = function([], out_c, updates=[out_c.update])
+        fn_c = function([], out_c, updates=[out_c.tag.update])
         fn_c_val0 = fn_c()
         fn_c_val1 = fn_c()
         assert np.all(fn_c_val0 == fn_a_val0)
@@ -241,7 +241,7 @@ class TestSharedRandomStream:
         # No updates for out
         random_e = RandomStream(utt.fetch_seed(), rng_ctor=rng_ctor)
         out_e = random_e.uniform(0, 1, size=(2, 2))
-        fn_e = function([], out_e, no_default_updates=[out_e.rng])
+        fn_e = function([], out_e, no_default_updates=[out_e.tag.rng])
         fn_e_val0 = fn_e()
         fn_e_val1 = fn_e()
         assert np.all(fn_e_val0 == fn_a_val0)


### PR DESCRIPTION
This PR updates the `Variable.[default_update|update]` machinery so that cloning can handle these values (see https://github.com/Theano/Theano/issues/1467).

The first part of these changes involves some refactoring of the graph cloning code, which is currently split between `aesara.graph.basic.clone_replace` and `aesara.compile.function.pfunc.rebuild_collect_shared`.  The latter is a bottom-up approach that  does a lot of other unrelated things as well; it needs to be cleaned up or simply replaced altogether, and the former applies the latter twice in order to achieve the desired replacement semantics.

The first major change:

- [x] Base `clone_replace` on `clone_get_equiv`

With this change, `clone_replace`first toposorts the graph, walking bottom-up to do that, and then clones in a top-down manner.
Although this entails two passes through the graph, `clone_replace` is already performing two bottom-up passes, so that shouldn't be a problem.  This approach is a much simpler and consistent means of performing the replacements, and it should be considerably easier to apply additional replacements&mdash;like the ones involving `Variable.[default_update|update]`, which require a pass through the graph in order to find updates.

The second major change:

- [ ] Change `rebuild_collect_shared` and `clone_get_equiv` so that they can perform consistent replacements when `Variable.[default_update|update]` graphs are discovered

More generally, `rebuild_collect_shared` needs to be cleaned up and made to work in a TCO/stack-like fashion (e.g. something closer to `clone_get_equiv`).

Following (or possibly before) those:

- [x] Change `Variable.[default_update|update]` to `Variable.tag.[default_update|update]`

We shouldn't be dynamically adding fields to `Variable`s, especially not ones like these.  Moving these to `Variable.tag` is a good start, but we really need to handle this functionality differently, or replace it with an entirely different approach.
