### PR TITLE
Deprecate patternbroadcast

### DIFF
--- a/aesara/sparse/basic.py
+++ b/aesara/sparse/basic.py
@@ -44,7 +44,7 @@ from aesara.tensor.math import (
     tanh,
     trunc,
 )
-from aesara.tensor.shape import shape
+from aesara.tensor.shape import shape, specify_shape
 from aesara.tensor.type import TensorType
 from aesara.tensor.type import continuous_dtypes as tensor_continuous_dtypes
 from aesara.tensor.type import discrete_dtypes as tensor_discrete_dtypes
@@ -1133,7 +1133,8 @@ class SparseFromDense(Op):
         (x,) = inputs
         (gz,) = gout
         gx = dense_from_sparse(gz)
-        gx = at.patternbroadcast(gx, x.broadcastable)
+        if gx.type.broadcastable != x.type.broadcastable:
+            gx = specify_shape(gx, [1 if b else None for b in x.type.broadcastable])
         return (gx,)
 
     def infer_shape(self, fgraph, node, shapes):

--- a/aesara/sparse/opt.py
+++ b/aesara/sparse/opt.py
@@ -20,7 +20,7 @@ from aesara.sparse.basic import (
     usmm,
 )
 from aesara.tensor import blas
-from aesara.tensor.basic import as_tensor_variable, cast, patternbroadcast
+from aesara.tensor.basic import as_tensor_variable, cast
 from aesara.tensor.basic_opt import register_canonicalize, register_specialize
 from aesara.tensor.math import mul, neg, sub
 from aesara.tensor.shape import shape, specify_shape
@@ -43,13 +43,7 @@ def local_csm_properties_csm(fgraph, node):
     if node.op == csm_properties:
         (csm,) = node.inputs
         if csm.owner and (csm.owner.op == CSC or csm.owner.op == CSR):
-            # csm.owner.inputs could be broadcastable. In that case, we have
-            # to adjust the broadcasting flag here.
-            ret_var = [
-                patternbroadcast(i, o.broadcastable)
-                for i, o in zip(csm.owner.inputs, node.outputs)
-            ]
-            return ret_var
+            return csm.owner.inputs
 
     return False
 

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -51,6 +51,7 @@ from aesara.tensor.shape import (
     shape_padleft,
     shape_padright,
     shape_tuple,
+    specify_shape,
 )
 from aesara.tensor.type import (
     TensorType,
@@ -2547,7 +2548,10 @@ class Join(COp):
             # broadcast. As the grad need to keep the information,
             # read it if needed.
             split_gz = [
-                patternbroadcast(g, t.broadcastable) for t, g in zip(tens, split_gz)
+                g
+                if g.type.broadcastable == t.type.broadcastable
+                else specify_shape(g, [1 if b else None for b in t.type.broadcastable])
+                for t, g in zip(tens, split_gz)
             ]
             rval = rval + split_gz
         else:

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -2289,6 +2289,11 @@ def patternbroadcast(
         not ``1``, a `ValueError` will be raised.
 
     """
+    warnings.warn(
+        "patternbroadcast is deprecated and will be removed in a future version. Use "
+        "specify_shape instead.",
+        FutureWarning,
+    )
     x = as_tensor_variable(x)
 
     if x.broadcastable == broadcastable:

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -2246,13 +2246,10 @@ def addbroadcast(x, *axes):
 
 def unbroadcast(x, *axes):
     """
-    Make the input impossible to broadcast in the specified axes.
+    Make the input unknown to be broadcastable in the specified axes.
 
-    For example, addbroadcast(x, 0) will make the first dimension
-    of x broadcastable. When performing the function, if the length
-    of x along that dimension is not 1, a ValueError will be raised.
-
-    We apply the opt here not to pollute the graph
+    For example, unbroadcast(x, 0) will make the first dimension
+    of x unbroadcastable.
 
     Parameters
     ----------
@@ -2260,8 +2257,6 @@ def unbroadcast(x, *axes):
         Input aesara tensor.
     axis : an int or an iterable object such as list or tuple of int values
         The dimension along which the tensor x should be unbroadcastable.
-        If the length of x along these dimensions is not 1, a ValueError will
-        be raised.
 
     Returns
     -------

--- a/aesara/tensor/basic_opt.py
+++ b/aesara/tensor/basic_opt.py
@@ -63,7 +63,6 @@ from aesara.tensor.basic import (
     get_vector_length,
     join,
     ones_like,
-    patternbroadcast,
     stack,
     switch,
     tensor_copy,
@@ -2434,15 +2433,6 @@ def local_join_empty(fgraph, node):
         # by an error in the old join op.
         copy_stack_trace(node.outputs, ret)
 
-        if not o.type.is_super(ret.type):
-            assert ret.dtype == o.dtype
-            assert ret.ndim == o.ndim
-            ret = patternbroadcast(ret, node.outputs[0].broadcastable)
-
-        # Copy over stacktrace from previous output
-        # (after patternbroadcast op) for same reasons as before.
-        copy_stack_trace(node.outputs, ret)
-
         return [ret]
 
 
@@ -2917,20 +2907,7 @@ def local_reshape_lift(fgraph, node):
         # Copy stacktrace from both previous Reshape and UnaryElemwise op
         # because an error in new cg could have been caused by either ops.
         copy_stack_trace(node.outputs + node.inputs, e)
-
-        # In rare case the original broadcast was (False, True), but
-        # the new one is (False, False). So don't crash in that case.
-        if not node.outputs[0].type.is_super(e.type):
-            re = patternbroadcast(e, node.outputs[0].broadcastable)
-
-            # Copy over stack trace.
-            # If the graph fails it is usually due to the fact that a dimension
-            # that should be broadcastable does not actually have length 1,
-            copy_stack_trace(e, re)
-        else:
-            re = e
-
-        return [re]
+        return [e]
 
 
 register_canonicalize(OpRemove(tensor_copy), name="remove_tensor_copy")

--- a/aesara/tensor/blas.py
+++ b/aesara/tensor/blas.py
@@ -166,6 +166,7 @@ from aesara.tensor.blas_headers import blas_header_text, blas_header_version
 from aesara.tensor.elemwise import DimShuffle, Elemwise
 from aesara.tensor.exceptions import NotScalarConstantError
 from aesara.tensor.math import Dot, add, mul, neg, sub
+from aesara.tensor.shape import specify_shape
 from aesara.tensor.type import (
     DenseTensorType,
     integer_dtypes,
@@ -2499,9 +2500,13 @@ class BatchedDot(COp):
         # above code don't always return the right broadcast pattern.
         # This cause problem down the road. See gh-1461.
         if xgrad.broadcastable != x.broadcastable:
-            xgrad = at.patternbroadcast(xgrad, x.broadcastable)
+            xgrad = specify_shape(
+                xgrad, [1 if b else None for b in x.type.broadcastable]
+            )
         if ygrad.broadcastable != y.broadcastable:
-            ygrad = at.patternbroadcast(ygrad, y.broadcastable)
+            ygrad = specify_shape(
+                ygrad, [1 if b else None for b in y.type.broadcastable]
+            )
 
         return xgrad, ygrad
 

--- a/aesara/tensor/nnet/abstract_conv.py
+++ b/aesara/tensor/nnet/abstract_conv.py
@@ -30,11 +30,7 @@ from aesara.configdefaults import config
 from aesara.graph.basic import Apply, Variable
 from aesara.graph.op import Op
 from aesara.raise_op import Assert
-from aesara.tensor.basic import (
-    as_tensor_variable,
-    get_scalar_constant_value,
-    patternbroadcast,
-)
+from aesara.tensor.basic import as_tensor_variable, get_scalar_constant_value
 from aesara.tensor.exceptions import NotScalarConstantError
 from aesara.tensor.var import TensorConstant, TensorVariable
 
@@ -2704,11 +2700,7 @@ class AbstractConv2d(AbstractConv):
         # Make sure that the broadcastable pattern of the inputs is used
         # for the gradients, even if the grad opts are not able to infer
         # that the dimensions are broadcastable.
-        # Also make sure that the gradient lives on the same device than
-        # the corresponding input.
-        d_bottom = patternbroadcast(d_bottom, bottom.broadcastable)
         d_bottom = bottom.type.filter_variable(d_bottom)
-        d_weights = patternbroadcast(d_weights, weights.broadcastable)
         d_weights = weights.type.filter_variable(d_weights)
         return d_bottom, d_weights
 
@@ -2765,11 +2757,7 @@ class AbstractConv3d(AbstractConv):
         # Make sure that the broadcastable pattern of the inputs is used
         # for the gradients, even if the grad opts are not able to infer
         # that the dimensions are broadcastable.
-        # Also make sure that the gradient lives on the same device than
-        # the corresponding input.
-        d_bottom = patternbroadcast(d_bottom, bottom.broadcastable)
         d_bottom = bottom.type.filter_variable(d_bottom)
-        d_weights = patternbroadcast(d_weights, weights.broadcastable)
         d_weights = weights.type.filter_variable(d_weights)
         return d_bottom, d_weights
 
@@ -3062,11 +3050,7 @@ class AbstractConv2d_gradWeights(AbstractConv_gradWeights):
         # Make sure that the broadcastable pattern of the inputs is used
         # for the gradients, even if the grad opts are not able to infer
         # that the dimensions are broadcastable.
-        # Also make sure that the gradient lives on the same device than
-        # the corresponding input.
-        d_bottom = patternbroadcast(d_bottom, bottom.broadcastable)
         d_bottom = bottom.type.filter_variable(d_bottom)
-        d_top = patternbroadcast(d_top, top.broadcastable)
         d_top = top.type.filter_variable(d_top)
 
         d_height_width = (aesara.gradient.DisconnectedType()(),)
@@ -3129,11 +3113,7 @@ class AbstractConv3d_gradWeights(AbstractConv_gradWeights):
         # Make sure that the broadcastable pattern of the inputs is used
         # for the gradients, even if the grad opts are not able to infer
         # that the dimensions are broadcastable.
-        # Also make sure that the gradient lives on the same device than
-        # the corresponding input.
-        d_bottom = patternbroadcast(d_bottom, bottom.broadcastable)
         d_bottom = bottom.type.filter_variable(d_bottom)
-        d_top = patternbroadcast(d_top, top.broadcastable)
         d_top = top.type.filter_variable(d_top)
 
         d_depth_height_width = (aesara.gradient.DisconnectedType()(),)
@@ -3452,11 +3432,7 @@ class AbstractConv2d_gradInputs(AbstractConv_gradInputs):
         # Make sure that the broadcastable pattern of the inputs is used
         # for the gradients, even if the grad opts are not able to infer
         # that the dimensions are broadcastable.
-        # Also make sure that the gradient lives on the same device than
-        # the corresponding input.
-        d_weights = patternbroadcast(d_weights, weights.broadcastable)
         d_weights = weights.type.filter_variable(d_weights)
-        d_top = patternbroadcast(d_top, top.broadcastable)
         d_top = top.type.filter_variable(d_top)
 
         d_height_width = (aesara.gradient.DisconnectedType()(),)
@@ -3519,11 +3495,7 @@ class AbstractConv3d_gradInputs(AbstractConv_gradInputs):
         # Make sure that the broadcastable pattern of the inputs is used
         # for the gradients, even if the grad opts are not able to infer
         # that the dimensions are broadcastable.
-        # Also make sure that the gradient lives on the same device than
-        # the corresponding input.
-        d_weights = patternbroadcast(d_weights, weights.broadcastable)
         d_weights = weights.type.filter_variable(d_weights)
-        d_top = patternbroadcast(d_top, top.broadcastable)
         d_top = top.type.filter_variable(d_top)
 
         d_depth_height_width = (aesara.gradient.DisconnectedType()(),)

--- a/aesara/tensor/nnet/batchnorm.py
+++ b/aesara/tensor/nnet/batchnorm.py
@@ -265,12 +265,14 @@ def batch_normalization_train(
             running_var=running_var,
         )
         if new_running_mean.broadcastable != running_mean.broadcastable:
-            new_running_mean = at.patternbroadcast(
-                new_running_mean, running_mean.broadcastable
+            new_running_mean = at.specify_shape(
+                new_running_mean,
+                [1 if b else None for b in running_mean.type.broadcastable],
             )
         if new_running_var.broadcastable != running_var.broadcastable:
-            new_running_var = at.patternbroadcast(
-                new_running_var, running_var.broadcastable
+            new_running_var = at.specify_shape(
+                new_running_var,
+                [1 if b else None or None for b in running_var.type.broadcastable],
             )
         results = (out, mean, invstd, new_running_mean, new_running_var)
     else:

--- a/aesara/tensor/nnet/batchnorm.py
+++ b/aesara/tensor/nnet/batchnorm.py
@@ -823,11 +823,6 @@ def local_abstract_batch_norm_train(fgraph, node):
         )
         results.append(running_var)
 
-    results = [
-        at.patternbroadcast(r, r_orig.broadcastable)
-        for (r, r_orig) in zip(results, node.outputs)
-    ]
-
     for var in aesara.graph.basic.vars_between(node.inputs, results):
         if var not in node.inputs:
             copy_stack_trace(node.outputs[0], var)
@@ -862,11 +857,6 @@ def local_abstract_batch_norm_train_grad(fgraph, node):
     g_wrt_bias = at_sum(dy, axis=axes, keepdims=True)
     results = [g_wrt_inputs, g_wrt_scale, g_wrt_bias]
 
-    results = [
-        at.patternbroadcast(r, r_orig.broadcastable)
-        for (r, r_orig) in zip(results, node.outputs)
-    ]
-
     for var in aesara.graph.basic.vars_between(node.inputs, results):
         if var not in node.inputs:
             copy_stack_trace(node.outputs[0], var)
@@ -895,7 +885,6 @@ def local_abstract_batch_norm_inference(fgraph, node):
         epsilon = epsilon.astype("float32")
 
     result = (x - estimated_mean) * (scale / sqrt(estimated_variance + epsilon)) + bias
-    result = at.patternbroadcast(result, node.outputs[0].broadcastable)
 
     for var in aesara.graph.basic.vars_between(node.inputs, [result]):
         if var not in node.inputs:

--- a/aesara/tensor/nnet/opt.py
+++ b/aesara/tensor/nnet/opt.py
@@ -164,8 +164,7 @@ def local_abstractconv_gradweight_gemm(fgraph, node):
     if node.op.filter_flip:
         flip = (slice(None),) * (rval.ndim - 2) + (slice(None, None, -1),) * 2
         rval = rval[flip]
-    rval = aesara.tensor.patternbroadcast(rval, node.outputs[0].broadcastable)
-    copy_stack_trace(node.outputs[0], rval)
+        copy_stack_trace(node.outputs[0], rval)
 
     return [rval]
 
@@ -193,8 +192,7 @@ def local_abstractconv3d_gradweight_gemm(fgraph, node):
     # need to flip the kernel if necessary
     if node.op.filter_flip:
         rval = rval[:, :, ::-1, ::-1, ::-1]
-    rval = aesara.tensor.patternbroadcast(rval, node.outputs[0].broadcastable)
-    copy_stack_trace(node.outputs[0], rval)
+        copy_stack_trace(node.outputs[0], rval)
 
     return [rval]
 
@@ -393,10 +391,8 @@ def local_conv2d_gradweight_cpu(fgraph, node):
     if node.op.border_mode == "valid":
         res = res.dimshuffle((1, 0, 2, 3))
         res = res[:, :, ::-1, ::-1]
+        copy_stack_trace(node.outputs[0], res)
 
-    res = aesara.tensor.patternbroadcast(res, node.outputs[0].broadcastable)
-
-    copy_stack_trace(node.outputs[0], res)
     return [res]
 
 
@@ -484,8 +480,6 @@ def local_conv2d_gradinputs_cpu(fgraph, node):
         direction_hint="bprop inputs",
     )
     din = din(topgrad, filters)
-    copy_stack_trace(node.outputs[0], din)
-    din = aesara.tensor.patternbroadcast(din, node.outputs[0].broadcastable)
     copy_stack_trace(node.outputs[0], din)
     return [din]
 

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -1922,6 +1922,9 @@ class TestDot:
         # These examples should all work.  All dimensions of all results have
         # size 1.
         #
+        def is_super_shape(var1, var2):
+            # Check that var1.type is a superset of var2.type, ignoring dtype
+            return var1.type.is_super(var2.type.clone(dtype=var1.type.dtype))
 
         for dtype0 in ("float32", "float64", "complex64"):
             for dtype1 in ("float32", "complex64", "complex128"):
@@ -1948,9 +1951,9 @@ class TestDot:
 
                         if dtype0.startswith("float") and dtype1.startswith("float"):
                             g = grad(z.sum(), x)
-                            assert g.broadcastable == x.broadcastable
+                            assert is_super_shape(x, g)
                             g = grad(z.sum(), y)
-                            assert g.broadcastable == y.broadcastable
+                            assert is_super_shape(y, g)
 
 
 class TestTensordot:

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -1922,32 +1922,6 @@ class TestDot:
         # These examples should all work.  All dimensions of all results have
         # size 1.
         #
-        def val_for(r):
-            if r.dtype.startswith("complex"):
-                # We want to test complex at the same time, so we give a value
-                # to the imaginary component.
-                # This strange way of doing things is the only way that worked
-                # on NumPy 1.4.1.
-                if r.ndim == 0:
-                    return np.asarray(np.complex(1.1, 2.1), dtype=r.dtype)
-                if r.ndim == 1:
-                    if r.dtype == "complex64":
-                        return np.complex64([np.complex(1.2, 2.2)])
-                    elif r.dtype == "complex128":
-                        return np.complex128([np.complex(1.2, 2.2)])
-                elif r.ndim == 2:
-                    if r.dtype == "complex64":
-                        return np.complex64([[np.complex(1.3, 2.3)]])
-                    elif r.dtype == "complex128":
-                        return np.complex128([[np.complex(1.3, 2.3)]])
-
-            if r.ndim == 0:
-                return np.asarray(1.1, dtype=r.dtype)
-            if r.ndim == 1:
-                return np.asarray([1.2], dtype=r.dtype)
-            elif r.ndim == 2:
-                return np.asarray([[1.3]], dtype=r.dtype)
-            raise AssertionError()
 
         for dtype0 in ("float32", "float64", "complex64"):
             for dtype1 in ("float32", "complex64", "complex128"):

--- a/tests/tensor/test_opt_uncanonicalize.py
+++ b/tests/tensor/test_opt_uncanonicalize.py
@@ -19,7 +19,7 @@ from aesara.tensor.opt_uncanonicalize import (
     local_dimshuffle_subtensor,
     local_reshape_dimshuffle,
 )
-from aesara.tensor.shape import reshape
+from aesara.tensor.shape import reshape, specify_shape
 from aesara.tensor.type import dtensor4, iscalar, matrix, tensor, vector
 from tests.link.test_link import make_function
 
@@ -179,7 +179,7 @@ def test_local_dimshuffle_subtensor():
     dimshuffle_subtensor = out2in(local_dimshuffle_subtensor)
 
     x = dtensor4("x")
-    x = at.patternbroadcast(x, (False, True, False, False))
+    x = specify_shape(x, (None, 1, None, None))
     i = iscalar("i")
 
     out = x[:, :, 10:30, ::i].dimshuffle(0, 2, 3)
@@ -213,7 +213,7 @@ def test_local_dimshuffle_subtensor():
 
     # Test a corner case that had Aesara return a bug.
     x = dtensor4("x")
-    x = at.patternbroadcast(x, (False, True, False, False))
+    x = specify_shape(x, (None, 1, None, None))
 
     assert x[:, :, 0:3, ::-1].dimshuffle(0, 2, 3).eval(
         {x: np.ones((5, 1, 6, 7))}


### PR DESCRIPTION
This is a spinoff from #915 

This makes sure that direct calls to `patternbroadcast` in the library were not being done in order to `unbroadcast` inputs but only to specialize static shapes (i.e., to `addbroadcast`s). Such behavior is well supported by `SpecifyShape`. 

It's possible that some of the `specify_shape` used to replace `patternbroadcast` could be even more precise (i.e., not limited to broadcastable/or not), but that would require a bit more careful investigation.

This is related to #651 and #748, in that it removes one source of `Rebroadcast` in the graphs