### PR TITLE
Add `Scan` input/output type annotations to `debugprint` output

### DIFF
--- a/aesara/printing.py
+++ b/aesara/printing.py
@@ -116,6 +116,8 @@ def debugprint(
     print_storage: bool = False,
     used_ids: Optional[Dict[Variable, str]] = None,
     print_op_info: bool = False,
+    print_destroy_map: bool = False,
+    print_view_map: bool = False,
 ) -> Union[str, IOBase]:
     r"""Print a computation graph as text to stdout or a file.
 
@@ -169,6 +171,10 @@ def debugprint(
     print_op_info
         Print extra information provided by the relevant `Op`\s.  For example,
         print the tap information for `Scan` inputs and outputs.
+    print_destroy_map
+        Whether to print the `destroy_map`\s of printed objects
+    print_view_map
+        Whether to print the `view_map`\s of printed objects
 
     Returns
     -------
@@ -286,6 +292,8 @@ N.B.:
             op_information=op_information,
             parent_node=r.owner,
             print_op_info=print_op_info,
+            print_destroy_map=print_destroy_map,
+            print_view_map=print_view_map,
         )
 
     if len(inner_graph_ops) > 0:
@@ -340,6 +348,8 @@ N.B.:
                 op_information=op_information,
                 parent_node=s.owner,
                 print_op_info=print_op_info,
+                print_destroy_map=print_destroy_map,
+                print_view_map=print_view_map,
             )
 
             for idx, i in enumerate(inner_outputs):
@@ -363,6 +373,8 @@ N.B.:
                     op_information=op_information,
                     parent_node=s.owner,
                     print_op_info=print_op_info,
+                    print_destroy_map=print_destroy_map,
+                    print_view_map=print_view_map,
                 )
 
     if file is _file:
@@ -507,21 +519,15 @@ def _debugprint(
         if r_name:
             r_name = f" '{r_name}'"
 
-        if print_destroy_map:
-            destroy_map_str = str(r.owner.op.destroy_map)
+        if print_destroy_map and r.owner.op.destroy_map:
+            destroy_map_str = f" d={r.owner.op.destroy_map}"
         else:
             destroy_map_str = ""
 
-        if print_view_map:
-            view_map_str = str(r.owner.op.view_map)
+        if print_view_map and r.owner.op.view_map:
+            view_map_str = f" v={r.owner.op.view_map}"
         else:
             view_map_str = ""
-
-        if destroy_map_str and destroy_map_str != "{}":
-            destroy_map_str = f" d={destroy_map_str} "
-
-        if view_map_str and view_map_str != "{}":
-            view_map_str = f" v={view_map_str} "
 
         if order:
             o = f" {order.index(r.owner)}"
@@ -607,6 +613,8 @@ def _debugprint(
                     op_information=op_information,
                     parent_node=a,
                     print_op_info=print_op_info,
+                    print_destroy_map=print_destroy_map,
+                    print_view_map=print_view_map,
                 )
     else:
 

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -544,17 +544,17 @@ def test_debugprint():
     output_str = debugprint(out, file="str")
     lines = output_str.split("\n")
 
-    exp_res = """OpFromGraph{inline=False} [id A] ''
+    exp_res = """OpFromGraph{inline=False} [id A]
  |x [id B]
  |y [id C]
  |z [id D]
 
 Inner graphs:
 
-OpFromGraph{inline=False} [id A] ''
- >Elemwise{add,no_inplace} [id E] ''
+OpFromGraph{inline=False} [id A]
+ >Elemwise{add,no_inplace} [id E]
  > |x [id F]
- > |Elemwise{mul,no_inplace} [id G] ''
+ > |Elemwise{mul,no_inplace} [id G]
  >   |y [id H]
  >   |z [id I]
 """

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -141,11 +141,11 @@ def test_debugprint():
     reference = (
         "\n".join(
             [
-                "Elemwise{add,no_inplace} [id 0] ''   ",
-                " |Elemwise{add,no_inplace} [id 1] 'C'   ",
+                "Elemwise{add,no_inplace} [id 0]",
+                " |Elemwise{add,no_inplace} [id 1] 'C'",
                 " | |A [id 2]",
                 " | |B [id 3]",
-                " |Elemwise{add,no_inplace} [id 4] ''   ",
+                " |Elemwise{add,no_inplace} [id 4]",
                 "   |D [id 5]",
                 "   |E [id 6]",
             ]
@@ -167,11 +167,11 @@ def test_debugprint():
     reference = (
         "\n".join(
             [
-                "Elemwise{add,no_inplace} [id A] ''   ",
-                " |Elemwise{add,no_inplace} [id B] 'C'   ",
+                "Elemwise{add,no_inplace} [id A]",
+                " |Elemwise{add,no_inplace} [id B] 'C'",
                 " | |A [id C]",
                 " | |B [id D]",
-                " |Elemwise{add,no_inplace} [id E] ''   ",
+                " |Elemwise{add,no_inplace} [id E]",
                 "   |D [id F]",
                 "   |E [id G]",
             ]
@@ -193,9 +193,9 @@ def test_debugprint():
     reference = (
         "\n".join(
             [
-                "Elemwise{add,no_inplace} [id A] ''   ",
-                " |Elemwise{add,no_inplace} [id B] 'C'   ",
-                " |Elemwise{add,no_inplace} [id C] ''   ",
+                "Elemwise{add,no_inplace} [id A]",
+                " |Elemwise{add,no_inplace} [id B] 'C'",
+                " |Elemwise{add,no_inplace} [id C]",
                 "   |D [id D]",
                 "   |E [id E]",
             ]
@@ -217,13 +217,13 @@ def test_debugprint():
     reference = (
         "\n".join(
             [
-                "Elemwise{add,no_inplace}  ''   ",
-                " |Elemwise{add,no_inplace}  'C'   ",
-                " | |A ",
-                " | |B ",
-                " |Elemwise{add,no_inplace}  ''   ",
-                "   |D ",
-                "   |E ",
+                "Elemwise{add,no_inplace}",
+                " |Elemwise{add,no_inplace} 'C'",
+                " | |A",
+                " | |B",
+                " |Elemwise{add,no_inplace}",
+                "   |D",
+                "   |E",
             ]
         )
         + "\n"
@@ -238,15 +238,14 @@ def test_debugprint():
     s = StringIO()
     debugprint(g, file=s, ids="", print_storage=True)
     s = s.getvalue()
-    # The additional white space are needed!
     reference = (
         "\n".join(
             [
-                "Elemwise{add,no_inplace}  ''   0 [None]",
-                " |A  [None]",
-                " |B  [None]",
-                " |D  [None]",
-                " |E  [None]",
+                "Elemwise{add,no_inplace} 0 [None]",
+                " |A [None]",
+                " |B [None]",
+                " |D [None]",
+                " |E [None]",
             ]
         )
         + "\n"
@@ -269,8 +268,8 @@ def test_debugprint_ids():
     debugprint(e_at, ids="auto", file=s)
     s = s.getvalue()
 
-    exp_res = f"""Elemwise{{add,no_inplace}} [id {e_at.auto_name}] ''
- |dot [id {d_at.auto_name}] ''
+    exp_res = f"""Elemwise{{add,no_inplace}} [id {e_at.auto_name}]
+ |dot [id {d_at.auto_name}]
  | |<TensorType(float64, (None, None))> [id {b_at.auto_name}]
  | |<TensorType(float64, (None,))> [id {a_at.auto_name}]
  |<TensorType(float64, (None,))> [id {a_at.auto_name}]
@@ -306,13 +305,13 @@ def test_debugprint_inner_graph():
     output_str = debugprint(out, file="str")
     lines = output_str.split("\n")
 
-    exp_res = """MyInnerGraphOp [id A] ''
+    exp_res = """MyInnerGraphOp [id A]
  |3 [id B]
  |4 [id C]
 
 Inner graphs:
 
-MyInnerGraphOp [id A] ''
+MyInnerGraphOp [id A]
  >op2 [id D] 'igo1'
  > |4 [id E]
  > |5 [id F]
@@ -330,17 +329,17 @@ MyInnerGraphOp [id A] ''
     output_str = debugprint(out_2, file="str")
     lines = output_str.split("\n")
 
-    exp_res = """MyInnerGraphOp [id A] ''
+    exp_res = """MyInnerGraphOp [id A]
  |5 [id B]
 
 Inner graphs:
 
-MyInnerGraphOp [id A] ''
- >MyInnerGraphOp [id C] ''
+MyInnerGraphOp [id A]
+ >MyInnerGraphOp [id C]
  > |3 [id D]
  > |4 [id E]
 
-MyInnerGraphOp [id C] ''
+MyInnerGraphOp [id C]
  >op2 [id F] 'igo1'
  > |4 [id G]
  > |5 [id H]
@@ -371,13 +370,13 @@ def test_get_var_by_id():
     # op1 [id A] 'o1'
     #  |1 [id B]
     #  |2 [id C]
-    # MyInnerGraphOp [id D] ''
+    # MyInnerGraphOp [id D]
     #  |3 [id E]
     #  |op1 [id A] 'o1'
     #
     # Inner graphs:
     #
-    # MyInnerGraphOp [id D] ''
+    # MyInnerGraphOp [id D]
     #  >op2 [id F] 'igo1'
     #  > |4 [id G]
     #  > |5 [id H]

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -153,10 +153,6 @@ def test_debugprint():
         + "\n"
     )
 
-    if s != reference:
-        print("--" + s + "--")
-        print("--" + reference + "--")
-
     assert s == reference
 
     # test ids=CHAR
@@ -179,10 +175,6 @@ def test_debugprint():
         + "\n"
     )
 
-    if s != reference:
-        print("--" + s + "--")
-        print("--" + reference + "--")
-
     assert s == reference
 
     # test ids=CHAR, stop_on_name=True
@@ -202,10 +194,6 @@ def test_debugprint():
         )
         + "\n"
     )
-
-    if s != reference:
-        print("--" + s + "--")
-        print("--" + reference + "--")
 
     assert s == reference
 
@@ -228,9 +216,6 @@ def test_debugprint():
         )
         + "\n"
     )
-    if s != reference:
-        print("--" + s + "--")
-        print("--" + reference + "--")
 
     assert s == reference
 
@@ -250,11 +235,39 @@ def test_debugprint():
         )
         + "\n"
     )
-    if s != reference:
-        print("--" + s + "--")
-        print("--" + reference + "--")
 
     assert s == reference
+
+    A = dmatrix(name="A")
+    B = dmatrix(name="B")
+    D = dmatrix(name="D")
+    J = dvector()
+    s = StringIO()
+    debugprint(
+        aesara.function([A, B, D, J], A + (B.dot(J) - D), mode="FAST_RUN"),
+        file=s,
+        ids="",
+        print_destroy_map=True,
+        print_view_map=True,
+    )
+    s = s.getvalue()
+    exp_res = r"""Elemwise{Composite{(i0 + (i1 - i2))}} 4
+ |A
+ |InplaceDimShuffle{x,0} v={0: [0]} 3
+ | |CGemv{inplace} d={0: [0]} 2
+ |   |AllocEmpty{dtype='float64'} 1
+ |   | |Shape_i{0} 0
+ |   |   |B
+ |   |TensorConstant{1.0}
+ |   |B
+ |   |<TensorType(float64, (None,))>
+ |   |TensorConstant{0.0}
+ |D
+    """
+
+    assert [l.strip() for l in s.split("\n")] == [
+        l.strip() for l in exp_res.split("\n")
+    ]
 
 
 def test_debugprint_ids():


### PR DESCRIPTION
Closes #945

Here are the results of printing a somewhat complicated `Scan` under these changes:
```python

Sum{acc_dtype=float64} [id A]
 |for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
 |Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
 | |Subtensor{int64} [id D]
 | | |Shape [id E]
 | | | |Subtensor{int64::} [id F] 'coefficients[0:]'
 | | |   |coefficients [id G]
 | | |   |ScalarConstant{0} [id H]
 | | |ScalarConstant{0} [id I]
 | |Subtensor{int64} [id J]
 |   |Shape [id K]
 |   | |Subtensor{int64::} [id L]
 |   |   |ARange{dtype='int64'} [id M]
 |   |   | |TensorConstant{0} [id N]
 |   |   | |TensorConstant{10} [id O]
 |   |   | |TensorConstant{1} [id P]
 |   |   |ScalarConstant{0} [id Q]
 |   |ScalarConstant{0} [id R]
 |Subtensor{:int64:} [id S] (outer_in_seqs-0)
 | |Subtensor{int64::} [id F] 'coefficients[0:]'
 | |ScalarFromTensor [id T]
 |   |Elemwise{scalar_minimum,no_inplace} [id C]
 |Subtensor{:int64:} [id U] (outer_in_seqs-1)
 | |Subtensor{int64::} [id L]
 | |ScalarFromTensor [id V]
 |   |Elemwise{scalar_minimum,no_inplace} [id C]
 |Elemwise{scalar_minimum,no_inplace} [id C] (outer_in_nit_sot-0)
 |A [id W] (outer_in_non_seqs-0)
 |k [id X] (outer_in_non_seqs-1)
 
 Inner graphs:
 
 for{cpu,scan_fn} [id B] (outer_out_nit_sot-0)
 >Elemwise{mul,no_inplace} [id Y] (inner_out_nit_sot-0)
 > |InplaceDimShuffle{x} [id Z]
 > | |coefficients[t] [id BA] -> [id S] (inner_in_seqs-0)
 > |Elemwise{pow,no_inplace} [id BB]
 >   |Subtensor{int64} [id BC]
 >   | |Subtensor{int64::} [id BD]
 >   | | |for{cpu,scan_fn} [id BE] (outer_out_sit_sot-0)
 >   | | | |k_copy [id BF] -> [id X] (inner_in_non_seqs-1) (n_steps)
 >   | | | |IncSubtensor{Set;:int64:} [id BG] (outer_in_sit_sot-0)
 >   | | | | |AllocEmpty{dtype='float64'} [id BH]
 >   | | | | | |Elemwise{add,no_inplace} [id BI]
 >   | | | | | | |k_copy [id BF] -> [id X] (inner_in_non_seqs-1)
 >   | | | | | | |Subtensor{int64} [id BJ]
 >   | | | | | |   |Shape [id BK]
 >   | | | | | |   | |Rebroadcast{(0, False)} [id BL]
 >   | | | | | |   |   |InplaceDimShuffle{x,0} [id BM]
 >   | | | | | |   |     |Elemwise{second,no_inplace} [id BN]
 >   | | | | | |   |       |A_copy [id BO] -> [id W] (inner_in_non_seqs-0)
 >   | | | | | |   |       |InplaceDimShuffle{x} [id BP]
 >   | | | | | |   |         |TensorConstant{1.0} [id BQ]
 >   | | | | | |   |ScalarConstant{0} [id BR]
 >   | | | | | |Subtensor{int64} [id BS]
 >   | | | | |   |Shape [id BT]
 >   | | | | |   | |Rebroadcast{(0, False)} [id BL]
 >   | | | | |   |ScalarConstant{1} [id BU]
 >   | | | | |Rebroadcast{(0, False)} [id BL]
 >   | | | | |ScalarFromTensor [id BV]
 >   | | | |   |Subtensor{int64} [id BJ]
 >   | | | |A_copy [id BO] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
 >   | | |ScalarConstant{1} [id BW]
 >   | |ScalarConstant{-1} [id BX]
 >   |InplaceDimShuffle{x} [id BY]
 >     |<TensorType(int64, ())> [id BZ] -> [id U] (inner_in_seqs-1)
 
 for{cpu,scan_fn} [id BE] (outer_out_sit_sot-0)
 >Elemwise{mul,no_inplace} [id CA] (inner_out_sit_sot-0)
 > |<TensorType(float64, (None,))> [id CB] -> [id BG] (inner_in_sit_sot-0)
 > |A_copy [id CC] -> [id BO] (inner_in_non_seqs-0)
```

- [x] Decouple/remove the `Scan`-specific code from `aesara.printing`
  - We could add a dispatch function&mdash;based on the `Op`&mdash;that computes the `extra_information` used by this new feature.