### PR TITLE
Fix `ScipyRandomVariable` issue when `size` is `None` and parameters are all broadcastable

### DIFF
--- a/aesara/tensor/random/basic.py
+++ b/aesara/tensor/random/basic.py
@@ -57,7 +57,7 @@ class ScipyRandomVariable(RandomVariable):
         if np.ndim(res) == 0:
             # The sample is an `np.number`, and is not writeable, or non-NumPy
             # type, so we need to clone/create a usable NumPy result
-            return np.asarray(res)
+            res = np.asarray(res)
 
         if size is None:
             # SciPy will sometimes drop broadcastable dimensions; we need to

--- a/tests/tensor/random/test_basic.py
+++ b/tests/tensor/random/test_basic.py
@@ -787,6 +787,11 @@ def test_hypergeometric_samples(ngood, nbad, nsample, size):
     "loc, scale, size",
     [
         (np.array(10, dtype=config.floatX), np.array(0.1, dtype=config.floatX), None),
+        (
+            np.array([[0]], dtype=config.floatX),
+            np.array([[1]], dtype=config.floatX),
+            None,
+        ),
         (np.array(10, dtype=config.floatX), np.array(0.1, dtype=config.floatX), []),
         (np.array(10, dtype=config.floatX), np.array(0.1, dtype=config.floatX), [2, 3]),
         (


### PR DESCRIPTION
This PR fixes an issue that prevents `ScipyRandomVariable` from un-squeezing SciPy sample results.