### PR TITLE
Fix a type consistency issue in `Apply.clone_with_new_inputs`

### DIFF
--- a/aesara/graph/basic.py
+++ b/aesara/graph/basic.py
@@ -249,10 +249,14 @@ class Apply(Node):
         for i, (curr, new) in enumerate(zip(self.inputs, new_inputs)):
             if curr.type != new.type:
                 if strict:
-                    # If compatible, casts new into curr.type
-                    new_inputs[i] = curr.type.filter_variable(new)
+                    new_i = curr.type.filter_variable(new)
+                    new_inputs[i] = new_i
+
+                    if curr.type != new_i.type:
+                        remake_node = True
                 else:
                     remake_node = True
+
         if remake_node:
             new_node = self.op.make_node(*new_inputs)
             new_node.tag = copy(self.tag).__update__(new_node.tag)

--- a/aesara/graph/type.py
+++ b/aesara/graph/type.py
@@ -56,12 +56,18 @@ class Type(MetaObject):
         return False
 
     def is_super(self, otype: "Type") -> Optional[bool]:
-        """Determine if `self` represents a superset of the types represented by `otype`.
+        """Determine if `self` is a supertype of `otype`.
 
-        See `Type.in_same_class`.
+        This method effectively implements the type relation ``>``.
 
         In general, ``t1.is_super(t2) == True`` implies that ``t1`` can be
         replaced with ``t2``.
+
+        See `Type.in_same_class`.
+
+        Returns
+        -------
+        ``None`` if the type relation cannot be applied/determined.
 
         """
         if self.in_same_class(otype):


### PR DESCRIPTION
This PR fixes a bug in `Apply.clone_with_new_inputs` that prevents the method from computing a new output `Type` when the input `Type`s change.  This bug causes graph cloning (e.g. via `aesara.graph.basic.clone_get_equiv`) to produce inconsistent `Apply` nodes.