### PR TITLE
Remove `default_update`s from variables created in a `Scan` loop function

### DIFF
--- a/aesara/scan/basic.py
+++ b/aesara/scan/basic.py
@@ -1,4 +1,4 @@
-import logging
+import warnings
 
 import numpy as np
 
@@ -17,9 +17,6 @@ from aesara.tensor.math import minimum
 from aesara.tensor.shape import shape_padleft
 from aesara.tensor.type import TensorType, integer_dtypes
 from aesara.updates import OrderedUpdates
-
-
-_logger = logging.getLogger("aesara.scan.basic")
 
 
 def scan(
@@ -394,7 +391,7 @@ def scan(
                 # ^ initial state but taps not provided
                 if "taps" in outs_info[i]:
                     # ^ explicitly provided a None for taps
-                    _logger.warning(
+                    warnings.warn(
                         f"Output {getattr(outs_info[i]['initial'], 'name', 'None')} (index {i}) has a initial "
                         "state but taps is explicitly set to None ",
                     )
@@ -471,12 +468,12 @@ def scan(
                         if config.compute_test_value != "ignore":
                             # No need to print a warning or raise an error now,
                             # it will be done when fn will be called.
-                            _logger.warning(
+                            warnings.warn(
                                 (
                                     "Cannot compute test value for "
                                     "the inner function of scan, input value "
-                                    "missing {}"
-                                ).format(_seq_val_slice)
+                                    f"missing {_seq_val_slice}"
+                                )
                             )
 
                 # Add names to slices for debugging and pretty printing ..
@@ -600,11 +597,11 @@ def scan(
                     arg.tag.test_value = get_test_value(actual_arg)
                 except TestValueError:
                     if config.compute_test_value != "ignore":
-                        _logger.warning(
+                        warnings.warn(
                             (
                                 "Cannot compute test value for the "
-                                "inner function of scan, test value missing: {}"
-                            ).format(actual_arg)
+                                f"inner function of scan, test value missing: {actual_arg}"
+                            )
                         )
 
             if getattr(init_out["initial"], "name", None) is not None:
@@ -658,12 +655,12 @@ def scan(
                         nw_slice.tag.test_value = get_test_value(_init_out_var_slice)
                     except TestValueError:
                         if config.compute_test_value != "ignore":
-                            _logger.warning(
+                            warnings.warn(
                                 (
                                     "Cannot compute test value for "
                                     "the inner function of scan, test value "
-                                    "missing: {}"
-                                ).format(_init_out_var_slice)
+                                    f"missing: {_init_out_var_slice}"
+                                )
                             )
 
                 # give it a name or debugging and pretty printing

--- a/aesara/tensor/random/var.py
+++ b/aesara/tensor/random/var.py
@@ -8,12 +8,14 @@ from aesara.tensor.random.type import random_generator_type, random_state_type
 
 class RandomStateSharedVariable(SharedVariable):
     def __str__(self):
-        return "RandomStateSharedVariable({})".format(repr(self.container))
+        return self.name or "RandomStateSharedVariable({})".format(repr(self.container))
 
 
 class RandomGeneratorSharedVariable(SharedVariable):
     def __str__(self):
-        return "RandomGeneratorSharedVariable({})".format(repr(self.container))
+        return self.name or "RandomGeneratorSharedVariable({})".format(
+            repr(self.container)
+        )
 
 
 @shared_constructor


### PR DESCRIPTION
This PR closes #579 by removing the `.default_update` attribute on shared inner-graph variables during `Scan` node construction.

Simply put, shared variables currently do not honor the closed context/scope of inner-graph-having `Op`s, and this PR fixes that.

This work also fixes another shortcoming of the `RandomVariable` + `Scan`'s interaction: `Scan` inner-functions pick up the `.default_update`s for RNG states outside of their scopes.

A demonstration:
```python
import aesara
import aesara.tensor as at


srng = at.random.RandomStream()

x = srng.normal(name="x")

out, out_updates = aesara.scan(lambda: x, n_steps=4)

out_fn = aesara.function((), out, updates=out_updates)

# The values are all different, which is wrong, so this fails
assert len(set(out_fn())) == 1
```
What happens in this example is that the `Scan` takes responsibility for computing the `.default_update` on `x`'s RNG state, making the RNG state and&mdash;as a result&mdash;`x` change on every iteration within the `Scan`.

Currently, we are required to specify the scope manually via `non_sequences`:
```python
out_2, out_2_updates = aesara.scan(lambda x: x, non_sequences=[x], n_steps=4)
out_2_fn = aesara.function((), out_2, updates=out_2_updates)

# This works
assert len(set(out_2_fn())) == 1
```

With the changes in this PR, `Scan`s will only perform the shared variable updates specified by a user (e.g. by returning an updates `dict`) or created within the body of a `Scan` loop.