### PR TITLE
Add `kwargs` to `OpFromGraph`s constructed in `OpFromGraph.make_node`

### DIFF
--- a/aesara/compile/builders.py
+++ b/aesara/compile/builders.py
@@ -811,6 +811,7 @@ class OpFromGraph(Op, HasInnerGraph):
                 rop_overrides=self.rop_overrides,
                 connection_pattern=self._connection_pattern,
                 name=self.name,
+                **self.kwargs,
             )
             new_inputs = (
                 list(non_shared_inputs) + unshared_inputs + new_op.shared_inputs

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -465,7 +465,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         x = at.scalar("x")
         y = shared(1.0, name="y")
 
-        test_ofg = OpFromGraph([x], [x + y])
+        test_ofg = OpFromGraph([x], [x + y], on_unused_input="ignore")
         assert test_ofg.inputs == [x]
         assert test_ofg.shared_inputs == [y]
 
@@ -477,6 +477,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
 
         out_new = test_ofg.make_node(*(out.owner.inputs[:1] + [y_clone])).outputs[0]
 
+        assert "on_unused_input" in out_new.owner.op.kwargs
         assert out_new.owner.op.inputs == [x]
         assert out_new.owner.op.shared_inputs == [y_clone]
 


### PR DESCRIPTION
This PR fixes an issue caused by not copying the `OpFromGraph.kwargs` values to newly created `OpFromGraph` `Op`s produced by `OpFromGraph.make_node`.