### PR TITLE
Implement `at.diff` using basic slicing and subtraction `Op`s

### DIFF
--- a/aesara/link/jax/dispatch.py
+++ b/aesara/link/jax/dispatch.py
@@ -39,7 +39,6 @@ from aesara.tensor.extra_ops import (
     Bartlett,
     BroadcastTo,
     CumOp,
-    DiffOp,
     FillDiagonal,
     FillDiagonalOffset,
     RavelMultiIndex,
@@ -936,17 +935,6 @@ def jax_funcify_CumOp(op, **kwargs):
             return jnp.cumprod(x, axis=axis)
 
     return cumop
-
-
-@jax_funcify.register(DiffOp)
-def jax_funcify_DiffOp(op, **kwargs):
-    n = op.n
-    axis = op.axis
-
-    def diffop(x, n=n, axis=axis):
-        return jnp.diff(x, n=n, axis=axis)
-
-    return diffop
 
 
 @jax_funcify.register(Repeat)

--- a/aesara/tensor/extra_ops.py
+++ b/aesara/tensor/extra_ops.py
@@ -551,17 +551,17 @@ def diff(x, n=1, axis=-1):
     """
     ndim = x.ndim
     axis = normalize_axis_index(axis, ndim)
-        
+
     slice1 = [slice(None)] * ndim
     slice2 = [slice(None)] * ndim
     slice1[axis] = slice(1, None)
     slice2[axis] = slice(None, -1)
     slice1 = tuple(slice1)
     slice2 = tuple(slice2)
-    
+
     for _ in range(n):
         x = x[slice1] - x[slice2]
-    
+
     return x
 
 

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -1515,50 +1515,6 @@ def test_CumOp(val, axis, mode):
 
 
 @pytest.mark.parametrize(
-    "val, n, axis",
-    [
-        (
-            set_test_value(at.matrix(), rng.normal(size=(3, 2)).astype(config.floatX)),
-            0,
-            0,
-        ),
-        (
-            set_test_value(at.matrix(), rng.normal(size=(3, 2)).astype(config.floatX)),
-            0,
-            1,
-        ),
-        (
-            set_test_value(at.matrix(), rng.normal(size=(3, 2)).astype(config.floatX)),
-            1,
-            0,
-        ),
-        (
-            set_test_value(at.matrix(), rng.normal(size=(3, 2)).astype(config.floatX)),
-            1,
-            1,
-        ),
-        (
-            set_test_value(at.lmatrix(), rng.poisson(size=(3, 2))),
-            0,
-            0,
-        ),
-    ],
-)
-def test_DiffOp(val, axis, n):
-    g = extra_ops.DiffOp(n=n, axis=axis)(val)
-    g_fg = FunctionGraph(outputs=[g])
-
-    (res,) = compare_numba_and_py(
-        g_fg,
-        [
-            i.tag.test_value
-            for i in g_fg.inputs
-            if not isinstance(i, (SharedVariable, Constant))
-        ],
-    )
-
-
-@pytest.mark.parametrize(
     "a, val",
     [
         (

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -310,7 +310,6 @@ class TestDiff(utt.InferShapeTester):
                 g = aesara.function([x], diff(x, n=n, axis=axis))
                 assert np.allclose(np.diff(a, n=n, axis=axis), g(a))
 
-
     @pytest.mark.xfail(reason="Subtensor shape cannot be inferred correctly")
     @pytest.mark.parametrize(
         "x_type",

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -18,7 +18,6 @@ from aesara.tensor.extra_ops import (
     BroadcastTo,
     CpuContiguous,
     CumOp,
-    DiffOp,
     FillDiagonal,
     FillDiagonalOffset,
     RavelMultiIndex,
@@ -333,33 +332,6 @@ class TestDiffOp(utt.InferShapeTester):
                         assert out.type.shape[i] is None
                     else:
                         assert out.type.shape[i] == out_test.shape[i]
-
-    def test_infer_shape(self):
-        x = matrix("x")
-        a = np.random.random((30, 50)).astype(config.floatX)
-
-        # Test default n and axis
-        self._compile_and_check([x], [DiffOp()(x)], [a], DiffOp)
-
-        for axis in (-2, -1, 0, 1):
-            for n in (0, 1, 2, a.shape[0], a.shape[0] + 1):
-                self._compile_and_check([x], [diff(x, n=n, axis=axis)], [a], DiffOp)
-
-    def test_grad(self):
-        a = np.random.random(50).astype(config.floatX)
-
-        # Test default n and axis
-        utt.verify_grad(DiffOp(), [a])
-
-        for n in (0, 1, 2, a.shape[0]):
-            utt.verify_grad(DiffOp(n=n), [a], eps=7e-3)
-
-    @pytest.mark.xfail(reason="gradient is wrong when n is larger than input size")
-    def test_grad_n_larger_than_input(self):
-        # Gradient is wrong when n is larger than the input size. Until it is fixed,
-        # this test ensures the behavior is documented
-        a = np.random.random(10).astype(config.floatX)
-        utt.verify_grad(DiffOp(n=11), [a], eps=7e-3)
 
     def test_grad_not_implemented(self):
         x = at.matrix("x")

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -310,6 +310,8 @@ class TestDiff(utt.InferShapeTester):
                 g = aesara.function([x], diff(x, n=n, axis=axis))
                 assert np.allclose(np.diff(a, n=n, axis=axis), g(a))
 
+
+    @pytest.mark.xfail(reason="Subtensor shape cannot be inferred correctly")
     @pytest.mark.parametrize(
         "x_type",
         (

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -8,7 +8,6 @@ from aesara import function
 from aesara import tensor as at
 from aesara.compile.mode import Mode
 from aesara.configdefaults import config
-from aesara.gradient import grad
 from aesara.graph.basic import applys_between
 from aesara.graph.optdb import OptimizationQuery
 from aesara.raise_op import Assert
@@ -298,8 +297,8 @@ class TestBinCount(utt.InferShapeTester):
                     f5(a)
 
 
-class TestDiffOp(utt.InferShapeTester):
-    def test_diffOp(self):
+class TestDiff(utt.InferShapeTester):
+    def test_diff(self):
         x = matrix("x")
         a = np.random.random((30, 50)).astype(config.floatX)
 
@@ -332,11 +331,6 @@ class TestDiffOp(utt.InferShapeTester):
                         assert out.type.shape[i] is None
                     else:
                         assert out.type.shape[i] == out_test.shape[i]
-
-    def test_grad_not_implemented(self):
-        x = at.matrix("x")
-        with pytest.raises(NotImplementedError):
-            grad(diff(x).sum(), x)
 
 
 class TestSqueeze(utt.InferShapeTester):


### PR DESCRIPTION
Closes #860.

I'm happy to receive any pointers or suggestions via the creation of this PR. Hopefully, this PR can bring some discussion since there are gaps in my understanding.

Two questions:

- Currently, I did not remove the class `DiffOp` because the [Jax](https://github.com/aesara-devs/aesara/blob/main/aesara/link/jax/dispatch.py#L942) and [Numba](https://github.com/aesara-devs/aesara/blob/main/aesara/link/numba/dispatch/extra_ops.py#L71) seem to use it. Should I delete `DiffOp` altogether or just modify `at.diff` as in the current (first) commit?
- Should the loop be replaced by a implementation that builds on `aesara.scan`?