### PR TITLE
Use `SeedSequence` in `RandomStream`

### DIFF
--- a/aesara/compile/nanguardmode.py
+++ b/aesara/compile/nanguardmode.py
@@ -30,12 +30,13 @@ def _is_numeric_value(arr, var):
 
     """
     from aesara.link.c.type import _cdata_type
+    from aesara.tensor.random.type import RandomType
 
     if isinstance(arr, _cdata_type):
         return False
     elif isinstance(arr, (np.random.mtrand.RandomState, np.random.Generator)):
         return False
-    elif var and getattr(var.tag, "is_rng", False):
+    elif var and isinstance(var.type, RandomType):
         return False
     elif isinstance(arr, slice):
         return False

--- a/aesara/sandbox/rng_mrg.py
+++ b/aesara/sandbox/rng_mrg.py
@@ -926,8 +926,6 @@ class MRG_RandomStream:
             size=size,
             nstreams=orig_nstreams,
         )
-        # Add a reference to distinguish from other shared variables
-        node_rstate.tag.is_rng = True
         r = u * (high - low) + low
 
         if u.type.broadcastable != r.type.broadcastable:

--- a/doc/library/tensor/random/utils.rst
+++ b/doc/library/tensor/random/utils.rst
@@ -12,16 +12,20 @@
 Guide
 =====
 
-Since Aesara uses a functional design, producing pseudo-random numbers in a
-graph is not quite as straightforward as it is in numpy.
+Aesara assignes NumPy RNG states (e.g. `Generator` or `RandomState` objects) to
+each `RandomVariable`.  The combination of an RNG state, a specific
+`RandomVariable` type (e.g. `NormalRV`), and a set of distribution parameters
+uniquely defines the `RandomVariable` instances in a graph.
 
-The way to think about putting randomness into Aesara's computations is to
-put random variables in your graph.  Aesara will allocate a numpy RandomState
-object for each such variable, and draw from it as necessary.  We will call this sort of sequence of
-random numbers a *random stream*.
+This means that a "stream" of distinct RNG states is required in order to
+produce distinct random variables of the same kind.  `RandomStream` provides a
+means of generating distinct random variables in a fully reproducible way.
 
-For an example of how to use random numbers, see
-:ref:`Using Random Numbers <using_random_numbers>`.
+`RandomStream` is also designed to produce simpler graphs and work with more
+sophisticated `Op`\s like `Scan`, which makes it the de facto random variable
+interface in Aesara.
+
+For an example of how to use random numbers, see :ref:`Using Random Numbers <using_random_numbers>`.
 
 
 Reference
@@ -29,7 +33,7 @@ Reference
 
 .. class:: RandomStream()
 
-    This is a symbolic stand-in for ``numpy.random.RandomState``.
+    This is a symbolic stand-in for `numpy.random.Generator`.
 
     .. method:: updates()
 
@@ -37,7 +41,8 @@ Reference
           random variables created by this object
 
         This can be a convenient shortcut to enumerating all the random
-        variables in a large graph in the ``update`` parameter of function.
+        variables in a large graph in the ``update`` argument to
+        `aesara.function`.
 
     .. method:: seed(meta_seed)
 
@@ -49,9 +54,7 @@ Reference
 
     .. method:: gen(op, *args, **kwargs)
 
-        Return the random variable from `op(*args, **kwargs)`, but
-        also install special attributes (``.rng`` and ``update``, see
-        :class:`RandomVariable` ) into it.
+        Return the random variable from ``op(*args, **kwargs)``.
 
         This function also adds the returned variable to an internal list so
         that it can be seeded later by a call to `seed`.

--- a/tests/sandbox/test_rng_mrg.py
+++ b/tests/sandbox/test_rng_mrg.py
@@ -507,7 +507,7 @@ def test_normal0():
 
         sys.stdout.flush()
 
-        RR = RandomStream(234)
+        RR = RandomStream(235)
 
         nn = RR.normal(avg, std, size=size)
         ff = function(var_input, nn)

--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -888,8 +888,9 @@ class TestScan:
         )
         my_f = function([], values, updates=updates, allow_input_downcast=True)
 
-        rng_seed = np.random.default_rng(utt.fetch_seed()).integers(2**30)
-        rng = np.random.default_rng(int(rng_seed))  # int() is for 32bit
+        rng_seed = np.random.SeedSequence(utt.fetch_seed())
+        (rng_seed,) = rng_seed.spawn(1)
+        rng = aesara_rng.rng_ctor(rng_seed)
 
         numpy_v = np.zeros((10, 2))
         for i in range(10):
@@ -2698,12 +2699,10 @@ class TestExamples:
             [vsample], aesara_vsamples[-1], updates=updates, allow_input_downcast=True
         )
 
-        _rng = np.random.default_rng(utt.fetch_seed())
-        rng_seed = _rng.integers(2**30)
-        nrng1 = np.random.default_rng(int(rng_seed))  # int() is for 32bit
-
-        rng_seed = _rng.integers(2**30)
-        nrng2 = np.random.default_rng(int(rng_seed))  # int() is for 32bit
+        rng_seed = np.random.SeedSequence(utt.fetch_seed())
+        (rng_seed_1, rng_seed_2) = rng_seed.spawn(2)
+        nrng1 = trng.rng_ctor(rng_seed_1)
+        nrng2 = trng.rng_ctor(rng_seed_2)
 
         def numpy_implementation(vsample):
             for idx in range(10):

--- a/tests/tensor/random/test_utils.py
+++ b/tests/tensor/random/test_utils.py
@@ -119,8 +119,9 @@ class TestSharedRandomStream:
         fn_val0 = fn()
         fn_val1 = fn()
 
-        rng_seed = np.random.default_rng(utt.fetch_seed()).integers(2**30)
-        rng = rng_ctor(int(rng_seed))  # int() is for 32bit
+        rng_seed = np.random.SeedSequence(utt.fetch_seed())
+        (rng_seed,) = rng_seed.spawn(1)
+        rng = random.rng_ctor(rng_seed)
 
         numpy_val0 = rng.uniform(0, 1, size=(2, 2))
         numpy_val1 = rng.uniform(0, 1, size=(2, 2))
@@ -133,26 +134,18 @@ class TestSharedRandomStream:
         init_seed = 234
         random = RandomStream(init_seed, rng_ctor=rng_ctor)
 
-        ref_state = np.random.default_rng(init_seed).__getstate__()
-        random_state = random.gen_seedgen.__getstate__()
         assert random.default_instance_seed == init_seed
-        assert random_state["bit_generator"] == ref_state["bit_generator"]
-        assert random_state["state"] == ref_state["state"]
 
         new_seed = 43298
         random.seed(new_seed)
 
-        ref_state = np.random.default_rng(new_seed).__getstate__()
-        random_state = random.gen_seedgen.__getstate__()
-        assert random_state["bit_generator"] == ref_state["bit_generator"]
-        assert random_state["state"] == ref_state["state"]
+        rng_seed = np.random.SeedSequence(new_seed)
+        assert random.gen_seedgen.entropy == rng_seed.entropy
 
         random.seed()
-        ref_state = np.random.default_rng(init_seed).__getstate__()
-        random_state = random.gen_seedgen.__getstate__()
-        assert random.default_instance_seed == init_seed
-        assert random_state["bit_generator"] == ref_state["bit_generator"]
-        assert random_state["state"] == ref_state["state"]
+
+        rng_seed = np.random.SeedSequence(init_seed)
+        assert random.gen_seedgen.entropy == rng_seed.entropy
 
         # Reset the seed
         random.seed(new_seed)
@@ -163,8 +156,9 @@ class TestSharedRandomStream:
         # Now, change the seed when there are state updates
         random.seed(new_seed)
 
-        update_seed = np.random.default_rng(new_seed).integers(2**30)
-        ref_rng = rng_ctor(update_seed)
+        update_seed = np.random.SeedSequence(new_seed)
+        (update_seed,) = update_seed.spawn(1)
+        ref_rng = random.rng_ctor(update_seed)
         state_rng = random.state_updates[0][0].get_value(borrow=True)
 
         if hasattr(state_rng, "get_state"):
@@ -188,8 +182,10 @@ class TestSharedRandomStream:
         fn_val0 = fn()
         fn_val1 = fn()
 
-        rng_seed = np.random.default_rng(utt.fetch_seed()).integers(2**30)
-        rng = rng_ctor(int(rng_seed))  # int() is for 32bit
+        rng_seed = np.random.SeedSequence(utt.fetch_seed())
+        (rng_seed,) = rng_seed.spawn(1)
+
+        rng = random.rng_ctor(rng_seed)
         numpy_val0 = rng.uniform(-1, 1, size=(2, 2))
         numpy_val1 = rng.uniform(-1, 1, size=(2, 2))
 

--- a/tests/tensor/random/test_utils.py
+++ b/tests/tensor/random/test_utils.py
@@ -97,7 +97,6 @@ class TestSharedRandomStream:
         assert np.all(f() != f())
         assert np.all(g() == g())
         assert np.all(abs(nearly_zeros()) < 1e-5)
-        assert isinstance(rv_u.rng.get_value(borrow=True), np.random.Generator)
 
     @pytest.mark.parametrize("rng_ctor", [np.random.RandomState, np.random.default_rng])
     def test_basics(self, rng_ctor):
@@ -109,8 +108,7 @@ class TestSharedRandomStream:
         with pytest.raises(AttributeError):
             random.blah
 
-        # test if standard_normal is available in the namespace, See: GH issue #528
-        random.standard_normal
+        assert hasattr(random, "standard_normal")
 
         with pytest.raises(AttributeError):
             np_random = RandomStream(namespace=np, rng_ctor=rng_ctor)
@@ -223,7 +221,7 @@ class TestSharedRandomStream:
         # Explicit updates #2
         random_c = RandomStream(utt.fetch_seed(), rng_ctor=rng_ctor)
         out_c = random_c.uniform(0, 1, size=(2, 2))
-        fn_c = function([], out_c, updates=[out_c.update])
+        fn_c = function([], out_c, updates=random_c.state_updates)
         fn_c_val0 = fn_c()
         fn_c_val1 = fn_c()
         assert np.all(fn_c_val0 == fn_a_val0)
@@ -241,7 +239,7 @@ class TestSharedRandomStream:
         # No updates for out
         random_e = RandomStream(utt.fetch_seed(), rng_ctor=rng_ctor)
         out_e = random_e.uniform(0, 1, size=(2, 2))
-        fn_e = function([], out_e, no_default_updates=[out_e.rng])
+        fn_e = function([], out_e, no_default_updates=[random_e.state_updates[0][0]])
         fn_e_val0 = fn_e()
         fn_e_val1 = fn_e()
         assert np.all(fn_e_val0 == fn_a_val0)


### PR DESCRIPTION
This PR closes #936 and removes the old/deprecated attributes that `RandomStream` adds to the variables it generates (e.g. `.rng`, `.update`).