### PR TITLE
Update `np.random` usage, improve test seeding, and other misc. refactoring

### DIFF
--- a/aesara/compile/builders.py
+++ b/aesara/compile/builders.py
@@ -146,7 +146,7 @@ class OpFromGraph(Op, HasInnerGraph):
         from aesara.compile.builders import OpFromGraph
 
         x, y, z = at.scalars('xyz')
-        s = aesara.shared(np.random.rand(2, 2).astype(config.floatX))
+        s = aesara.shared(np.random.random((2, 2)).astype(config.floatX))
         e = x + y * z + s
         op = OpFromGraph([x, y, z], [e])
         # op behaves like a normal aesara op

--- a/aesara/configdefaults.py
+++ b/aesara/configdefaults.py
@@ -378,13 +378,6 @@ def add_basic_configvars():
         in_c_key=False,
     )
 
-    config.add(
-        "reoptimize_unpickled_function",
-        "Re-optimize the graph when an Aesara function is unpickled from the disk.",
-        BoolParam(False, mutable=True),
-        in_c_key=False,
-    )
-
 
 def _is_gt_0(x):
     return x > 0

--- a/aesara/gradient.py
+++ b/aesara/gradient.py
@@ -5,6 +5,7 @@ import time
 import warnings
 from collections import OrderedDict
 from functools import partial, reduce
+from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import numpy as np
 
@@ -16,6 +17,10 @@ from aesara.graph.basic import Variable
 from aesara.graph.null_type import NullType, null_type
 from aesara.graph.op import get_test_values
 from aesara.graph.type import Type
+
+
+if TYPE_CHECKING:
+    from aesara.compile.mode import Mode
 
 
 __docformat__ = "restructuredtext en"
@@ -684,8 +689,8 @@ def subgraph_grad(wrt, end, start=None, cost=None, details=False):
     .. code-block:: python
 
         x, t = aesara.tensor.fvector('x'), aesara.tensor.fvector('t')
-        w1 = aesara.shared(np.random.randn(3,4))
-        w2 = aesara.shared(np.random.randn(4,2))
+        w1 = aesara.shared(np.random.standard_normal((3,4)))
+        w2 = aesara.shared(np.random.standard_normal((4,2)))
         a1 = aesara.tensor.tanh(aesara.tensor.dot(x,w1))
         a2 = aesara.tensor.tanh(aesara.tensor.dot(a1,w2))
         cost2 = aesara.tensor.sqr(a2 - t).sum()
@@ -1690,17 +1695,17 @@ def mode_not_slow(mode):
 
 
 def verify_grad(
-    fun,
-    pt,
-    n_tests=2,
-    rng=None,
-    eps=None,
-    out_type=None,
-    abs_tol=None,
-    rel_tol=None,
-    mode=None,
-    cast_to_output_type=False,
-    no_debug_ref=True,
+    fun: Callable,
+    pt: List[np.ndarray],
+    n_tests: int = 2,
+    rng: Optional[Union[np.random.Generator, np.random.RandomState]] = None,
+    eps: Optional[float] = None,
+    out_type: Optional[str] = None,
+    abs_tol: Optional[float] = None,
+    rel_tol: Optional[float] = None,
+    mode: Optional[Union["Mode", str]] = None,
+    cast_to_output_type: bool = False,
+    no_debug_ref: bool = True,
 ):
     """Test a gradient by Finite Difference Method. Raise error on failure.
 
@@ -1713,47 +1718,47 @@ def verify_grad(
     --------
     >>> verify_grad(aesara.tensor.tanh,
     ...             (np.asarray([[2, 3, 4], [-1, 3.3, 9.9]]),),
-    ...             rng=np.random)
+    ...             rng=np.random.default_rng(23098))
 
     Parameters
     ----------
-    fun : a Python function
+    fun
         `fun` takes Aesara variables as inputs, and returns an Aesara variable.
-        For instance, an Op instance with  a single output.
-    pt : list of numpy.ndarrays
+        For instance, an `Op` instance with  a single output.
+    pt
         Input values, points where the gradient is estimated.
         These arrays must be either float16, float32, or float64 arrays.
-    n_tests : int
-        Number of times to run the test
-    rng : numpy.random.RandomState
+    n_tests
+        Number o to run the test.
+    rng
         Random number generator used to sample the output random projection `u`,
-        we test gradient of sum(u * fun) at `pt`
-    eps : float, optional
+        we test gradient of ``sum(u * fun)`` at `pt`.
+    eps
         Step size used in the Finite Difference Method (Default
-        None is type-dependent).
-        Raising the value of eps can raise or lower the absolute
+        ``None`` is type-dependent).
+        Raising the value of `eps` can raise or lower the absolute
         and relative errors of the verification depending on the
-        Op. Raising eps does not lower the verification quality for
+        `Op`. Raising `eps` does not lower the verification quality for
         linear operations. It is better to raise `eps` than raising
         `abs_tol` or `rel_tol`.
-    out_type : string
-        Dtype of output, if complex (i.e., 'complex32' or 'complex64')
-    abs_tol : float
+    out_type
+        Dtype of output, if complex (i.e., ``'complex32'`` or ``'complex64'``)
+    abs_tol
         Absolute tolerance used as threshold for gradient comparison
-    rel_tol : float
+    rel_tol
         Relative tolerance used as threshold for gradient comparison
-    cast_to_output_type : bool
-        If the output is float32 and cast_to_output_type is True, cast
-        the random projection to float32. Otherwise it is float64.
+    cast_to_output_type
+        If the output is float32 and `cast_to_output_type` is ``True``, cast
+        the random projection to float32; otherwise, it is float64.
         float16 is not handled here.
-    no_debug_ref : bool
-        Don't use DebugMode for the numerical gradient function.
+    no_debug_ref
+        Don't use `DebugMode` for the numerical gradient function.
 
     Notes
     -----
-    This function does not support multiple outputs. In
-    tests/scan/test_basic.py there is an experimental `verify_grad` that covers
-    that case as well by using random projections.
+    This function does not support multiple outputs. In `tests.scan.test_basic`
+    there is an experimental `verify_grad` that covers that case as well by
+    using random projections.
 
     """
     from aesara.compile.function import function

--- a/aesara/sandbox/rng_mrg.py
+++ b/aesara/sandbox/rng_mrg.py
@@ -692,9 +692,10 @@ def guess_n_streams(size, warn=False):
         if warn:
             warnings.warn(
                 (
-                    "MRG_RandomStream Can't determine #streams "
+                    "MRG_RandomStream can't determine the number ofstreams "
                     f"from size ({size}), guessing 60*256"
                 ),
+                DeprecationWarning,
                 stacklevel=3,
             )
         return 60 * 256
@@ -1106,9 +1107,10 @@ class MRG_RandomStream:
         **kwargs,
     ):
         warnings.warn(
-            "MRG_RandomStream.multinomial_wo_replacement() is "
+            "MRG_RandomStream.multinomial_wo_replacement is "
             "deprecated and will be removed in the next release of "
-            "Aesara. Please use MRG_RandomStream.choice() instead."
+            "Aesara. Please use MRG_RandomStream.choice instead.",
+            DeprecationWarning,
         )
         assert size is None
         return self.choice(

--- a/aesara/scalar/basic.py
+++ b/aesara/scalar/basic.py
@@ -2159,7 +2159,7 @@ class Mod(BinaryScalarOp):
     )
 
     def impl(self, x, y):
-        if isinstance(x, np.complex) or isinstance(y, np.complex):
+        if isinstance(x, builtins.complex) or isinstance(y, builtins.complex):
             raise self.complex_error
         return x % y
 
@@ -3936,7 +3936,7 @@ class Complex(BinaryScalarOp):
             return [complex64]
 
     def impl(self, x, y):
-        return np.complex(x, y)
+        return builtins.complex(x, y)
 
     def grad(self, inputs, gout):
         (x, y) = inputs
@@ -3979,9 +3979,9 @@ class ComplexFromPolar(BinaryScalarOp):
         x = r * np.cos(theta)
         y = r * np.sin(theta)
         if x.dtype == "float32":
-            return np.complex64(np.complex(x, y))
+            return np.complex64(builtins.complex(x, y))
         else:
-            return np.complex128(np.complex(x, y))
+            return np.complex128(builtins.complex(x, y))
 
     def grad(self, inputs, gout):
         (r, theta) = inputs

--- a/aesara/tensor/elemwise.py
+++ b/aesara/tensor/elemwise.py
@@ -320,15 +320,16 @@ class Elemwise(OpenMPOp):
 
     Notes
     -----
-    | Elemwise(add) represents + on tensors (x + y)
-    | Elemwise(add, {0 : 0}) represents the += operation (x += y)
-    | Elemwise(add, {0 : 1}) represents += on the second argument (y += x)
-    | Elemwise(mul)(rand(10, 5), rand(1, 5)) the second input is completed \
-along the first dimension to match the first input
-    | Elemwise(true_div)(rand(10, 5), rand(10, 1)) same but along the \
-second dimension
-    | Elemwise(int_div)(rand(1, 5), rand(10, 1)) the output has size (10, 5)
-    | Elemwise(log)(rand(3, 4, 5))
+    -``Elemwise(add)``: represents ``+`` on tensors ``x + y``
+    -``Elemwise(add, {0 : 0})``: represents the ``+=`` operation ``x += y``
+    -``Elemwise(add, {0 : 1})``: represents ``+=`` on the second argument ``y += x``
+    -``Elemwise(mul)(np.random.random((10, 5)), np.random.random((1, 5)))``:
+    the second input is completed along the first dimension to match the first input
+    -``Elemwise(true_div)(np.random.random(10, 5), np.random.random(10, 1))``: same but along the
+    second dimension
+    -``Elemwise(int_div)(np.random.random((1, 5)), np.random.random((10, 1)))``:
+    the output has size ``(10, 5)``.
+    -``Elemwise(log)(np.random.random((3, 4, 5)))``
 
     """
 

--- a/aesara/tensor/math.py
+++ b/aesara/tensor/math.py
@@ -1789,23 +1789,25 @@ floor_div = int_div
 
 
 def ceil_intdiv(a, b):
-    """
-    Safely compute ceil(float_division(a, b)).
+    """Safely compute ``ceil(float_division(a, b))``.
 
-    Works for all dtypes, but mostly useful when a and b are int.
+    Works for all dtypes, but mostly useful when `a` and `b` are ints.
 
     """
     # If a and b are int with not many significant bits, we could
     # cast them to float to avoid doing the modulo. We do not know if this
-    # is faster or not. But this is not safe for int64 as the cast will
-    # lose precision.
-    # e.g.: cast(cast(a, scalar.upcast(a, 'float32')) / b, aes.upcast(a, b))
+    # is faster or not. But this is not safe for int64, because the cast will
+    # lose precision. For example:
+    #     cast(cast(a, scalar.upcast(a.type.dtype, 'float32')) / b,
+    #          aes.upcast(a.type.dtype, b.type.dtype))
 
-    # We cast for the case when a and b are uint*. Otherwise neq will
+    # We cast for the case when a and b are uint*; otherwise, neq will
     # force their upcast to int.
     div = int_div(a, b)
     ret = cast(neq(a % b, 0), div.dtype) + div
-    assert ret.dtype == aes.upcast(div.owner.inputs[0], div.owner.inputs[1])
+    assert ret.dtype == aes.upcast(
+        div.owner.inputs[0].type.dtype, div.owner.inputs[1].type.dtype
+    )
     return ret
 
 

--- a/aesara/tensor/nnet/conv.py
+++ b/aesara/tensor/nnet/conv.py
@@ -107,7 +107,8 @@ def conv2d(
 
     warnings.warn(
         "aesara.tensor.nnet.conv.conv2d is deprecated."
-        " Use aesara.tensor.nnet.conv2d instead."
+        " Use aesara.tensor.nnet.conv2d instead.",
+        DeprecationWarning,
     )
 
     # accept Constant value for image_shape and filter_shape.
@@ -406,6 +407,7 @@ class ConvOp(OpenMPOp):
         warnings.warn(
             "The method `getOutputShape` is deprecated use"
             "`get_conv_output_shape` instead.",
+            DeprecationWarning,
             stacklevel=2,
         )
         return tuple(

--- a/doc/extending/extending_aesara_solution_1.py
+++ b/doc/extending/extending_aesara_solution_1.py
@@ -81,60 +81,60 @@ from aesara.tensor.type import dmatrix, matrix
 
 
 class TestProdOp(utt.InferShapeTester):
-
-    rng = np.random.RandomState(43)
-
     def setup_method(self):
         super().setup_method()
         self.op_class = ProdOp  # case 1
 
     def test_perform(self):
+        rng = np.random.default_rng(43)
         x = matrix()
         y = matrix()
         f = aesara.function([x, y], self.op_class()(x, y))
-        x_val = np.random.rand(5, 4)
-        y_val = np.random.rand(5, 4)
+        x_val = rng.random((5, 4))
+        y_val = rng.random((5, 4))
         out = f(x_val, y_val)
         assert np.allclose(x_val * y_val, out)
 
     def test_gradient(self):
+        rng = np.random.default_rng(43)
         utt.verify_grad(
             self.op_class(),
-            [np.random.rand(5, 4), np.random.rand(5, 4)],
+            [rng.random((5, 4)), rng.random((5, 4))],
             n_tests=1,
             rng=TestProdOp.rng,
         )
 
     def test_infer_shape(self):
+        rng = np.random.default_rng(43)
         x = dmatrix()
         y = dmatrix()
 
         self._compile_and_check(
             [x, y],
             [self.op_class()(x, y)],
-            [np.random.rand(5, 6), np.random.rand(5, 6)],
+            [rng.random(5, 6), rng.random((5, 6))],
             self.op_class,
         )
 
 
 class TestSumDiffOp(utt.InferShapeTester):
-
-    rng = np.random.RandomState(43)
-
     def setup_method(self):
         super().setup_method()
         self.op_class = SumDiffOp
 
     def test_perform(self):
+        rng = np.random.RandomState(43)
         x = matrix()
         y = matrix()
         f = aesara.function([x, y], self.op_class()(x, y))
-        x_val = np.random.rand(5, 4)
-        y_val = np.random.rand(5, 4)
+        x_val = rng.random((5, 4))
+        y_val = rng.random((5, 4))
         out = f(x_val, y_val)
         assert np.allclose([x_val + y_val, x_val - y_val], out)
 
     def test_gradient(self):
+        rng = np.random.RandomState(43)
+
         def output_0(x, y):
             return self.op_class()(x, y)[0]
 
@@ -143,18 +143,20 @@ class TestSumDiffOp(utt.InferShapeTester):
 
         utt.verify_grad(
             output_0,
-            [np.random.rand(5, 4), np.random.rand(5, 4)],
+            [rng.random((5, 4)), rng.random((5, 4))],
             n_tests=1,
             rng=TestSumDiffOp.rng,
         )
         utt.verify_grad(
             output_1,
-            [np.random.rand(5, 4), np.random.rand(5, 4)],
+            [rng.random((5, 4)), rng.random((5, 4))],
             n_tests=1,
             rng=TestSumDiffOp.rng,
         )
 
     def test_infer_shape(self):
+        rng = np.random.RandomState(43)
+
         x = dmatrix()
         y = dmatrix()
 
@@ -163,7 +165,7 @@ class TestSumDiffOp(utt.InferShapeTester):
         self._compile_and_check(
             [x, y],
             self.op_class()(x, y),
-            [np.random.rand(5, 6), np.random.rand(5, 6)],
+            [rng.random((5, 6)), rng.random((5, 6))],
             self.op_class,
         )
 

--- a/doc/extending/unittest.rst
+++ b/doc/extending/unittest.rst
@@ -240,22 +240,28 @@ product :class:`Op`:
 
 .. testcode::
 
-    from numpy import dot
-    from numpy.random import rand
+    import numpy as np
 
     from tests.tensor.utils import makeTester
 
-    TestDot = makeTester(name = 'DotTester',
-                         op = dot,
-                         expected = lambda x, y: numpy.dot(x, y),
-                         checks = {},
-                         good = dict(correct1 = (rand(5, 7), rand(7, 5)),
-                                     correct2 = (rand(5, 7), rand(7, 9)),
-                                     correct3 = (rand(5, 7), rand(7))),
-                         bad_build = dict(),
-                         bad_runtime = dict(bad1 = (rand(5, 7), rand(5, 7)),
-                                           bad2 = (rand(5, 7), rand(8,3))),
-                         grad = dict())
+    rng = np.random.default_rng(23098)
+
+    TestDot = makeTester(
+        name="DotTester",
+        op=np.dot,
+        expected=lambda x, y: numpy.dot(x, y),
+        checks={},
+        good=dict(
+            correct1=(rng.rand(5, 7), rng.rand(7, 5)),
+            correct2=(rng.rand(5, 7), rng.rand(7, 9)),
+            correct3=(rng.rand(5, 7), rng.rand(7)),
+        ),
+        bad_build=dict(),
+        bad_runtime=dict(
+            bad1=(rng.rand(5, 7), rng.rand(5, 7)), bad2=(rng.rand(5, 7), rng.rand(8, 3))
+        ),
+        grad=dict(),
+    )
 
 In the above example, we provide a name and a reference to the :class:`Op` we
 want to test. We then provide in the ``expected`` field, a function

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -72,15 +72,6 @@ detection algorithm. If the graph is big enough,we suggest that you use
 this flag instead of ``optimizer_excluding=inplace``. It will result in a
 computation time that is in between fast compile and fast run.
 
-Aesara flag `reoptimize_unpickled_function` controls if an unpickled
-aesara function should reoptimize its graph or not. Aesara users can
-use the standard python pickle tools to save a compiled aesara
-function. When pickling, both graph before and after the optimization
-are saved, including shared variables. When set to True, the graph is
-reoptimized when being unpickled. Otherwise, skip the graph
-optimization and use directly the optimized graph from the pickled
-file. The default is False.
-
 Faster Aesara function
 ----------------------
 

--- a/doc/library/compile/nanguardmode.rst
+++ b/doc/library/compile/nanguardmode.rst
@@ -14,37 +14,36 @@ Guide
 =====
 
 
-The NanGuardMode aims to prevent the model from outputting NaNs or Infs. It has
-a number of self-checks, which can help to find out which apply node is
-generating those incorrect outputs. It provides automatic detection of 3 types
+The :class:`NanGuardMode` aims to prevent the model from outputting NaNs or Infs. It has
+a number of self-checks, which can help to find out which :class:`Apply` node is
+generating those incorrect outputs. It provides automatic detection of three types
 of abnormal values: NaNs, Infs, and abnormally big values.
 
-NanGuardMode can be used as follows:
+`NanGuardMode` can be used as follows:
 
 .. testcode::
 
-    import numpy
+    import numpy as np
     import aesara
     import aesara.tensor as at
     from aesara.compile.nanguardmode import NanGuardMode
 
     x = at.matrix()
-    w = aesara.shared(numpy.random.randn(5, 7).astype(aesara.config.floatX))
+    w = aesara.shared(np.random.standard_normal((5, 7)).astype(aesara.config.floatX))
     y = at.dot(x, w)
     fun = aesara.function(
         [x], y,
         mode=NanGuardMode(nan_is_error=True, inf_is_error=True, big_is_error=True)
     )
 
-While using the aesara function ``fun``, it will monitor the values of each
+While using the Aesara function ``fun``, it will monitor the values of each
 input and output variable of each node. When abnormal values are
 detected, it raises an error to indicate which node yields the NaNs. For
 example, if we pass the following values to ``fun``:
 
 .. testcode::
 
-    infa = numpy.tile(
-        (numpy.asarray(100.) ** 1000000).astype(aesara.config.floatX), (3, 5))
+    infa = np.tile((np.asarray(100.) ** 1000000).astype(aesara.config.floatX), (3, 5))
     fun(infa)
 
 .. testoutput::
@@ -55,17 +54,17 @@ example, if we pass the following values to ``fun``:
      ...
    AssertionError: ...
 
-It will raise an AssertionError indicating that Inf value is detected while
+It will raise an `AssertionError` indicating that Inf value is detected while
 executing the function.
 
-You can also set the three parameters in ``NanGuardMode()`` to indicate which
+You can also set the three parameters in `NanGuardMode` to indicate which
 kind of abnormal values to monitor. ``nan_is_error`` and ``inf_is_error`` has
 no default values, so they need to be set explicitly, but ``big_is_error`` is
 set to be ``True`` by default.
 
 .. note::
 
-        NanGuardMode significantly slows down computations; only
+        `NanGuardMode` significantly slows down computations; only
         enable as needed.
 
 Reference

--- a/doc/library/config.rst
+++ b/doc/library/config.rst
@@ -820,12 +820,6 @@ import ``aesara`` and print the config variable, as in:
     If ``'True'``, Aesara will include the test values in a variable's
     ``__str__`` output.
 
-.. attribute:: reoptimize_unpickled_function
-
-    Bool value, default: False
-
-    When this option is set to ``True``, a graph is re-optimized when unpickled.
-
 .. attribute:: exception_verbosity
 
     String Value: ``'low'``, ``'high'``.

--- a/doc/library/config.rst
+++ b/doc/library/config.rst
@@ -797,8 +797,7 @@ import ``aesara`` and print the config variable, as in:
     Aesara will execute the graph using constants and/or shared variables
     provided by the user. Purely symbolic variables (e.g. ``x =
     aesara.tensor.dmatrix()``) can be augmented with test values, by writing to
-    their ``tag.test_value`` attribute (e.g. ``x.tag.test_value =
-    numpy.random.rand(5, 4)``).
+    their ``.tag.test_value`` attributes (e.g. ``x.tag.test_value = np.ones((5, 4))``).
 
     When not ``'off'``, the value of this option dictates what happens when
     an :class:`Op`'s inputs do not provide appropriate test values:

--- a/doc/library/tensor/basic.rst
+++ b/doc/library/tensor/basic.rst
@@ -8,28 +8,31 @@ Basic Tensor Functionality
 
 .. testsetup::
 
+   import numpy as np
    import aesara
    import aesara.tensor as at
    from aesara.tensor.type import scalar, iscalar, TensorType, dmatrix, ivector, fmatrix
    from aesara.tensor import set_subtensor, inc_subtensor, batched_dot
    from aesara import shared
-   import numpy
-   import numpy as np
 
-Aesara supports any kind of Python object, but its focus is support for
-symbolic matrix expressions.  When you type,
+Aesara supports symbolic tensor expressions.  When you type,
 
+>>> import aesara.tensor as at
 >>> x = at.fmatrix()
 
 the ``x`` is a :class:`TensorVariable` instance.
+
 The ``at.fmatrix`` object itself is an instance of :class:`TensorType`.
 Aesara knows what type of variable ``x`` is because ``x.type``
 points back to ``at.fmatrix``.
 
-This chapter explains the various ways of creating tensor variables,
+This section explains the various ways in which a tensor variable can be created,
 the attributes and methods of :class:`TensorVariable` and :class:`TensorType`,
 and various basic symbolic math and arithmetic that Aesara supports for
 tensor variables.
+
+In general, Aesara's API tries to mirror NumPy's, so, in most cases, it's safe
+to assume that the basic NumPy array functions and methods will be available.
 
 .. _libdoc_tensor_creation:
 
@@ -39,63 +42,65 @@ Creation
 Aesara provides a list of predefined tensor types that can be used
 to create a tensor variables.  Variables can be named to facilitate debugging,
 and all of these constructors accept an optional ``name`` argument.
-For example, the following each produce a TensorVariable instance that stands
-for a 0-dimensional ndarray of integers with the name ``'myvar'``:
+For example, the following each produce a `TensorVariable` instance that stands
+for a 0-dimensional `ndarray` of integers with the name ``'myvar'``:
 
->>> x = scalar('myvar', dtype='int32')
->>> x = iscalar('myvar')
+>>> x = at.scalar('myvar', dtype='int32')
+>>> x = at.iscalar('myvar')
+>>> x = at.tensor(dtype='int32', shape=(), name='myvar')
+>>> from aesara.tensor.type import TensorType
 >>> x = TensorType(dtype='int32', shape=())('myvar')
 
 Constructors with optional dtype
-----------------------------------------
+--------------------------------
 
 These are the simplest and often-preferred methods for creating symbolic
 variables in your code.  By default, they produce floating-point variables
-(with dtype determined by config.floatX, see :attr:`floatX`) so if you use
+(with dtype determined by `aesara.config.floatX`) so if you use
 these constructors it is easy to switch your code between different levels of
 floating-point precision.
 
 .. function:: scalar(name=None, dtype=config.floatX)
 
-    Return a Variable for a 0-dimensional ndarray
+    Return a `Variable` for a 0-dimensional `ndarray`
 
 .. function:: vector(name=None, dtype=config.floatX)
 
-    Return a Variable for a 1-dimensional ndarray
+    Return a `Variable` for a 1-dimensional `ndarray`
 
 .. function:: row(name=None, dtype=config.floatX)
 
-    Return a Variable for a 2-dimensional ndarray
+    Return a `Variable` for a 2-dimensional `ndarray`
     in which the number of rows is guaranteed to be 1.
 
 .. function:: col(name=None, dtype=config.floatX)
 
-    Return a Variable for a 2-dimensional ndarray
+    Return a `Variable` for a 2-dimensional `ndarray`
     in which the number of columns is guaranteed to be 1.
 
 .. function:: matrix(name=None, dtype=config.floatX)
 
-    Return a Variable for a 2-dimensional ndarray
+    Return a `Variable` for a 2-dimensional `ndarray`
 
 .. function:: tensor3(name=None, dtype=config.floatX)
 
-    Return a Variable for a 3-dimensional ndarray
+    Return a `Variable` for a 3-dimensional `ndarray`
 
 .. function:: tensor4(name=None, dtype=config.floatX)
 
-    Return a Variable for a 4-dimensional ndarray
+    Return a `Variable` for a 4-dimensional `ndarray`
 
 .. function:: tensor5(name=None, dtype=config.floatX)
 
-    Return a Variable for a 5-dimensional ndarray
+    Return a `Variable` for a 5-dimensional `ndarray`
 
 .. function:: tensor6(name=None, dtype=config.floatX)
 
-    Return a Variable for a 6-dimensional ndarray
+    Return a `Variable` for a 6-dimensional `ndarray`
 
 .. function:: tensor7(name=None, dtype=config.floatX)
 
-    Return a Variable for a 7-dimensional ndarray
+    Return a `Variable` for a 7-dimensional `ndarray`
 
 .. #COMMENT
     Each of the types described above can be constructed by two methods:
@@ -109,16 +114,14 @@ floating-point precision.
 All Fully-Typed Constructors
 ----------------------------
 
-The following TensorType instances are provided in the aesara.tensor module.
+The following `TensorType` instances are provided in the `aesara.tensor` module.
 They are all callable, and accept an optional ``name`` argument.  So for example:
 
 .. testcode:: constructors
 
-   from aesara.tensor import *
-
-   x = dmatrix()        # creates one Variable with no name
-   x = dmatrix('x')     # creates one Variable with name 'x'
-   xyz = dmatrix('xyz') # creates one Variable with name 'xyz'
+   x = at.dmatrix()        # creates one Variable with no name
+   x = at.dmatrix('x')     # creates one Variable with name 'x'
+   xyz = at.dmatrix('xyz') # creates one Variable with name 'xyz'
 
 .. #COMMENT
     table generated by
@@ -210,7 +213,7 @@ ztensor7     complex128  7    (?,?,?,?,?,?,?)  (False,) * 7
 ============ =========== ==== ================ ===================================
 
 Plural Constructors
---------------------------
+-------------------
 
 There are several constructors that can produce multiple variables at once.
 These are not frequently used in practice, but often used in tutorial examples to save space!
@@ -237,16 +240,16 @@ These are not frequently used in practice, but often used in tutorial examples t
 
 Each of these plural constructors accepts
 an integer or several strings. If an integer is provided, the method
-will return that many Variables and if strings are provided, it will
-create one Variable for each string, using the string as the Variable's
+will return that many `Variables` and if strings are provided, it will
+create one `Variable` for each string, using the string as the `Variable`'s
 name. For example:
 
 .. testcode:: constructors
 
-   from aesara.tensor import *
-
-   x, y, z = dmatrices(3) # creates three matrix Variables with no names
-   x, y, z = dmatrices('x', 'y', 'z') # creates three matrix Variables named 'x', 'y' and 'z'
+   # Creates three matrix `Variable`s with no names
+   x, y, z = at.dmatrices(3)
+   # Creates three matrix `Variables` named 'x', 'y' and 'z'
+   x, y, z = at.dmatrices('x', 'y', 'z')
 
 
 Custom tensor types
@@ -258,110 +261,121 @@ your own :class:`TensorType` instance.  You create such an instance by passing
 the dtype and broadcasting pattern to the constructor.  For example, you
 can create your own 8-dimensional tensor type
 
->>> dtensor8 = TensorType('float64', (False,)*8)
+>>> dtensor8 = TensorType(dtype='float64', shape=(None,)*8)
 >>> x = dtensor8()
 >>> z = dtensor8('z')
 
 You can also redefine some of the provided types and they will interact
 correctly:
 
->>> my_dmatrix = TensorType('float64', (False,)*2)
->>> x = my_dmatrix()       # allocate a matrix variable
+>>> my_dmatrix = TensorType('float64', shape=(None,)*2)
+>>> x = my_dmatrix()  # allocate a matrix variable
 >>> my_dmatrix == dmatrix
 True
 
 See :class:`TensorType` for more information about creating new types of
-Tensor.
+tensors.
 
 
 Converting from Python Objects
 -------------------------------
 
-Another way of creating a TensorVariable (a TensorSharedVariable to be
-precise) is by calling :func:`shared()`
+Another way of creating a `TensorVariable` (a `TensorSharedVariable` to be
+precise) is by calling :func:`aesara.shared`
 
 .. testcode::
 
-    x = shared(numpy.random.randn(3,4))
+    x = aesara.shared(np.random.standard_normal((3, 4)))
 
 This will return a :term:`shared variable <shared variable>` whose ``.value`` is
-a numpy ndarray.  The number of dimensions and dtype of the Variable are
-inferred from the ndarray argument.  The argument to `shared` *will not be
+a NumPy `ndarray`.  The number of dimensions and dtype of the `Variable` are
+inferred from the `ndarray` argument.  The argument to `shared` *will not be
 copied*, and subsequent changes will be reflected in ``x.value``.
 
 For additional information, see the :func:`shared() <shared.shared>` documentation.
 
 .. _libdoc_tensor_autocasting:
 
-Finally, when you use a numpy ndarray or a Python number together with
+Finally, when you use a NumPy `ndarray` or a Python number together with
 :class:`TensorVariable` instances in arithmetic expressions, the result is a
-:class:`TensorVariable`. What happens to the ndarray or the number?
-Aesara requires that the inputs to all expressions be Variable instances, so
+:class:`TensorVariable`. What happens to the `ndarray` or the number?
+Aesara requires that the inputs to all expressions be `Variable` instances, so
 Aesara automatically wraps them in a :class:`TensorConstant`.
 
 .. note::
 
-    Aesara makes a copy of any ndarray that you use in an expression, so
-    subsequent
-    changes to that ndarray will not have any effect on the Aesara expression.
+    Aesara makes a copy of any `ndarray` that is used in an expression, so
+    subsequent changes to that `ndarray` will not have any effect on the Aesara
+    expression in which they're contained.
 
-For numpy ndarrays the dtype is given, but the broadcastable pattern must be
-inferred.  The TensorConstant is given a type with a matching dtype,
-and a broadcastable pattern with a ``True`` for every shape dimension that is 1.
+For NumPy `ndarrays` the dtype is given, but the static shape/broadcastable pattern must be
+inferred.  The `TensorConstant` is given a type with a matching dtype,
+and a static shape/broadcastable pattern with a ``1``\/``True`` for every shape
+dimension that is one and ``None``\/``False`` for every dimension with an unknown
+shape.
 
-For python numbers, the broadcastable pattern is ``()`` but the dtype must be
+For Python numbers, the static shape/broadcastable pattern is ``()`` but the dtype must be
 inferred.  Python integers are stored in the smallest dtype that can hold
-them, so small constants like ``1`` are stored in a ``bscalar``.
-Likewise, Python floats are stored in an fscalar if fscalar suffices to hold
-them perfectly, but a dscalar otherwise.
+them, so small constants like ``1`` are stored in a `bscalar`.
+Likewise, Python floats are stored in an `fscalar` if `fscalar` suffices to hold
+them perfectly, but a `dscalar` otherwise.
 
 .. note::
 
-    When config.floatX==float32 (see :mod:`config`), then Python floats
+    When ``config.floatX == float32`` (see :mod:`config`), then Python floats
     are stored instead as single-precision floats.
 
     For fine control of this rounding policy, see
-    aesara.tensor.basic.autocast_float.
+    `aesara.tensor.basic.autocast_float`.
 
 .. function:: as_tensor_variable(x, name=None, ndim=None)
 
-    Turn an argument `x` into a TensorVariable or TensorConstant.
+    Turn an argument `x` into a `TensorVariable` or `TensorConstant`.
 
-    Many tensor Ops run their arguments through this function as
-    pre-processing.  It passes through TensorVariable instances, and tries to
-    wrap other objects into TensorConstant.
+    Many tensor `Op`\s run their arguments through this function as
+    pre-processing.  It passes through `TensorVariable` instances, and tries to
+    wrap other objects into `TensorConstant`.
 
     When `x` is a Python number, the dtype is inferred as described above.
 
-    When `x` is a `list` or `tuple` it is passed through numpy.asarray
+    When `x` is a `list` or `tuple` it is passed through `np.asarray`
 
-    If the `ndim` argument is not None, it must be an integer and the output
+    If the `ndim` argument is not ``None``, it must be an integer and the output
     will be broadcasted if necessary in order to have this many dimensions.
 
     :rtype: :class:`TensorVariable` or :class:`TensorConstant`
 
 
-TensorType and TensorVariable
-=============================
+`TensorType` and `TensorVariable`
+=================================
 
 .. class:: TensorType(Type)
 
-    The Type class used to mark Variables that stand for `numpy.ndarray`
-    values (`numpy.memmap`, which is a subclass of `numpy.ndarray`, is also allowed).
-    Recalling to the tutorial, the purple box in
+    The `Type` class used to mark Variables that stand for `numpy.ndarray`
+    values.  `numpy.memmap`, which is a subclass of `numpy.ndarray`, is also
+    allowed.  Recalling to the tutorial, the purple box in
     :ref:`the tutorial's graph-structure figure <tutorial-graphfigure>` is an instance of this class.
+
+    .. attribute:: shape
+        A tuple of ``None`` and integer values representing the static shape associated with this
+        `Type`.  ``None`` values represent unknown/non-fixed shape values.
+
+        .. note::
+
+            Broadcastable tuples/values are an old Theano construct that are
+            being phased-out in Aesara.
 
     .. attribute:: broadcastable
 
-        A tuple of True/False values, one for each dimension.  True in
-        position 'i' indicates that at evaluation-time, the ndarray will have
-        size 1 in that 'i'-th dimension.  Such a dimension is called a
+        A tuple of ``True``\/``False`` values, one for each dimension.  ``True`` in
+        position ``i`` indicates that at evaluation-time, the `ndarray` will have
+        size one in that ``i``-th dimension.  Such a dimension is called a
         *broadcastable dimension* (see :ref:`tutbroadcasting`).
 
         The broadcastable pattern indicates both the number of dimensions and
-        whether a particular dimension must have length 1.
+        whether a particular dimension must have length one.
 
-        Here is a table mapping some `broadcastable` patterns to what they
+        Here is a table mapping some broadcastable patterns to what they
         mean:
 
         ===================== =================================
@@ -380,19 +394,18 @@ TensorType and TensorVariable
         [False, False, False] A MxNxP tensor (pattern of a + b)
         ===================== =================================
 
-        For dimensions in which broadcasting is False, the length of this
-        dimension can be 1 or more.  For dimensions in which broadcasting is True,
-        the length of this dimension must be 1.
+        For dimensions in which broadcasting is ``False``, the length of this
+        dimension can be one or more.  For dimensions in which broadcasting is ``True``,
+        the length of this dimension must be one.
 
         When two arguments to an element-wise operation (like addition or
-        subtraction) have a different
-        number of dimensions, the broadcastable
+        subtraction) have a different number of dimensions, the broadcastable
         pattern is *expanded to the left*, by padding with ``True``. For example,
         a vector's pattern, ``[False]``, could be expanded to ``[True, False]``, and
         would behave like a row (1xN matrix). In the same way, a matrix (``[False,
         False]``) would behave like a 1xNxP tensor (``[True, False, False]``).
 
-        If we wanted to create a type representing a matrix that would
+        If we wanted to create a `TensorType` representing a matrix that would
         broadcast over the middle dimension of a 3-dimensional tensor when
         adding them together, we would define it like this:
 
@@ -400,19 +413,18 @@ TensorType and TensorVariable
 
     .. attribute:: ndim
 
-        The number of dimensions that a Variable's value will have at
+        The number of dimensions that a `Variable`'s value will have at
         evaluation-time.  This must be known when we are building the
         expression graph.
 
     .. attribute:: dtype
 
-        A string indicating
-        the numerical type of the ndarray for which a Variable of this Type
-        is standing.
+        A string indicating the numerical type of the `ndarray` for which a
+        `Variable` of this `Type` represents.
 
         .. _dtype_list:
 
-        The dtype attribute of a TensorType instance can be any of the
+        The :attr:`dtype` attribute of a `TensorType` instance can be any of the
         following strings.
 
         ================= =================== =================
@@ -434,31 +446,31 @@ TensorType and TensorVariable
 
     .. method:: __init__(self, dtype, broadcastable)
 
-        If you wish to use a type of tensor which is not already available
-        (for example, a 5D tensor) you can build an appropriate type by instantiating
+        If you wish to use a `Type` that is not already available (for example,
+        a 5D tensor), you can build an appropriate `Type` by instantiating
         :class:`TensorType`.
 
 
-TensorVariable
+`TensorVariable`
 ----------------
 
 .. class:: TensorVariable(Variable, _tensor_py_operators)
 
-    The result of symbolic operations typically have this type.
+    A `Variable` type that represents symbolic tensors.
 
     See :class:`_tensor_py_operators` for most of the attributes and methods
     you'll want to call.
 
 .. class:: TensorConstant(Variable, _tensor_py_operators)
 
-    Python and numpy numbers are wrapped in this type.
+    Python and NumPy numbers are wrapped in this type.
 
     See :class:`_tensor_py_operators` for most of the attributes and methods
     you'll want to call.
 
 .. class:: TensorSharedVariable(Variable, _tensor_py_operators)
 
-    This type is returned by :func:`shared` when the value to share is a numpy
+    This type is returned by :func:`shared` when the value to share is a NumPy
     ndarray.
 
     See :class:`_tensor_py_operators` for most of the attributes and methods
@@ -469,7 +481,7 @@ TensorVariable
    :members:
 
     This mix-in class adds convenient attributes, methods, and support
-    to TensorVariable, TensorConstant and TensorSharedVariable for
+    to `TensorVariable`, `TensorConstant` and `TensorSharedVariable` for
     Python operators (see :ref:`tensor_operator_support`).
 
     .. attribute:: type
@@ -493,7 +505,7 @@ TensorVariable
        :noindex:
 
         Returns a view of this tensor that has been reshaped as in
-        numpy.reshape.  If the shape is a Variable argument, then you might
+        `numpy.reshape`.  If the shape is a `Variable` argument, then you might
         need to use the optional `ndim` parameter to declare how many elements
         the shape has, and therefore how many dimensions the reshaped Variable
         will have.
@@ -504,32 +516,32 @@ TensorVariable
        :noindex:
 
         Returns a view of this tensor with permuted dimensions.  Typically the
-        pattern will include the integers 0, 1, ... ndim-1, and any number of
-        'x' characters in dimensions where this tensor should be broadcasted.
+        pattern will include the integers ``0, 1, ... ndim-1``, and any number of
+        ``'x'`` characters in dimensions where this tensor should be broadcasted.
 
         A few examples of patterns and their effect:
 
-            * ('x') -> make a 0d (scalar) into a 1d vector
-            * (0, 1) -> identity for 2d vectors
-            * (1, 0) -> inverts the first and second dimensions
-            * ('x', 0) -> make a row out of a 1d vector (N to 1xN)
-            * (0, 'x') -> make a column out of a 1d vector (N to Nx1)
-            * (2, 0, 1) -> AxBxC to CxAxB
-            * (0, 'x', 1) -> AxB to Ax1xB
-            * (1, 'x', 0) -> AxB to Bx1xA
-            * (1,) -> This remove dimensions 0. It must be a broadcastable dimension (1xA to A)
+            * ``('x',)``: make a 0d (scalar) into a 1d vector
+            * ``(0, 1)``: identity for 2d vectors
+            * ``(1, 0)``: inverts the first and second dimensions
+            * ``('x', 0)``: make a row out of a 1d vector (N to 1xN)
+            * ``(0, 'x')``: make a column out of a 1d vector (N to Nx1)
+            * ``(2, 0, 1)``: AxBxC to CxAxB
+            * ``(0, 'x', 1)``: AxB to Ax1xB
+            * ``(1, 'x', 0)``: AxB to Bx1xA
+            * ``(1,)``: This removes the dimension at index 0. It must be a broadcastable dimension.
 
     .. method:: flatten(ndim=1)
 
         Returns a view of this tensor with `ndim` dimensions, whose shape for the first
-        `ndim-1` dimensions will be the same as `self`, and shape in the
-        remaining dimension will be expanded to fit in all the data from self.
+        ``ndim-1`` dimensions will be the same as ``self``, and shape in the
+        remaining dimension will be expanded to fit in all the data from ``self``.
 
         See :func:`flatten`.
 
     .. method:: ravel()
 
-        return self.flatten(). For NumPy compatibility.
+        return `flatten`. For NumPy compatibility.
 
     .. attribute:: T
 
@@ -538,19 +550,16 @@ TensorVariable
         >>> x = at.zmatrix()
         >>> y = 3+.2j * x.T
 
-        .. note::
-
-            In numpy and in Aesara, the transpose of a vector is exactly the
-            same vector!  Use `reshape` or `dimshuffle` to turn your vector
-            into a row or column matrix.
-
     .. method:: {any,all}(axis=None, keepdims=False)
     .. method:: {sum,prod,mean}(axis=None, dtype=None, keepdims=False, acc_dtype=None)
     .. method:: {var,std,min,max,argmin,argmax}(axis=None, keepdims=False),
     .. method:: diagonal(offset=0, axis1=0, axis2=1)
     .. method:: astype(dtype)
     .. method:: take(indices, axis=None, mode='raise')
-    .. method:: copy() Return a new symbolic variable that is a copy of the variable. Does not copy the tag.
+    .. method:: copy()
+
+        Return a new symbolic variable that is a copy of the variable. Does not copy the tag.
+
     .. method:: norm(L, axis=None)
     .. method:: nonzero(self, return_matrix=False)
        :noindex:
@@ -584,27 +593,27 @@ dimensions, see :meth:`_tensor_py_operators.dimshuffle`.
 
 .. function:: shape(x)
 
-    Returns an lvector representing the shape of `x`.
+    Returns an `lvector` representing the shape of `x`.
 
 .. function:: reshape(x, newshape, ndim=None)
    :noindex:
 
-    :type x: any TensorVariable (or compatible)
+    :type x: any `TensorVariable` (or compatible)
     :param x: variable to be reshaped
 
-    :type newshape: lvector (or compatible)
+    :type newshape: `lvector` (or compatible)
     :param newshape: the new shape for `x`
 
     :param ndim: optional - the length that `newshape`'s value will have.
-        If this is ``None``, then `reshape()` will infer it from `newshape`.
+        If this is ``None``, then `reshape` will infer it from `newshape`.
 
-    :rtype: variable with x's dtype, but ndim dimensions
+    :rtype: variable with `x`'s dtype, but `ndim` dimensions
 
     .. note::
 
-        This function can infer the length of a symbolic newshape in some
-        cases, but if it cannot and you do not provide the `ndim`, then this
-        function will raise an Exception.
+        This function can infer the length of a symbolic `newshape` value in
+        some cases, but if it cannot and you do not provide the `ndim`, then
+        this function will raise an Exception.
 
 
 .. function:: shape_padleft(x, n_ones=1)
@@ -614,7 +623,7 @@ dimensions, see :meth:`_tensor_py_operators.dimshuffle`.
     see the :func:`unbroadcast`.
 
     :param x: variable to be reshaped
-    :type x: any TensorVariable (or compatible)
+    :type x: any `TensorVariable` (or compatible)
 
     :type n_ones: int
     :type n_ones: number of dimension to be added to `x`
@@ -623,7 +632,7 @@ dimensions, see :meth:`_tensor_py_operators.dimshuffle`.
 
 .. function:: shape_padright(x, n_ones=1)
 
-    Reshape `x` by right padding the shape with `n_ones` 1s. Note that all
+    Reshape `x` by right padding the shape with `n_ones` ones. Note that all
     this new dimension will be broadcastable. To make them non-broadcastable
     see the :func:`unbroadcast`.
 
@@ -636,11 +645,11 @@ dimensions, see :meth:`_tensor_py_operators.dimshuffle`.
 
 .. function:: shape_padaxis(t, axis)
 
-    Reshape `t` by inserting 1 at the dimension `axis`. Note that this new
+    Reshape `t` by inserting ``1`` at the dimension `axis`. Note that this new
     dimension will be broadcastable. To make it non-broadcastable
     see the :func:`unbroadcast`.
 
-    :type x: any TensorVariable (or compatible)
+    :type x: any `TensorVariable` (or compatible)
     :param x: variable to be reshaped
 
     :type axis: int
@@ -669,7 +678,7 @@ dimensions, see :meth:`_tensor_py_operators.dimshuffle`.
     Similar to :func:`reshape`, but the shape is inferred from the shape of `x`.
 
     :param x: variable to be flattened
-    :type x: any TensorVariable (or compatible)
+    :type x: any `TensorVariable` (or compatible)
 
     :type ndim: int
     :param ndim: the number of dimensions in the returned variable
@@ -679,10 +688,10 @@ dimensions, see :meth:`_tensor_py_operators.dimshuffle`.
         dimensions, but with all remaining dimensions of `x` collapsed into
         the last dimension.
 
-    For example, if we flatten a tensor of shape (2, 3, 4, 5) with flatten(x,
-    ndim=2), then we'll have the same (2-1=1) leading dimensions (2,), and the
-    remaining dimensions are collapsed.  So the output in this example would
-    have shape (2, 60).
+    For example, if we flatten a tensor of shape ``(2, 3, 4, 5)`` with ``flatten(x,
+    ndim=2)``, then we'll have the same (i.e. ``2-1=1``) leading dimensions
+    ``(2,)``, and the remaining dimensions are collapsed, so the output in this
+    example would have shape ``(2, 60)``.
 
 
 .. function:: tile(x, reps, ndim=None)
@@ -702,13 +711,13 @@ dimensions, see :meth:`_tensor_py_operators.dimshuffle`.
         <aesara.tensor.extra_ops.repeat>`
 
     :note: Currently, `reps` must be a constant, `x.ndim` and
-        `len(reps)` must be equal and, if specified, `ndim` must be
+        ``len(reps)`` must be equal and, if specified, `ndim` must be
         equal to both.
 
 .. autofunction:: roll
 
-Creating Tensor
-===============
+Creating Tensors
+================
 
 
 .. function:: zeros_like(x, dtype=None)
@@ -717,7 +726,7 @@ Creating Tensor
     :param dtype: data-type, optional
                   By default, it will be x.dtype.
 
-    Returns a tensor the shape of x filled with zeros of the type of dtype.
+    Returns a tensor the shape of `x` filled with zeros of the type of `dtype`.
 
 
 .. function:: ones_like(x)
@@ -725,31 +734,31 @@ Creating Tensor
 
     :param x: tensor that has the same shape as output
     :param dtype: data-type, optional
-                  By default, it will be x.dtype.
+                  By default, it will be `x.dtype`.
 
-    Returns a tensor the shape of x filled with ones of the type of dtype.
+    Returns a tensor the shape of `x` filled with ones of the type of `dtype`.
 
 
 .. function:: zeros(shape, dtype=None)
 
     :param shape: a tuple/list of scalar with the shape information.
-    :param dtype: the dtype of the new tensor. If None, will use floatX.
+    :param dtype: the dtype of the new tensor. If ``None``, will use ``"floatX"``.
 
-    Returns a tensor filled with 0s of the provided shape.
+    Returns a tensor filled with zeros of the provided shape.
 
 .. function:: ones(shape, dtype=None)
 
     :param shape: a tuple/list of scalar with the shape information.
-    :param dtype: the dtype of the new tensor. If None, will use floatX.
+    :param dtype: the dtype of the new tensor. If ``None``, will use ``"floatX"``.
 
-    Returns a tensor filled with 1s of the provided shape.
+    Returns a tensor filled with ones of the provided shape.
 
 .. function:: fill(a,b)
 
     :param a: tensor that has same shape as output
-    :param b: aesara scalar or value with which you want to fill the output
+    :param b: Aesara scalar or value with which you want to fill the output
 
-    Create a matrix by filling the shape of `a` with `b`
+    Create a matrix by filling the shape of `a` with `b`.
 
 .. function:: alloc(value, *shape)
 
@@ -759,9 +768,9 @@ Creating Tensor
 
 .. function:: eye(n, m=None, k=0, dtype=aesara.config.floatX)
 
-    :param n: number of rows in output (value or aesara scalar)
-    :param m: number of columns in output (value or aesara scalar)
-    :param k: Index of the diagonal: 0 refers to the main diagonal,
+    :param n: number of rows in output (value or Aesara scalar)
+    :param m: number of columns in output (value or Aesara scalar)
+    :param k: Index of the diagonal: ``0`` refers to the main diagonal,
               a positive value refers to an upper diagonal, and a
               negative value to a lower diagonal. It can be an Aesara
               scalar.
@@ -771,21 +780,21 @@ Creating Tensor
 .. function:: identity_like(x)
 
     :param x: tensor
-    :returns: A tensor of same shape as `x` that is filled with 0s everywhere
+    :returns: A tensor of same shape as `x` that is filled with zeros everywhere
               except for the main diagonal, whose values are equal to one. The output
               will have same dtype as `x`.
 
 .. function:: stack(tensors, axis=0)
 
-    Stack tensors in sequence on given axis (default is 0).
+    Stack tensors in sequence on given axis (default is ``0``).
 
     Take a sequence of tensors and stack them on given axis to make a single
     tensor. The size in dimension `axis` of the result will be equal to the number
     of tensors passed.
 
     :param tensors: a list or a tuple of one or more tensors of the same rank.
-    :param axis: the axis along which the tensors will be stacked. Default value is 0.
-    :returns: A tensor such that rval[0] == tensors[0], rval[1] == tensors[1], etc.
+    :param axis: the axis along which the tensors will be stacked. Default value is ``0``.
+    :returns: A tensor such that ``rval[0] == tensors[0]``, ``rval[1] == tensors[1]``, etc.
 
     Examples:
 
@@ -805,7 +814,7 @@ Creating Tensor
     >>> rval.shape # 3 tensors are stacked on axis 0
     (3, 2, 2, 2, 2)
 
-    We can also specify different axis than default value 0
+    We can also specify different axis than default value ``0``:
 
     >>> x = aesara.tensor.stack([a, b, c], axis=3)
     >>> x.ndim
@@ -834,7 +843,7 @@ Creating Tensor
     tensor.
 
     :param tensors: one or more tensors of the same rank
-    :returns: A tensor such that rval[0] == tensors[0], rval[1] == tensors[1], etc.
+    :returns: A tensor such that ``rval[0] == tensors[0]``, ``rval[1] == tensors[1]``, etc.
 
     >>> x0 = at.scalar()
     >>> x1 = at.scalar()
@@ -906,7 +915,7 @@ Reductions
     :Returns: maximum of *x* along *axis*
 
     axis can be:
-     * *None* - in which case the maximum is computed along all axes (like numpy)
+     * *None* - in which case the maximum is computed along all axes (like NumPy)
      * an *int* - computed along this axis
      * a *list of ints* - computed along these axes
 
@@ -919,7 +928,7 @@ Reductions
 		will broadcast correctly against the original tensor.
     :Returns: the index of the maximum value along a given axis
 
-    if axis=None, argmax over the flattened tensor (like numpy)
+    if ``axis == None``, `argmax` over the flattened tensor (like NumPy)
 
 .. function:: max_and_argmax(x, axis=None, keepdims=False)
 
@@ -930,7 +939,7 @@ Reductions
 		will broadcast correctly against the original tensor.
     :Returns: the maximum value along a given axis and its index.
 
-    if axis=None, max_and_argmax over the flattened tensor (like numpy)
+    if ``axis == None``, `max_and_argmax` over the flattened tensor (like NumPy)
 
 .. function:: min(x, axis=None, keepdims=False)
 
@@ -941,8 +950,8 @@ Reductions
 		will broadcast correctly against the original tensor.
     :Returns: minimum of *x* along *axis*
 
-    axis can be:
-     * *None* - in which case the minimum is computed along all axes (like numpy)
+    `axis` can be:
+     * ``None`` - in which case the minimum is computed along all axes (like NumPy)
      * an *int* - computed along this axis
      * a *list of ints* - computed along these axes
 
@@ -955,7 +964,7 @@ Reductions
 		will broadcast correctly against the original tensor.
     :Returns: the index of the minimum value along a given axis
 
-    if axis=None, argmin over the flattened tensor (like numpy)
+    if ``axis == None``, `argmin` over the flattened tensor (like NumPy)
 
 .. function:: sum(x, axis=None, dtype=None, keepdims=False, acc_dtype=None)
 
@@ -987,10 +996,10 @@ Reductions
 
     :Returns: sum of *x* along *axis*
 
-    axis can be:
-     * *None* - in which case the sum is computed along all axes (like numpy)
-     * an *int* - computed along this axis
-     * a *list of ints* - computed along these axes
+    `axis` can be:
+     * ``None`` - in which case the sum is computed along all axes (like NumPy)
+     * an int - computed along this axis
+     * a list of ints - computed along these axes
 
 .. function:: prod(x, axis=None, dtype=None, keepdims=False, acc_dtype=None, no_zeros_in_input=False)
 
@@ -1037,10 +1046,10 @@ Reductions
 
     :Returns: product of every term in *x* along *axis*
 
-    axis can be:
-     * *None* - in which case the sum is computed along all axes (like numpy)
-     * an *int* - computed along this axis
-     * a *list of ints* - computed along these axes
+    `axis` can be:
+     * ``None`` - in which case the sum is computed along all axes (like NumPy)
+     * an int - computed along this axis
+     * a list of ints - computed along these axes
 
 .. function:: mean(x, axis=None, dtype=None, keepdims=False, acc_dtype=None)
 
@@ -1060,10 +1069,10 @@ Reductions
         rules as :func:`sum()`.
     :Returns: mean value of *x* along *axis*
 
-    axis can be:
-     * *None* - in which case the mean is computed along all axes (like numpy)
-     * an *int* - computed along this axis
-     * a *list of ints* - computed along these axes
+    `axis` can be:
+     * ``None`` - in which case the mean is computed along all axes (like NumPy)
+     * an int - computed along this axis
+     * a list of ints - computed along these axes
 
 .. function:: var(x, axis=None, keepdims=False)
 
@@ -1074,10 +1083,10 @@ Reductions
 		will broadcast correctly against the original tensor.
     :Returns: variance of *x* along *axis*
 
-    axis can be:
-     * *None* - in which case the variance is computed along all axes (like numpy)
-     * an *int* - computed along this axis
-     * a *list of ints* - computed along these axes
+    `axis` can be:
+     * ``None`` - in which case the variance is computed along all axes (like NumPy)
+     * an int - computed along this axis
+     * a list of ints - computed along these axes
 
 .. function:: std(x, axis=None, keepdims=False)
 
@@ -1088,10 +1097,10 @@ Reductions
 		will broadcast correctly against the original tensor.
     :Returns: variance of *x* along *axis*
 
-    axis can be:
-     * *None* - in which case the standard deviation is computed along all axes (like numpy)
-     * an *int* - computed along this axis
-     * a *list of ints* - computed along these axes
+    `axis` can be:
+     * ``None`` - in which case the standard deviation is computed along all axes (like NumPy)
+     * an int - computed along this axis
+     * a list of ints - computed along these axes
 
 .. function:: all(x, axis=None, keepdims=False)
 
@@ -1102,10 +1111,10 @@ Reductions
 		will broadcast correctly against the original tensor.
     :Returns: bitwise and of *x* along *axis*
 
-    axis can be:
-     * *None* - in which case the 'bitwise and' is computed along all axes (like numpy)
-     * an *int* - computed along this axis
-     * a *list of ints* - computed along these axes
+    `axis` can be:
+     * ``None`` - in which case the 'bitwise and' is computed along all axes (like NumPy)
+     * an int - computed along this axis
+     * a list of ints - computed along these axes
 
 .. function:: any(x, axis=None, keepdims=False)
 
@@ -1116,10 +1125,10 @@ Reductions
 		will broadcast correctly against the original tensor.
     :Returns: bitwise or of *x* along *axis*
 
-    axis can be:
-     * *None* - in which case the 'bitwise or' is computed along all axes (like numpy)
-     * an *int* - computed along this axis
-     * a *list of ints* - computed along these axes
+    `axis` can be:
+     * ``None`` - in which case the 'bitwise or' is computed along all axes (like NumPy)
+     * an int - computed along this axis
+     * a list of ints - computed along these axes
 
 .. function:: ptp(x, axis = None)
 
@@ -1205,30 +1214,30 @@ Casting
 
 .. function:: cast(x, dtype)
 
-    Cast any tensor `x` to a Tensor of the same shape, but with a different
+    Cast any tensor `x` to a tensor of the same shape, but with a different
     numerical type `dtype`.
 
-    This is not a reinterpret cast, but a coercion cast, similar to
+    This is not a reinterpret cast, but a coercion `cast`, similar to
     ``numpy.asarray(x, dtype=dtype)``.
 
     .. testcode:: cast
 
-        import Aesara.tensor as at
+        import aesara.tensor as at
         x = at.matrix()
         x_as_int = at.cast(x, 'int32')
 
     Attempting to casting a complex value to a real value is ambiguous and
-    will raise an exception.  Use `real()`, `imag()`, `abs()`, or `angle()`.
+    will raise an exception.  Use `real`, `imag`, `abs`, or `angle`.
 
 .. function:: real(x)
 
-    Return the real (not imaginary) components of Tensor x.
-    For non-complex `x` this function returns x.
+    Return the real (not imaginary) components of tensor `x`.
+    For non-complex `x` this function returns `x`.
 
 .. function:: imag(x)
 
-    Return the imaginary components of Tensor x.
-    For non-complex `x` this function returns zeros_like(x).
+    Return the imaginary components of tensor `x`.
+    For non-complex `x` this function returns ``zeros_like(x)``.
 
 
 Comparisons
@@ -1249,7 +1258,7 @@ The six usual equality and inequality operators share the same interface.
 
   .. testcode:: oper
 
-    import Aesara.tensor as at
+    import aesara.tensor as at
     x,y = at.dmatrices('x','y')
     z = at.le(x,y)
 
@@ -1332,8 +1341,8 @@ Condition
 
 .. function:: switch(cond, ift, iff)
 
-    Returns a variable representing a switch between ift (iftrue) and iff (iffalse)
-     based on the condition cond. This is the Aesara equivalent of numpy.where.
+    Returns a variable representing a switch between ift (i.e. "if true") and iff (i.e. "if false")
+    based on the condition cond. This is the Aesara equivalent of `numpy.where`.
 
       :Parameter:  *cond* - symbolic Tensor (or compatible)
       :Parameter:  *ift* - symbolic Tensor (or compatible)
@@ -1342,32 +1351,32 @@ Condition
 
     .. testcode:: switch
 
-      import Aesara.tensor as at
+      import aesara.tensor as at
       a,b = at.dmatrices('a','b')
       x,y = at.dmatrices('x','y')
       z = at.switch(at.lt(a,b), x, y)
 
 .. function:: where(cond, ift, iff)
 
-   Alias for `switch`. where is the numpy name.
+   Alias for `switch`. where is the NumPy name.
 
 .. function:: clip(x, min, max)
 
-    Return a variable representing x, but with all elements greater than
+    Return a variable representing `x`, but with all elements greater than
     `max` clipped to `max` and all elements less than `min` clipped to `min`.
 
     Normal broadcasting rules apply to each of `x`, `min`, and `max`.
 
     Note that there is no warning for inputs that are the wrong way round
-    (`min > max`), and that results in this case may differ from ``numpy.clip``.
+    (`min > max`), and that results in this case may differ from `numpy.clip`.
 
 Bit-wise
 --------
 
 
 The bitwise operators possess this interface:
-    :Parameter:  *a* - symbolic Tensor of integer type.
-    :Parameter:  *b* - symbolic Tensor of integer type.
+    :Parameter:  *a* - symbolic tensor of integer type.
+    :Parameter:  *b* - symbolic tensor of integer type.
 
     .. note::
 
@@ -1375,7 +1384,7 @@ The bitwise operators possess this interface:
 
         The bit-wise not (invert) takes only one parameter.
 
-    :Return type: symbolic Tensor with corresponding dtype.
+    :Return type: symbolic tensor with corresponding dtype.
 
 .. function:: and_(a, b)
 
@@ -1395,25 +1404,25 @@ The bitwise operators possess this interface:
 
 .. function:: bitwise_and(a, b)
 
-   Alias for `and_`. bitwise_and is the numpy name.
+   Alias for `and_`. bitwise_and is the NumPy name.
 
 .. function:: bitwise_or(a, b)
 
-   Alias for `or_`. bitwise_or is the numpy name.
+   Alias for `or_`. bitwise_or is the NumPy name.
 
 .. function:: bitwise_xor(a, b)
 
-   Alias for `xor_`. bitwise_xor is the numpy name.
+   Alias for `xor_`. bitwise_xor is the NumPy name.
 
 .. function:: bitwise_not(a, b)
 
-   Alias for invert. invert is the numpy name.
+   Alias for invert. invert is the NumPy name.
 
 Here is an example using the bit-wise ``and_`` via the ``&`` operator:
 
 .. testcode:: bitwise
 
-    import Aesara.tensor as at
+    import aesara.tensor as at
     x,y = at.imatrices('x','y')
     z = x & y
 
@@ -1518,7 +1527,7 @@ Mathematical
    Returns a variable representing the survival function (1-cdf —
    sometimes more accurate).
 
-   C code is provided in the Aesara_lgpl repository.
+   C code is provided in the Theano_lgpl repository.
    This makes it faster.
 
    https://github.com/Theano/Theano_lgpl.git
@@ -1542,7 +1551,7 @@ Linear Algebra
     :param Y: right term
     :type X: symbolic tensor
     :type Y: symbolic tensor
-    :rtype: `symbolic matrix or vector`
+    :rtype: symbolic matrix or vector
     :return: the inner product of `X` and `Y`.
 
 .. function:: outer(X, Y)
@@ -1560,7 +1569,7 @@ Linear Algebra
     Given two tensors a and b,tensordot computes a generalized dot product over
     the provided axes. Aesara's implementation reduces all expressions to
     matrix or vector dot products and is based on code from Tijmen Tieleman's
-    gnumpy (http://www.cs.toronto.edu/~tijmen/gnumpy.html).
+    `gnumpy` (http://www.cs.toronto.edu/~tijmen/gnumpy.html).
 
     :param a: the first tensor variable
     :type a: symbolic tensor
@@ -1575,7 +1584,7 @@ Linear Algebra
                  Note that the default value of 2 is not guaranteed to work
                  for all values of a and b, and an error will be raised if
                  that is the case. The reason for keeping the default is to
-                 maintain the same signature as numpy's tensordot function
+                 maintain the same signature as NumPy's tensordot function
                  (and np.tensordot raises analogous errors for non-compatible
                  inputs).
 
@@ -1612,21 +1621,17 @@ Linear Algebra
         a = np.random.random((2,3,4))
         b = np.random.random((5,6,4,3))
 
-        #tensordot
         c = np.tensordot(a, b, [[1,2],[3,2]])
 
-        #loop replicating tensordot
         a0, a1, a2 = a.shape
         b0, b1, _, _ = b.shape
         cloop = np.zeros((a0,b0,b1))
 
-        #loop over non-summed indices -- these exist
-        #in the tensor product.
+        # Loop over non-summed indices--these exist in the tensor product
         for i in range(a0):
             for j in range(b0):
                 for k in range(b1):
-                    #loop over summed indices -- these don't exist
-                    #in the tensor product.
+                    # Loop over summed indices--these don't exist in the tensor product
                     for l in range(a1):
                         for m in range(a2):
                             cloop[i,j,k] += a[i,l,m] * b[j,k,m,l]
@@ -1668,9 +1673,7 @@ Linear Algebra
     >>> second = at.tensor3('second')
     >>> result = batched_dot(first, second)
 
-    :note:  This is a subset of numpy.einsum, but we do not provide it for now.
-        But numpy einsum is slower than dot or tensordot:
-        http://mail.scipy.org/pipermail/numpy-discussion/2012-October/064259.html
+    :note:  This is a subset of `numpy.einsum`, but we do not provide it for now.
 
     :param X: left term
     :param Y: right term

--- a/doc/sandbox/logistic_regression_example.rst
+++ b/doc/sandbox/logistic_regression_example.rst
@@ -65,8 +65,8 @@ BUT, YOU GOTTA RUN THIS CODE AND MAKE SURE IT STILL WORKS NICELY, HEY?
 
     up_fn, app_fn = build_logistic_regression_model(n_in=10, n_out=3, l2_coef=30.0)
 
-    x_data = numpy.random.randn(100, 10)
-    y_data = numpy.random.randn(100, 3)
+    x_data = numpy.random.standard_normal((100, 10))
+    y_data = numpy.random.standard_normal((100, 3))
     y_data = _asarray(y_data == numpy.max(y_data, axis=1), dtype='int64')
 
     print "Model Training ..."

--- a/doc/sandbox/sparse.rst
+++ b/doc/sandbox/sparse.rst
@@ -11,31 +11,36 @@ Note that you want SciPy >= 0.7.2
 
 .. warning::
 
-    In SciPy 0.6, ``scipy.csc_matrix.dot`` has a bug with singleton
+    In SciPy 0.6, `scipy.csc_matrix.dot` has a bug with singleton
     dimensions. There may be more bugs. It also has inconsistent
     implementation of sparse matrices.
 
     We do not test against SciPy versions below 0.7.2.
 
 We describe the details of the compressed sparse matrix types.
-    ``scipy.sparse.csc_matrix``
-        should be used if there are more rows than column (shape[0] > shape[1]).
-    ``scipy.sparse.csr_matrix``
-        should be used if there are more columns than rows (shape[0] < shape[1]).
-    ``scipy.sparse.lil_matrix``
+    `scipy.sparse.csc_matrix`
+        should be used if there are more rows than column (``shape[0] > shape[1]``).
+    `scipy.sparse.csr_matrix`
+        should be used if there are more columns than rows (``shape[0] < shape[1]``).
+    `scipy.sparse.lil_matrix`
         is faster if we are modifying the array. After initial inserts,
         we can then convert to the appropriate sparse matrix format.
 
 The following types also exist:
-    ``dok_matrix``
+    `dok_matrix`
         Dictionary of Keys format. From their doc: This is an efficient structure for constructing sparse matrices incrementally.
-    ``coo_matrix``
+    `coo_matrix`
         Coordinate format. From their lil doc: consider using the COO format when constructing large matrices.
 
-There seems to be a new format planned for scipy 0.7.x:
-    ``bsr_matrix``
-        Block Compressed Row (BSR). From their doc: The Block Compressed Row (BSR) format is very similar to the Compressed Sparse Row (CSR) format. BSR is appropriate for sparse matrices with dense sub matrices like the last example below. Block matrices often arise in vector-valued finite element discretizations. In such cases, BSR is considerably more efficient than CSR and CSC for many sparse arithmetic operations.
-    ``dia_matrix``
+There seems to be a new format planned for SciPy 0.7.x:
+    `bsr_matrix`
+        Block Compressed Row (BSR). From their doc: The Block Compressed Row
+        (BSR) format is very similar to the Compressed Sparse Row (CSR)
+        format. BSR is appropriate for sparse matrices with dense sub matrices
+        like the last example below. Block matrices often arise in vector-valued
+        finite element discretizations. In such cases, BSR is considerably more
+        efficient than CSR and CSC for many sparse arithmetic operations.
+    `dia_matrix`
         Sparse matrix with DIAgonal storage
 
 There are four member variables that comprise a compressed matrix ``sp`` (for at least csc, csr and bsr):
@@ -52,9 +57,9 @@ There are four member variables that comprise a compressed matrix ``sp`` (for at
         row location.
     ``sp.indptr``
         gives the other location of the non-zero entry. For CSC, there are
-        as many values of indptr as there are columns + 1 in the matrix.
+        as many values of indptr as there are ``columns + 1`` in the matrix.
         ``sp.indptr[k] = x`` and ``indptr[k+1] = y`` means that column
-        k contains sp.data[x:y], i.e. the xth through the y-1th non-zero values.
+        ``k`` contains ``sp.data[x:y]``, i.e. the ``x``-th through the y-1th non-zero values.
 
 See the example below for details.
 
@@ -63,7 +68,7 @@ See the example below for details.
     >>> import scipy.sparse
     >>> sp = scipy.sparse.csc_matrix((5, 10))
     >>> sp[4, 0] = 20
-    /u/lisa/local/byhost/test_maggie46.iro.umontreal.ca/lib64/python2.5/site-packages/scipy/sparse/compressed.py:494: SparseEfficiencyWarning: changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
+    SparseEfficiencyWarning: changing the sparsity structure of a csc_matrix is expensive. lil_matrix is more efficient.
      SparseEfficiencyWarning)
     >>> sp[0, 0] = 10
     >>> sp[2, 3] = 30
@@ -91,13 +96,13 @@ Several things should be learned from the above example:
 * We actually use the wrong sparse matrix type. In fact, it is the
   *rows* that are sparse, not the columns. So, it would have been
   better to use ``sp = scipy.sparse.csr_matrix((5, 10))``.
-* We should have actually created the matrix as a ``lil_matrix``,
+* We should have actually created the matrix as a `lil_matrix`,
   which is more efficient for inserts. Afterwards, we should convert
   to the appropriate compressed format.
-* `sp.indptr[0] = 0` and `sp.indptr[1] = 2`, which means that
-  column 0 contains sp.data[0:2], i.e. the first two non-zero values.
-* `sp.indptr[3] = 2` and `sp.indptr[4] = 3`, which means that column
-  3 contains sp.data[2:3], i.e. the third non-zero value.
+* ``sp.indptr[0] = 0`` and ``sp.indptr[1] = 2``, which means that
+  column 0 contains ``sp.data[0:2]``, i.e. the first two non-zero values.
+* ``sp.indptr[3] = 2`` and ``sp.indptr[4] = 3``, which means that column
+  three contains ``sp.data[2:3]``, i.e. the third non-zero value.
 
 TODO: Rewrite this documentation to do things in a smarter way.
 
@@ -112,7 +117,7 @@ For faster sparse code:
 
 Misc
 ----
-The sparse equivalent of dmatrix is csc_matrix and csr_matrix.
+The sparse equivalent of `dmatrix` is `csc_matrix` and `csr_matrix`.
 
 :class:`~aesara.sparse.basic.Dot` vs. :class:`~aesara.sparse.basic.StructuredDot`
 ---------------------------------------------------------------------------------
@@ -121,22 +126,22 @@ Often when you use a sparse matrix it is because there is a meaning to the
 structure of non-zeros. The gradient on terms outside that structure
 has no meaning, so it is computationally efficient not to compute them.
 
-StructuredDot is when you want the gradient to have zeroes corresponding to
+`StructuredDot` is when you want the gradient to have zeroes corresponding to
 the sparse entries in the matrix.
 
-TrueDot and Structured dot have different gradients
+`TrueDot` and `Structured` dot have different gradients
 but their perform functions should be the same.
 
-The gradient of TrueDot can have non-zeros where the sparse matrix had zeros.
-The gradient of StructuredDot can't.
+The gradient of `TrueDot` can have non-zeros where the sparse matrix had zeros.
+The gradient of `StructuredDot` can't.
 
 Suppose you have ``dot(x,w)`` where ``x`` and ``w`` are square matrices.
-If ``w`` is dense, like ``randn((5,5))`` and ``x`` is of full rank (though
-potentially sparse, like a diagonal matrix of 1s) then the output will
-be dense too. (But i guess the density of the output is a red herring.)
+If ``w`` is dense, like ``standard_normal((5,5))`` and ``x`` is of full rank (though
+potentially sparse, like a diagonal matrix of ones) then the output will
+be dense too.
 What's important is the density of the gradient on the output.
 If the gradient on the output is dense, and ``w`` is dense (as we said it was)
-then the True gradient on ``x`` will be dense.
-If our dot is a TrueDot, then it will say that the gradient on ``x`` is dense.
-If our dot is a StructuredDot, then it will say the gradient on ``x`` is only
+then the ``True`` gradient on ``x`` will be dense.
+If our dot is a `TrueDot`, then it will say that the gradient on ``x`` is dense.
+If our dot is a `StructuredDot`, then it will say the gradient on ``x`` is only
 defined on the diagonal and ignore the gradients on the off-diagonal.

--- a/doc/tutorial/examples.rst
+++ b/doc/tutorial/examples.rst
@@ -27,7 +27,7 @@ the logistic curve, which is given by:
 
 .. figure:: logistic.png
 
-    A plot of the logistic function, with x on the x-axis and s(x) on the
+    A plot of the logistic function, with :math:`x` on the x-axis and :math:`s(x)` on the
     y-axis.
 
 You want to compute the function :ref:`element-wise
@@ -49,9 +49,9 @@ Well, what you do is this:
 array([[ 0.5       ,  0.73105858],
        [ 0.26894142,  0.11920292]])
 
-The reason logistic is performed elementwise is because all of its
-operations---division, addition, exponentiation, and division---are
-themselves elementwise operations.
+The reason the logistic is applied element-wise is because all of its
+operations--division, addition, exponentiation, and division--are
+themselves element-wise operations.
 
 It is also the case that:
 
@@ -76,7 +76,7 @@ Computing More than one Thing at the Same Time
 
 Aesara supports functions with multiple outputs. For example, we can
 compute the :ref:`element-wise <libdoc_tensor_elemwise>` difference, absolute difference, and
-squared difference between two matrices *a* and *b* at the same time:
+squared difference between two matrices ``a`` and ``b`` at the same time:
 
 .. If you modify this code, also change :
 .. tests/test_tutorial.py:T_examples.test_examples_3
@@ -92,7 +92,7 @@ squared difference between two matrices *a* and *b* at the same time:
    shortcut for allocating symbolic variables that we will often use in the
    tutorials.
 
-When we use the function f, it returns the three variables (the printing
+When we use the function ``f``, it returns the three variables (the printing
 was reformatted for readability):
 
 >>> f([[1, 1], [1, 1]], [[0, 1], [2, 3]])
@@ -124,12 +124,12 @@ array(35.0)
 
 This makes use of the :ref:`In <function_inputs>` class which allows
 you to specify properties of your function's parameters with greater detail. Here we
-give a default value of 1 for *y* by creating a ``In`` instance with
-its ``value`` field set to 1.
+give a default value of ``1`` for ``y`` by creating a :class:`In` instance with
+its ``value`` field set to ``1``.
 
-Inputs with default values must follow inputs without default
-values (like Python's functions).  There can be multiple inputs with default values. These parameters can
-be set positionally or by name, as in standard Python:
+Inputs with default values must follow inputs without default values (like
+Python's functions).  There can be multiple inputs with default values. These
+parameters can be set positionally or by name, as in standard Python:
 
 
 .. If you modify this code, also change :
@@ -150,9 +150,9 @@ array(34.0)
 array(33.0)
 
 .. note::
-   ``In`` does not know the name of the local variables *y* and *w*
+   `In` does not know the name of the local variables ``y`` and ``w``
    that are passed as arguments.  The symbolic variable objects have name
-   attributes (set by ``dscalars`` in the example above) and *these* are the
+   attributes (set by `dscalars` in the example above) and *these* are the
    names of the keyword parameters in the functions that we build.  This is
    the mechanism at work in ``In(y, value=1)``.  In the case of ``In(w,
    value=2, name='w_by_name')``. We override the symbolic variable's name
@@ -169,11 +169,11 @@ Using Shared Variables
 
 It is also possible to make a function with an internal state. For
 example, let's say we want to make an accumulator: at the beginning,
-the state is initialized to zero. Then, on each function call, the state
+the state is initialized to zero, then, on each function call, the state
 is incremented by the function's argument.
 
 First let's define the *accumulator* function. It adds its argument to the
-internal state, and returns the old state value.
+internal state and returns the old state value.
 
 .. If you modify this code, also change :
 .. tests/test_tutorial.py:T_examples.test_examples_8
@@ -187,17 +187,17 @@ This code introduces a few new concepts.  The ``shared`` function constructs
 so-called :ref:`shared variables<libdoc_compile_shared>`.
 These are hybrid symbolic and non-symbolic variables whose value may be shared
 between multiple functions.  Shared variables can be used in symbolic expressions just like
-the objects returned by ``dmatrices(...)`` but they also have an internal
+the objects returned by `dmatrices` but they also have an internal
 value that defines the value taken by this symbolic variable in *all* the
 functions that use it.  It is called a *shared* variable because its value is
 shared between many functions.  The value can be accessed and modified by the
-``.get_value()`` and ``.set_value()`` methods. We will come back to this soon.
+:meth:`get_value` and :meth:`set_value` methods. We will come back to this soon.
 
-The other new thing in this code is the ``updates`` parameter of ``function``.
+The other new thing in this code is the ``updates`` parameter of :func:`aesara.function`.
 ``updates`` must be supplied with a list of pairs of the form (shared-variable, new expression).
 It can also be a dictionary whose keys are shared-variables and values are
 the new expressions.  Either way, it means "whenever this function runs, it
-will replace the ``.value`` of each shared variable with the result of the
+will replace the :attr:`value` of each shared variable with the result of the
 corresponding expression".  Above, our accumulator replaces the ``state``'s value with the sum
 of the state and the increment amount.
 
@@ -246,7 +246,7 @@ updates).
 
 It may happen that you expressed some formula using a shared variable, but
 you do *not* want to use its value. In this case, you can use the
-``givens`` parameter of ``function`` which replaces a particular node in a graph
+``givens`` parameter of :func:`aesara.function` which replaces a particular node in a graph
 for the purpose of one particular function.
 
 .. If you modify this code, also change :
@@ -274,18 +274,26 @@ expression that evaluates to a tensor of same shape and dtype.
 
 .. note::
 
-    Aesara shared variable broadcast pattern default to False for each
+    Aesara shared variable broadcast pattern default to ``False`` for each
     dimensions. Shared variable size can change over time, so we can't
     use the shape to find the broadcastable pattern. If you want a
     different pattern, just pass it as a parameter
-    ``aesara.shared(..., shape=(True, False))``
+    ``aesara.shared(..., broadcastable=(True, False))``
+
+.. note::
+    Use the ``shape`` parameter to specify tuples of static shapes instead;
+    the old broadcastable values are being phased-out.  Unknown shape values
+    for dimensions take the value ``None``; otherwise, integers are used for
+    known static shape values.
+    For example, ``aesara.shared(..., shape=(1, None))``.
 
 Copying functions
 =================
 Aesara functions can be copied, which can be useful for creating similar
 functions but with different shared variables or updates. This is done using
-the :func:`copy()<aesara.compile.function.types.Function.copy>` method of ``function`` objects. The optimized graph of the original function is copied,
-so compilation only needs to be performed once.
+the :func:`aesara.compile.function.types.Function.copy` method of :class:`Function` objects.
+The optimized graph of the original function is copied, so compilation only
+needs to be performed once.
 
 Let's start from the accumulator defined above:
 
@@ -302,7 +310,7 @@ array(0)
 >>> print(state.get_value())
 10
 
-We can use ``copy()`` to create a similar accumulator but with its own internal state
+We can use :meth:`copy` to create a similar accumulator but with its own internal state
 using the ``swap`` parameter, which is a dictionary of shared variables to exchange:
 
 >>> new_state = aesara.shared(0)
@@ -361,11 +369,13 @@ Here's a brief example.  The setup code is:
 
     from aesara.tensor.random.utils import RandomStream
     from aesara import function
+
+
     srng = RandomStream(seed=234)
     rv_u = srng.uniform(0, 1, size=(2,2))
     rv_n = srng.normal(0, 1, size=(2,2))
     f = function([], rv_u)
-    g = function([], rv_n, no_default_updates=True)    #Not updating rv_n.rng
+    g = function([], rv_n, no_default_updates=True)
     nearly_zeros = function([], rv_u + rv_u - 2 * rv_u)
 
 Here, ``rv_u`` represents a random stream of 2x2 matrices of draws from a uniform
@@ -383,16 +393,16 @@ so we get different random numbers every time.
 >>> f_val1 = f()  #different numbers from f_val0
 
 When we add the extra argument ``no_default_updates=True`` to
-``function`` (as in *g*), then the random number generator state is
+``function`` (as in ``g``), then the random number generator state is
 not affected by calling the returned function.  So, for example, calling
-*g* multiple times will return the same numbers.
+``g`` multiple times will return the same numbers.
 
 >>> g_val0 = g()  # different numbers from f_val0 and f_val1
 >>> g_val1 = g()  # same numbers as g_val0!
 
 An important remark is that a random variable is drawn at most once during any
-single function execution.  So the *nearly_zeros* function is guaranteed to
-return approximately 0 (except for rounding error) even though the *rv_u*
+single function execution.  So the `nearly_zeros` function is guaranteed to
+return approximately 0 (except for rounding error) even though the ``rv_u``
 random variable appears three times in the output expression.
 
 >>> nearly_zeros = function([], rv_u + rv_u - 2 * rv_u)
@@ -400,17 +410,8 @@ random variable appears three times in the output expression.
 Seeding Streams
 ---------------
 
-Random variables can be seeded individually or collectively.
-
-You can seed just one random variable by seeding or assigning to the
-``.rng`` attribute, using ``.rng.set_value()``.
-
->>> rng_val = rv_u.rng.get_value(borrow=True)   # Get the rng for rv_u
->>> rng_val.seed(89234)                         # seeds the generator
->>> rv_u.rng.set_value(rng_val, borrow=True)    # Assign back seeded rng
-
-You can also seed *all* of the random variables allocated by a :class:`RandomStream`
-object by that object's ``seed`` method.  This seed will be used to seed a
+You can seed all of the random variables allocated by a :class:`RandomStream`
+object by that object's :meth:`RandomStream.seed` method.  This seed will be used to seed a
 temporary random number generator, that will in turn generate seeds for each
 of the random variables.
 
@@ -420,28 +421,15 @@ Sharing Streams Between Functions
 ---------------------------------
 
 As usual for shared variables, the random number generators used for random
-variables are common between functions.  So our *nearly_zeros* function will
-update the state of the generators used in function *f* above.
-
-For example:
-
->>> state_after_v0 = rv_u.rng.get_value().get_state()
->>> nearly_zeros()       # this affects rv_u's generator
-array([[ 0.,  0.],
-       [ 0.,  0.]])
->>> v1 = f()
->>> rng = rv_u.rng.get_value(borrow=True)
->>> rng.set_state(state_after_v0)
->>> rv_u.rng.set_value(rng, borrow=True)
->>> v2 = f()             # v2 != v1
->>> v3 = f()             # v3 == v1
+variables are common between functions.  So our ``nearly_zeros`` function will
+update the state of the generators used in function ``f`` above.
 
 Copying Random State Between Aesara Graphs
 ------------------------------------------
 
 In some use cases, a user might want to transfer the "state" of all random
-number generators associated with a given aesara graph (e.g. g1, with compiled
-function f1 below) to a second graph (e.g. g2, with function f2). This might
+number generators associated with a given Aesara graph (e.g. ``g1``, with compiled
+function ``f1`` below) to a second graph (e.g. ``g2``, with function ``f2``). This might
 arise for example if you are trying to initialize the state of a model, from
 the parameters of a pickled version of a previous model. For
 :class:`aesara.tensor.random.utils.RandomStream` and
@@ -449,50 +437,10 @@ the parameters of a pickled version of a previous model. For
 this can be achieved by copying elements of the `state_updates` parameter.
 
 Each time a random variable is drawn from a `RandomStream` object, a tuple is
-added to the `state_updates` list. The first element is a shared variable,
+added to its :attr:`state_updates` list. The first element is a shared variable,
 which represents the state of the random number generator associated with this
-*particular* variable, while the second represents the aesara graph
-corresponding to the random number generation process (i.e. RandomFunction{uniform}.0).
-
-An example of how "random states" can be transferred from one aesara function
-to another is shown below.
-
->>> import aesara
->>> import numpy
->>> import aesara.tensor as at
->>> from aesara.sandbox.rng_mrg import MRG_RandomStream
->>> from aesara.tensor.random.utils import RandomStream
-
->>> class Graph():
-...     def __init__(self, seed=123):
-...         self.rng = RandomStream(seed)
-...         self.y = self.rng.uniform(size=(1,))
-
->>> g1 = Graph(seed=123)
->>> f1 = aesara.function([], g1.y)
-
->>> g2 = Graph(seed=987)
->>> f2 = aesara.function([], g2.y)
-
->>> # By default, the two functions are out of sync.
->>> f1()
-array([ 0.72803009])
->>> f2()
-array([ 0.55056769])
-
->>> def copy_random_state(g1, g2):
-...     if isinstance(g1.rng, MRG_RandomStream):
-...         g2.rng.rstate = g1.rng.rstate
-...     for (su1, su2) in zip(g1.rng.state_updates, g2.rng.state_updates):
-...         su2[0].set_value(su1[0].get_value())
-
->>> # We now copy the state of the aesara random number generators.
->>> copy_random_state(g1, g2)
->>> f1()
-array([ 0.59044123])
->>> f2()
-array([ 0.59044123])
-
+*particular* variable, while the second represents the Aesara graph
+corresponding to the random number generation process.
 
 Other Random Distributions
 --------------------------
@@ -511,16 +459,18 @@ It will be used repeatedly.
 
 .. testcode::
 
-    import numpy
+    import numpy as np
     import aesara
     import aesara.tensor as at
-    rng = numpy.random
+
+
+    rng = np.random.default_rng(2882)
 
     N = 400                                   # training sample size
     feats = 784                               # number of input variables
 
     # generate a dataset: D = (input_values, target_class)
-    D = (rng.randn(N, feats), rng.randint(size=N, low=0, high=2))
+    D = (rng.standard_normal((N, feats)), rng.integers(size=N, low=0, high=2))
     training_steps = 10000
 
     # Declare Aesara symbolic variables
@@ -532,7 +482,7 @@ It will be used repeatedly.
     # this and the following bias variable b
     # are shared so they keep their values
     # between training iterations (updates)
-    w = aesara.shared(rng.randn(feats), name="w")
+    w = aesara.shared(rng.standard_normal(feats), name="w")
 
     # initialize the bias term
     b = aesara.shared(0., name="b")
@@ -542,7 +492,7 @@ It will be used repeatedly.
     print(b.get_value())
 
     # Construct Aesara expression graph
-    p_1 = 1 / (1 + at.exp(-at.dot(x, w) - b))        # Probability that target = 1
+    p_1 = 1 / (1 + at.exp(-at.dot(x, w) - b))       # Probability that target = 1
     prediction = p_1 > 0.5                          # The prediction thresholded
     xent = -y * at.log(p_1) - (1-y) * at.log(1-p_1) # Cross-entropy loss function
     cost = xent.mean() + 0.01 * (w ** 2).sum()      # The cost to minimize

--- a/doc/tutorial/modes.rst
+++ b/doc/tutorial/modes.rst
@@ -9,11 +9,11 @@ Configuration Settings and Compiling Modes
 Configuration
 =============
 
-The ``config`` module contains several *attributes* that modify Aesara's behavior.  Many of these
-attributes are examined during the import of the ``aesara`` module and several are assumed to be
+The :mod:`aesara.config` module contains several *attributes* that modify Aesara's behavior.  Many of these
+attributes are examined during the import of the :mod:`aesara` module and several are assumed to be
 read-only.
 
-*As a rule, the attributes in the* ``config`` *module should not be modified inside the user code.*
+*As a rule, the attributes in the* :mod:`aesara.config` *module should not be modified inside the user code.*
 
 Aesara's code comes with default values for these attributes, but you can
 override them from your ``.aesararc`` file, and override those values in turn by
@@ -21,12 +21,12 @@ the :envvar:`AESARA_FLAGS` environment variable.
 
 The order of precedence is:
 
-1. an assignment to aesara.config.<property>
+1. an assignment to ``aesara.config.<property>``
 2. an assignment in :envvar:`AESARA_FLAGS`
-3. an assignment in the .aesararc file (or the file indicated in :envvar:`AESARARC`)
+3. an assignment in the ``.aesararc`` file (or the file indicated in :envvar:`AESARARC`)
 
 You can display the current/effective configuration at any time by printing
-aesara.config.  For example, to see a list  of all active configuration
+`aesara.config`.  For example, to see a list  of all active configuration
 variables, type this from the command-line:
 
 .. code-block:: bash
@@ -45,22 +45,24 @@ Consider the logistic regression:
 
 .. testcode::
 
-    import numpy
+    import numpy as np
     import aesara
     import aesara.tensor as at
-    rng = numpy.random
+
+
+    rng = np.random.default_rng(2498)
 
     N = 400
     feats = 784
-    D = (rng.randn(N, feats).astype(aesara.config.floatX),
-    rng.randint(size=N,low=0, high=2).astype(aesara.config.floatX))
+    D = (rng.standard_normal((N, feats)).astype(aesara.config.floatX),
+    rng.integers(size=N,low=0, high=2).astype(aesara.config.floatX))
     training_steps = 10000
 
     # Declare Aesara symbolic variables
     x = at.matrix("x")
     y = at.vector("y")
-    w = aesara.shared(rng.randn(feats).astype(aesara.config.floatX), name="w")
-    b = aesara.shared(numpy.asarray(0., dtype=aesara.config.floatX), name="b")
+    w = aesara.shared(rng.standard_normal(feats).astype(aesara.config.floatX), name="w")
+    b = aesara.shared(np.asarray(0., dtype=aesara.config.floatX), name="b")
     x.tag.test_value = D[0]
     y.tag.test_value = D[1]
 
@@ -73,15 +75,18 @@ Consider the logistic regression:
 
     # Compile expressions to functions
     train = aesara.function(
-                inputs=[x,y],
-                outputs=[prediction, xent],
-                updates=[(w, w-0.01*gw), (b, b-0.01*gb)],
-                name = "train")
-    predict = aesara.function(inputs=[x], outputs=prediction,
-                name = "predict")
+        inputs=[x,y],
+        outputs=[prediction, xent],
+        updates=[(w, w-0.01*gw), (b, b-0.01*gb)],
+        name = "train"
+    )
+    predict = aesara.function(
+        inputs=[x], outputs=prediction,
+        name = "predict"
+    )
 
-    if any([x.op.__class__.__name__ in ['Gemv', 'CGemv', 'Gemm', 'CGemm'] for x in
-            train.maker.fgraph.toposort()]):
+    if any([x.op.__class__.__name__ in ['Gemv', 'CGemv', 'Gemm', 'CGemm']
+           for x in train.maker.fgraph.toposort()]):
         print('Used the cpu')
     else:
         print('ERROR, not able to tell if aesara used the cpu or another device')
@@ -106,7 +111,7 @@ Consider the logistic regression:
    prediction on D
    ...
 
-Modify and execute this example to run on CPU (the default) with floatX=float32 and
+Modify and execute this example to run on CPU (the default) with ``floatX=float32`` and
 time the execution using the command line ``time python file.py``.  Save your code
 as it will be useful later on.
 
@@ -114,10 +119,10 @@ as it will be useful later on.
 
    * Apply the Aesara flag ``floatX=float32`` (through ``aesara.config.floatX``) in your code.
    * Cast inputs before storing them into a shared variable.
-   * Circumvent the automatic cast of *int32* with *float32* to *float64*:
+   * Circumvent the automatic cast of int32 with float32 to float64:
 
-     * Insert manual cast in your code or use *[u]int{8,16}*.
-     * Insert manual cast around the mean operator (this involves division by length, which is an *int64*).
+     * Insert manual cast in your code or use [u]int{8,16}.
+     * Insert manual cast around the mean operator (this involves division by length, which is an int64).
      * Note that a new casting mechanism is being developed.
 
 :download:`Solution<modes_solution_1.py>`
@@ -156,7 +161,7 @@ short name        Full constructor                                              
 
 .. Note::
 
-    For debugging purpose, there also exists a ``MonitorMode`` (which has no
+    For debugging purpose, there also exists a :class:`MonitorMode` (which has no
     short name). It can be used to step through the execution of a function:
     see :ref:`the debugging FAQ<faq_monitormode>` for details.
 
@@ -165,8 +170,8 @@ Linkers
 =======
 
 A mode is composed of 2 things: an optimizer and a linker. Some modes,
-like ``NanGuardMode`` and ``DebugMode``, add logic around the
-optimizer and linker. ``DebugMode`` uses its own linker.
+like `NanGuardMode` and `DebugMode`, add logic around the
+optimizer and linker. `DebugMode` uses its own linker.
 
 You can select which linker to use with the Aesara flag :attr:`config.linker`.
 Here is a table to compare the different linkers.
@@ -233,8 +238,8 @@ Using DebugMode
 
 While normally you should use the ``FAST_RUN`` or ``FAST_COMPILE`` mode,
 it is useful at first (especially when you are defining new kinds of
-expressions or new optimizations) to run your code using the DebugMode
-(available via ``mode='DebugMode``). The DebugMode is designed to
+expressions or new optimizations) to run your code using the `DebugMode`
+(available via ``mode='DebugMode``). The `DebugMode` is designed to
 run several self-checks and assertions that can help diagnose
 possible programming errors leading to incorrect output. Note that
 ``DebugMode`` is much slower than ``FAST_RUN`` or ``FAST_COMPILE`` so
@@ -245,7 +250,7 @@ cluster!).
 .. If you modify this code, also change :
 .. tests/test_tutorial.py:T_modes.test_modes_1
 
-DebugMode is used as follows:
+`DebugMode` is used as follows:
 
 .. testcode::
 
@@ -258,21 +263,21 @@ DebugMode is used as follows:
     f([7])
 
 
-If any problem is detected, DebugMode will raise an exception according to
-what went wrong, either at call time (*f(5)*) or compile time (
+If any problem is detected, `DebugMode` will raise an exception according to
+what went wrong, either at call time (e.g. ``f(5)``) or compile time (
 ``f = aesara.function(x, 10 * x, mode='DebugMode')``). These exceptions
 should *not* be ignored; talk to your local Aesara guru or email the
 users list if you cannot make the exception go away.
 
 Some kinds of errors can only be detected for certain input value combinations.
 In the example above, there is no way to guarantee that a future call to, say
-*f(-1)*, won't cause a problem.  DebugMode is not a silver bullet.
+``f(-1)``, won't cause a problem.  `DebugMode` is not a silver bullet.
 
 .. TODO: repair the following link
 
-If you instantiate DebugMode using the constructor (see :class:`DebugMode`)
-rather than the keyword ``DebugMode`` you can configure its behaviour via
-constructor arguments. The keyword version of DebugMode (which you get by using ``mode='DebugMode'``)
+If you instantiate `DebugMode` using the constructor (see :class:`DebugMode`)
+rather than the keyword `DebugMode` you can configure its behaviour via
+constructor arguments. The keyword version of `DebugMode` (which you get by using ``mode='DebugMode'``)
 is quite strict.
 
 For more detail, see :ref:`DebugMode<debugmode>` in the library.

--- a/doc/tutorial/modes_solution_1.py
+++ b/doc/tutorial/modes_solution_1.py
@@ -2,59 +2,62 @@
 # Aesara tutorial
 # Solution to Exercise in section 'Configuration Settings and Compiling Modes'
 
-
 import numpy as np
 import aesara
 import aesara.tensor as at
 
-aesara.config.floatX = 'float32'
 
-rng = np.random
+aesara.config.floatX = "float32"
+
+rng = np.random.default_rng(428)
 
 N = 400
 feats = 784
-D = (rng.randn(N, feats).astype(aesara.config.floatX),
-rng.randint(size=N, low=0, high=2).astype(aesara.config.floatX))
+D = (
+    rng.standard_normal((N, feats)).astype(aesara.config.floatX),
+    rng.integers(size=N, low=0, high=2).astype(aesara.config.floatX),
+)
 training_steps = 10000
 
 # Declare Aesara symbolic variables
 x = at.matrix("x")
 y = at.vector("y")
-w = aesara.shared(rng.randn(feats).astype(aesara.config.floatX), name="w")
-b = aesara.shared(np.asarray(0., dtype=aesara.config.floatX), name="b")
+w = aesara.shared(rng.standard_normal(feats).astype(aesara.config.floatX), name="w")
+b = aesara.shared(np.asarray(0.0, dtype=aesara.config.floatX), name="b")
 x.tag.test_value = D[0]
 y.tag.test_value = D[1]
-#print "Initial model:"
-#print w.get_value(), b.get_value()
+# print "Initial model:"
+# print w.get_value(), b.get_value()
 
 # Construct Aesara expression graph
 p_1 = 1 / (1 + at.exp(-at.dot(x, w) - b))  # Probability of having a one
 prediction = p_1 > 0.5  # The prediction that is done: 0 or 1
 xent = -y * at.log(p_1) - (1 - y) * at.log(1 - p_1)  # Cross-entropy
-cost = at.cast(xent.mean(), 'float32') + \
-       0.01 * (w ** 2).sum()  # The cost to optimize
+cost = at.cast(xent.mean(), "float32") + 0.01 * (w**2).sum()  # The cost to optimize
 gw, gb = at.grad(cost, [w, b])
 
 # Compile expressions to functions
 train = aesara.function(
-            inputs=[x, y],
-            outputs=[prediction, xent],
-            updates={w: w - 0.01 * gw, b: b - 0.01 * gb},
-            name="train")
-predict = aesara.function(inputs=[x], outputs=prediction,
-            name="predict")
+    inputs=[x, y],
+    outputs=[prediction, xent],
+    updates={w: w - 0.01 * gw, b: b - 0.01 * gb},
+    name="train",
+)
+predict = aesara.function(inputs=[x], outputs=prediction, name="predict")
 
-if any(x.op.__class__.__name__ in ('Gemv', 'CGemv', 'Gemm', 'CGemm') for x in
-train.maker.fgraph.toposort()):
-    print('Used the cpu')
+if any(
+    x.op.__class__.__name__ in ("Gemv", "CGemv", "Gemm", "CGemm")
+    for x in train.maker.fgraph.toposort()
+):
+    print("Used the cpu")
 else:
-    print('ERROR, not able to tell if aesara used the cpu or another device')
+    print("ERROR, not able to tell if aesara used the cpu or another device")
     print(train.maker.fgraph.toposort())
 
 for i in range(training_steps):
     pred, err = train(D[0], D[1])
-#print "Final model:"
-#print w.get_value(), b.get_value()
+# print "Final model:"
+# print w.get_value(), b.get_value()
 
 print("target values for D")
 print(D[1])

--- a/doc/tutorial/printing_drawing.rst
+++ b/doc/tutorial/printing_drawing.rst
@@ -25,20 +25,20 @@ that creates an image of the function. You can read about them in
 
 Consider again the logistic regression example:
 
->>> import numpy
+>>> import numpy as np
 >>> import aesara
 >>> import aesara.tensor as at
->>> rng = numpy.random
+>>> rng = np.random.default_rng(2382)
 >>> # Training data
 >>> N = 400
 >>> feats = 784
->>> D = (rng.randn(N, feats).astype(aesara.config.floatX), rng.randint(size=N,low=0, high=2).astype(aesara.config.floatX))
+>>> D = (rng.standard_normal(N, feats).astype(aesara.config.floatX), rng.integers(size=N,low=0, high=2).astype(aesara.config.floatX))
 >>> training_steps = 10000
 >>> # Declare Aesara symbolic variables
 >>> x = at.matrix("x")
 >>> y = at.vector("y")
->>> w = aesara.shared(rng.randn(feats).astype(aesara.config.floatX), name="w")
->>> b = aesara.shared(numpy.asarray(0., dtype=aesara.config.floatX), name="b")
+>>> w = aesara.shared(rng.standard_normal(feats).astype(aesara.config.floatX), name="w")
+>>> b = aesara.shared(np.asarray(0., dtype=aesara.config.floatX), name="b")
 >>> x.tag.test_value = D[0]
 >>> y.tag.test_value = D[1]
 >>> # Construct Aesara expression graph

--- a/doc/tutorial/profiling_example.py
+++ b/doc/tutorial/profiling_example.py
@@ -1,11 +1,10 @@
-
 import numpy as np
 
 import aesara
 
-x, y, z = aesara.tensor.vectors('xyz')
+x, y, z = aesara.tensor.vectors("xyz")
 f = aesara.function([x, y, z], [(x + y + z) * 2])
-xv = np.random.rand(10).astype(aesara.config.floatX)
-yv = np.random.rand(10).astype(aesara.config.floatX)
-zv = np.random.rand(10).astype(aesara.config.floatX)
+xv = np.random.random((10,)).astype(aesara.config.floatX)
+yv = np.random.random((10,)).astype(aesara.config.floatX)
+zv = np.random.random((10,)).astype(aesara.config.floatX)
 f(xv, yv, zv)

--- a/doc/tutorial/shape_info.rst
+++ b/doc/tutorial/shape_info.rst
@@ -49,7 +49,7 @@ upgrade.  Here is the current state of what can be done:
 
     aesara.tensor.nnet.conv2d(..., image_shape=(7, 3, 5, 5), filter_shape=(2, 3, 4, 4))
 
-- You can use the ``SpecifyShape`` op to add shape information anywhere in the
+- You can use the :class:`SpecifyShape`\ :class:`Op` to add shape information anywhere in the
   graph. This allows to perform some optimizations. In the following example,
   this makes it possible to precompute the Aesara function to a constant.
 
@@ -67,13 +67,13 @@ Problems with Shape inference
 
 Sometimes this can lead to errors.  Consider this example:
 
->>> import numpy
+>>> import numpy as np
 >>> import aesara
 >>> x = aesara.tensor.matrix('x')
 >>> y = aesara.tensor.matrix('y')
 >>> z = aesara.tensor.join(0, x, y)
->>> xv = numpy.random.rand(5, 4)
->>> yv = numpy.random.rand(3, 3)
+>>> xv = np.random.random((5, 4))
+>>> yv = np.random.random((3, 3))
 
 >>> f = aesara.function([x, y], z.shape)
 >>> aesara.printing.debugprint(f) # doctest: +NORMALIZE_WHITESPACE
@@ -109,7 +109,7 @@ This makes the computation of the shape faster, but it can also hide errors. In
 this example, the computation of the shape of the output of ``join`` is done only
 based on the first input Aesara variable, which leads to an error.
 
-This might happen with other ops such as ``elemwise`` and ``dot``, for example.
+This might happen with other `Op`\s such as :class:`Elemwise` and :class:`Dot`, for example.
 Indeed, to perform some optimizations (for speed or stability, for instance),
 Aesara assumes that the computation is correct and consistent
 in the first place, as it does here.
@@ -118,5 +118,5 @@ You can detect those problems by running the code without this
 optimization, using the Aesara flag
 ``optimizer_excluding=local_shape_to_shape_i``. You can also obtain the
 same effect by running in the modes ``FAST_COMPILE`` (it will not apply this
-optimization, nor most other optimizations) or ``DebugMode`` (it will test
-before and after all optimizations (much slower)).
+optimization, nor most other optimizations) or :class:`DebugMode` (it will test
+before and after all optimizations).

--- a/tests/compile/function/test_types.py
+++ b/tests/compile/function/test_types.py
@@ -352,7 +352,7 @@ class TestFunction:
 
     def test_swap_SharedVariable(self):
         i = iscalar()
-        x_list = shared(value=np.random.rand(10).astype(config.floatX))
+        x_list = shared(value=np.random.random((10,)).astype(config.floatX))
 
         x = scalar("x")
         # SharedVariable for tests, one of them has update
@@ -419,11 +419,11 @@ class TestFunction:
         # A special testcase for logistic_sgd.py in Deep Learning Tutorial
         # This test assert that SharedVariable in different function have same storage
 
-        train_x = shared(value=np.random.rand(10, 10).astype(config.floatX))
-        test_x = shared(value=np.random.rand(10, 10).astype(config.floatX))
+        train_x = shared(value=np.random.random((10, 10)).astype(config.floatX))
+        test_x = shared(value=np.random.random((10, 10)).astype(config.floatX))
 
-        train_y = shared(value=np.random.rand(10, 1).astype(config.floatX))
-        test_y = shared(value=np.random.rand(10, 1).astype(config.floatX))
+        train_y = shared(value=np.random.random((10, 1)).astype(config.floatX))
+        test_y = shared(value=np.random.random((10, 1)).astype(config.floatX))
 
         i = iscalar("index")
         x = vector("x")
@@ -604,7 +604,7 @@ class TestFunction:
         # when borrow=True is implemented.
 
         a = dmatrix()
-        aval = np.random.rand(3, 3)
+        aval = np.random.random((3, 3))
 
         # when borrow=False, test that a destroy map cannot alias output to input
         f = function([In(a, borrow=False)], Out(a + 1, borrow=True))
@@ -699,7 +699,7 @@ class TestFunction:
             assert funct(first=1) == x
 
     def test_check_for_aliased_inputs(self):
-        b = np.random.rand(5, 4)
+        b = np.random.random((5, 4))
         s1 = shared(b)
         s2 = shared(b)
         x1 = vector()
@@ -1053,7 +1053,7 @@ class TestPicklefunction:
         def pers_load(id):
             return saves[id]
 
-        b = np.random.rand(5, 4)
+        b = np.random.random((5, 4))
 
         x = matrix()
         y = shared(b)

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -124,7 +124,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
     )
     def test_shared(self, cls_ofg):
         x, y, z = matrices("xyz")
-        s = shared(np.random.rand(2, 2).astype(config.floatX))
+        s = shared(np.random.random((2, 2)).astype(config.floatX))
         e = x + y * z + s
         op = cls_ofg([x, y, z], [e])
         # (1+3*5=array of 16) - (3+1*5=array of 8)
@@ -144,7 +144,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
     )
     def test_shared_grad(self, cls_ofg):
         x, y, z = matrices("xyz")
-        s = shared(np.random.rand(2, 2).astype(config.floatX))
+        s = shared(np.random.random((2, 2)).astype(config.floatX))
         e = x + y * z + s
         op = cls_ofg([x, y, z], [e])
         f = op(x, y, z)
@@ -184,8 +184,8 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
             zz = at_sum(op(xx, yy))
             dx, dy = grad(zz, [xx, yy])
             fn = function([xx, yy], [dx, dy])
-            xv = np.random.rand(16).astype(config.floatX)
-            yv = np.random.rand(16).astype(config.floatX)
+            xv = np.random.random((16,)).astype(config.floatX)
+            yv = np.random.random((16,)).astype(config.floatX)
             dxv, dyv = fn(xv, yv)
             np.testing.assert_array_almost_equal(yv * 2, dxv, 4)
             np.testing.assert_array_almost_equal(xv * 1.5, dyv, 4)
@@ -210,9 +210,9 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         zz = at_sum(op_linear(xx, ww, bb))
         dx, dw, db = grad(zz, [xx, ww, bb])
         fn = function([xx, ww, bb], [dx, dw, db])
-        xv = np.random.rand(16).astype(config.floatX)
-        wv = np.random.rand(16).astype(config.floatX)
-        bv = np.random.rand(16).astype(config.floatX)
+        xv = np.random.random((16,)).astype(config.floatX)
+        wv = np.random.random((16,)).astype(config.floatX)
+        bv = np.random.random((16,)).astype(config.floatX)
         dxv, dwv, dbv = fn(xv, wv, bv)
         np.testing.assert_array_almost_equal(wv * 2, dxv, 4)
         np.testing.assert_array_almost_equal(xv * 1.5, dwv, 4)
@@ -262,7 +262,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
             gyy2 = grad(yy2, xx)
             fn = function([xx], [gyy1, gyy2])
 
-            xval = np.random.rand(32).astype(config.floatX)
+            xval = np.random.random((32,)).astype(config.floatX)
             y1val, y2val = fn(xval)
             np.testing.assert_array_almost_equal(y1val, y2val, 4)
 
@@ -280,9 +280,9 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         du = vector()
         dv = Rop(y, x, du)
         fn = function([x, W, du], dv)
-        xval = np.random.rand(16).astype(config.floatX)
-        Wval = np.random.rand(16, 16).astype(config.floatX)
-        duval = np.random.rand(16).astype(config.floatX)
+        xval = np.random.random((16,)).astype(config.floatX)
+        Wval = np.random.random((16, 16)).astype(config.floatX)
+        duval = np.random.random((16,)).astype(config.floatX)
         dvval = np.dot(duval, Wval)
         dvval2 = fn(xval, Wval, duval)
         np.testing.assert_array_almost_equal(dvval2, dvval, 4)
@@ -310,7 +310,7 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
             zz = op_mul(xx, yy)
             dw = Rop(zz, [xx, yy], [du, dv])
             fn = function([xx, yy, du, dv], dw)
-            vals = np.random.rand(4, 32).astype(config.floatX)
+            vals = np.random.random((4, 32)).astype(config.floatX)
             dwval = fn(*vals)
             np.testing.assert_array_almost_equal(
                 dwval, vals[0] * vals[3] * 1.5 + vals[1] * vals[2] * 2.0, 4
@@ -363,8 +363,8 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         xx2, yy2 = op_ift(*op_ft(xx, yy))
         fn = function([xx, yy], [xx2, yy2])
 
-        xv = np.random.rand(16).astype(config.floatX)
-        yv = np.random.rand(16).astype(config.floatX)
+        xv = np.random.random((16,)).astype(config.floatX)
+        yv = np.random.random((16,)).astype(config.floatX)
         xv2, yv2 = fn(xv, yv)
         np.testing.assert_array_almost_equal(xv, xv2, 4)
         np.testing.assert_array_almost_equal(yv, yv2, 4)

--- a/tests/compile/test_nanguardmode.py
+++ b/tests/compile/test_nanguardmode.py
@@ -20,14 +20,19 @@ def test_NanGuardMode():
     # Tests if NanGuardMode is working by feeding in numpy.inf and numpy.nans
     # intentionally. A working implementation should be able to capture all
     # the abnormalties.
+    rng = np.random.default_rng(2482)
     x = matrix()
-    w = shared(np.random.randn(5, 7).astype(config.floatX))
+    w = shared(rng.standard_normal((5, 7)).astype(config.floatX))
     y = dot(x, w)
 
     fun = function([x], y, mode=NanGuardMode(nan_is_error=True, inf_is_error=True))
-    a = np.random.randn(3, 5).astype(config.floatX)
-    infa = np.tile((np.asarray(100.0) ** 1000000).astype(config.floatX), (3, 5))
+    a = rng.standard_normal((3, 5)).astype(config.floatX)
+
+    with pytest.warns(RuntimeWarning):
+        infa = np.tile((np.asarray(100.0) ** 1000000).astype(config.floatX), (3, 5))
+
     nana = np.tile(np.asarray(np.nan).astype(config.floatX), (3, 5))
+
     biga = np.tile(np.asarray(1e20).astype(config.floatX), (3, 5))
 
     fun(a)  # normal values
@@ -38,7 +43,7 @@ def test_NanGuardMode():
         _logger.propagate = False
         with pytest.raises(AssertionError):
             fun(infa)  # INFs
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError), pytest.warns(RuntimeWarning):
             fun(nana)  # NANs
         with pytest.raises(AssertionError):
             fun(biga)  # big values
@@ -46,9 +51,13 @@ def test_NanGuardMode():
         _logger.propagate = True
 
     # slices
-    a = np.random.randn(3, 4, 5).astype(config.floatX)
-    infa = np.tile((np.asarray(100.0) ** 1000000).astype(config.floatX), (3, 4, 5))
+    a = rng.standard_normal((3, 4, 5)).astype(config.floatX)
+
+    with pytest.warns(RuntimeWarning):
+        infa = np.tile((np.asarray(100.0) ** 1000000).astype(config.floatX), (3, 4, 5))
+
     nana = np.tile(np.asarray(np.nan).astype(config.floatX), (3, 4, 5))
+
     biga = np.tile(np.asarray(1e20).astype(config.floatX), (3, 4, 5))
 
     x = tensor3()
@@ -59,7 +68,7 @@ def test_NanGuardMode():
         _logger.propagate = False
         with pytest.raises(AssertionError):
             fun(infa)  # INFs
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError), pytest.warns(RuntimeWarning):
             fun(nana)  # NANs
         with pytest.raises(AssertionError):
             fun(biga)  # big values

--- a/tests/compile/test_shared.py
+++ b/tests/compile/test_shared.py
@@ -37,9 +37,9 @@ class TestSharedVariable:
         # test tensor constructor
         b = shared(np.zeros((5, 5), dtype="int32"))
         assert b.type == TensorType("int32", shape=[False, False])
-        b = shared(np.random.rand(4, 5))
+        b = shared(np.random.random((4, 5)))
         assert b.type == TensorType("float64", shape=[False, False])
-        b = shared(np.random.rand(5, 1, 2))
+        b = shared(np.random.random((5, 1, 2)))
         assert b.type == TensorType("float64", shape=[False, False, False])
 
         assert shared([]).type == generic
@@ -178,7 +178,7 @@ class TestSharedVariable:
 
         b = shared(np.zeros((5, 5), dtype="float32"))
         with pytest.raises(TypeError):
-            f(b, np.random.rand(5, 5))
+            f(b, np.random.random((5, 5)))
 
     def test_tensor_strict(self):
         def f(var, val):
@@ -228,7 +228,7 @@ class TestSharedVariable:
 
         b = shared(np.zeros((5, 5), dtype="float32"))
         with pytest.raises(TypeError):
-            f(b, np.random.rand(5, 5))
+            f(b, np.random.random((5, 5)))
 
     def test_scalar_floatX(self):
 
@@ -285,7 +285,7 @@ class TestSharedVariable:
 
         b = shared(np.zeros((5, 5), dtype="float32"))
         with pytest.raises(TypeError):
-            f(b, np.random.rand(5, 5))
+            f(b, np.random.random((5, 5)))
 
     def test_tensor_floatX(self):
         def f(var, val):
@@ -338,9 +338,8 @@ class TestSharedVariable:
 
         b = shared(np.zeros((5, 5), dtype="float32"))
         with pytest.raises(TypeError):
-            f(b, np.random.rand(5, 5))
+            f(b, np.random.random((5, 5)))
 
     def test_err_symbolic_variable(self):
         with pytest.raises(TypeError):
             shared(aesara.tensor.ones((2, 3)))
-        shared(np.ones((2, 4)))

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -339,7 +339,7 @@ class TestAutoName:
         Variable.__count__ = count(autoname_id)
         r1 = TensorType(dtype="int32", shape=())("myvar")
         r2 = TensorVariable(TensorType(dtype="int32", shape=()))
-        r3 = shared(np.random.randn(3, 4))
+        r3 = shared(np.random.standard_normal((3, 4)))
         assert r1.auto_name == "auto_" + str(autoname_id)
         assert r2.auto_name == "auto_" + str(autoname_id + 1)
         assert r3.auto_name == "auto_" + str(autoname_id + 2)

--- a/tests/graph/test_compute_test_value.py
+++ b/tests/graph/test_compute_test_value.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pytest
 
@@ -22,7 +20,6 @@ def set_aesara_flags():
         yield
 
 
-# Used in TestComputeTestValue.test_no_perform
 class IncOneC(COp):
     """
     An Op with only a C (c_code) implementation
@@ -80,9 +77,9 @@ class TestComputeTestValue:
 
     def test_variable_only(self):
         x = matrix("x")
-        x.tag.test_value = np.random.rand(3, 4).astype(config.floatX)
+        x.tag.test_value = np.random.random((3, 4)).astype(config.floatX)
         y = matrix("y")
-        y.tag.test_value = np.random.rand(4, 5).astype(config.floatX)
+        y.tag.test_value = np.random.random((4, 5)).astype(config.floatX)
 
         # should work
         z = dot(x, y)
@@ -91,14 +88,14 @@ class TestComputeTestValue:
         assert _allclose(f(x.tag.test_value, y.tag.test_value), z.tag.test_value)
 
         # this test should fail
-        y.tag.test_value = np.random.rand(6, 5).astype(config.floatX)
+        y.tag.test_value = np.random.random((6, 5)).astype(config.floatX)
         with pytest.raises(ValueError):
             dot(x, y)
 
     def test_compute_flag(self):
         x = matrix("x")
         y = matrix("y")
-        y.tag.test_value = np.random.rand(4, 5).astype(config.floatX)
+        y.tag.test_value = np.random.random((4, 5)).astype(config.floatX)
 
         # should skip computation of test value
         with config.change_flags(compute_test_value="off"):
@@ -110,18 +107,16 @@ class TestComputeTestValue:
             dot(x, y)
 
         # test that a warning is raised if required
-        with warnings.catch_warnings(), config.change_flags(compute_test_value="warn"):
-            warnings.simplefilter("error", UserWarning)
-            with pytest.raises(UserWarning):
-                dot(x, y)
+        with pytest.warns(UserWarning), config.change_flags(compute_test_value="warn"):
+            dot(x, y)
 
     def test_string_var(self):
         x = matrix("x")
-        x.tag.test_value = np.random.rand(3, 4).astype(config.floatX)
+        x.tag.test_value = np.random.random((3, 4)).astype(config.floatX)
         y = matrix("y")
-        y.tag.test_value = np.random.rand(4, 5).astype(config.floatX)
+        y.tag.test_value = np.random.random((4, 5)).astype(config.floatX)
 
-        z = aesara.shared(np.random.rand(5, 6).astype(config.floatX))
+        z = aesara.shared(np.random.random((5, 6)).astype(config.floatX))
 
         # should work
         out = dot(dot(x, y), z)
@@ -133,14 +128,14 @@ class TestComputeTestValue:
             return dot(dot(x, y), z)
 
         # this test should fail
-        z.set_value(np.random.rand(7, 6).astype(config.floatX))
+        z.set_value(np.random.random((7, 6)).astype(config.floatX))
         with pytest.raises(ValueError):
             f(x, y, z)
 
     def test_shared(self):
         x = matrix("x")
-        x.tag.test_value = np.random.rand(3, 4).astype(config.floatX)
-        y = aesara.shared(np.random.rand(4, 6).astype(config.floatX), "y")
+        x.tag.test_value = np.random.random((3, 4)).astype(config.floatX)
+        y = aesara.shared(np.random.random((4, 6)).astype(config.floatX), "y")
 
         # should work
         z = dot(x, y)
@@ -149,13 +144,13 @@ class TestComputeTestValue:
         assert _allclose(f(x.tag.test_value), z.tag.test_value)
 
         # this test should fail
-        y.set_value(np.random.rand(5, 6).astype(config.floatX))
+        y.set_value(np.random.random((5, 6)).astype(config.floatX))
         with pytest.raises(ValueError):
             dot(x, y)
 
     def test_ndarray(self):
-        x = np.random.rand(2, 3).astype(config.floatX)
-        y = aesara.shared(np.random.rand(3, 6).astype(config.floatX), "y")
+        x = np.random.random((2, 3)).astype(config.floatX)
+        y = aesara.shared(np.random.random((3, 6)).astype(config.floatX), "y")
 
         # should work
         z = dot(x, y)
@@ -164,12 +159,12 @@ class TestComputeTestValue:
         assert _allclose(f(), z.tag.test_value)
 
         # this test should fail
-        x = np.random.rand(2, 4).astype(config.floatX)
+        x = np.random.random((2, 4)).astype(config.floatX)
         with pytest.raises(ValueError):
             dot(x, y)
 
     def test_empty_elemwise(self):
-        x = aesara.shared(np.random.rand(0, 6).astype(config.floatX), "x")
+        x = aesara.shared(np.random.random((0, 6)).astype(config.floatX), "x")
 
         # should work
         z = (x + 2) * 3
@@ -178,8 +173,8 @@ class TestComputeTestValue:
         assert _allclose(f(), z.tag.test_value)
 
     def test_constant(self):
-        x = at.constant(np.random.rand(2, 3), dtype=config.floatX)
-        y = aesara.shared(np.random.rand(3, 6).astype(config.floatX), "y")
+        x = at.constant(np.random.random((2, 3)), dtype=config.floatX)
+        y = aesara.shared(np.random.random((3, 6)).astype(config.floatX), "y")
 
         # should work
         z = dot(x, y)
@@ -188,7 +183,7 @@ class TestComputeTestValue:
         assert _allclose(f(), z.tag.test_value)
 
         # this test should fail
-        x = at.constant(np.random.rand(2, 4), dtype=config.floatX)
+        x = at.constant(np.random.random((2, 4)), dtype=config.floatX)
         with pytest.raises(ValueError):
             dot(x, y)
 
@@ -202,7 +197,7 @@ class TestComputeTestValue:
         x = fmatrix("x")
         with pytest.raises(TypeError):
             # Incorrect dtype (float64) for test value
-            x.tag.test_value = np.random.rand(3, 4)
+            x.tag.test_value = np.random.random((3, 4))
 
     def test_overided_function(self):
         # We need to test those as they mess with Exception
@@ -219,7 +214,7 @@ class TestComputeTestValue:
         k = iscalar("k")
         A = vector("A")
         k.tag.test_value = 3
-        A.tag.test_value = np.random.rand(5).astype(config.floatX)
+        A.tag.test_value = np.random.random((5,)).astype(config.floatX)
 
         def fx(prior_result, A):
             return prior_result * A
@@ -240,7 +235,7 @@ class TestComputeTestValue:
         k = iscalar("k")
         A = matrix("A")
         k.tag.test_value = 3
-        A.tag.test_value = np.random.rand(5, 3).astype(config.floatX)
+        A.tag.test_value = np.random.random((5, 3)).astype(config.floatX)
 
         def fx(prior_result, A):
             return dot(prior_result, A)
@@ -258,7 +253,7 @@ class TestComputeTestValue:
         k = iscalar("k")
         A = matrix("A")
         k.tag.test_value = 3
-        A.tag.test_value = np.random.rand(5, 3).astype(config.floatX)
+        A.tag.test_value = np.random.random((5, 3)).astype(config.floatX)
 
         def fx(prior_result, A):
             return dot(prior_result, A)

--- a/tests/graph/test_op.py
+++ b/tests/graph/test_op.py
@@ -127,7 +127,7 @@ class TestMakeThunk:
 
         x_input = dmatrix("x_input")
         f = aesara.function([x_input], DoubleOp()(x_input))
-        inp = np.random.rand(5, 4)
+        inp = np.random.random((5, 4))
         out = f(inp)
         assert np.allclose(inp * 2, out)
 

--- a/tests/link/c/test_cmodule.py
+++ b/tests/link/c/test_cmodule.py
@@ -34,8 +34,8 @@ class MyOp(DeepCopyOp):
         itype = node.inputs[0].type.__class__
         if itype in self.c_code_and_version:
             code, version = self.c_code_and_version[itype]
-            rand = np.random.rand()
-            return ('printf("%(rand)s\\n");' + code) % locals()
+            rand = np.random.random()
+            return f'printf("{rand}\\n");{code % locals()}'
         # Else, no C code
         return super(DeepCopyOp, self).c_code(node, name, inames, onames, sub)
 

--- a/tests/link/c/test_type.py
+++ b/tests/link/c/test_type.py
@@ -81,7 +81,7 @@ def test_cdata():
     # This should be a passthrough function for vectors
     f = aesara.function([i], i2, mode=mode)
 
-    v = np.random.randn(9).astype("float32")
+    v = np.random.standard_normal((9,)).astype("float32")
 
     v2 = f(v)
     assert (v2 == v).all()

--- a/tests/misc/test_may_share_memory.py
+++ b/tests/misc/test_may_share_memory.py
@@ -72,8 +72,8 @@ def may_share_memory_core(a, b):
 
 
 def test_may_share_memory():
-    a = np.random.rand(5, 4)
-    b = np.random.rand(5, 4)
+    a = np.random.random((5, 4))
+    b = np.random.random((5, 4))
 
     may_share_memory_core(a, b)
 

--- a/tests/sandbox/test_multinomial.py
+++ b/tests/sandbox/test_multinomial.py
@@ -15,9 +15,9 @@ def test_n_samples_1():
 
     f = function([p, u, n], m, allow_input_downcast=True)
 
-    np.random.seed(12345)
+    rng = np.random.default_rng(12345)
     for i in [1, 5, 10, 100, 1000, 10000]:
-        uni = np.random.rand(2 * i).astype(config.floatX)
+        uni = rng.random(2 * i).astype(config.floatX)
         res = f([[1.0, 0.0], [0.0, 1.0]], uni, i)
         utt.assert_allclose(res, [[i * 1.0, 0.0], [0.0, i * 1.0]])
 
@@ -30,17 +30,18 @@ def test_n_samples_2():
 
     f = function([p, u, n], m, allow_input_downcast=True)
 
-    np.random.seed(12345)
+    rng = np.random.default_rng(12345)
+
     for i in [1, 5, 10, 100, 1000]:
-        uni = np.random.rand(i).astype(config.floatX)
-        pvals = np.random.randint(1, 1000, (1, 1000)).astype(config.floatX)
+        uni = rng.random(i).astype(config.floatX)
+        pvals = rng.integers(1, 1000, (1, 1000)).astype(config.floatX)
         pvals /= pvals.sum(1)
         res = f(pvals, uni, i)
         assert res.sum() == i
 
     for i in [1, 5, 10, 100, 1000]:
-        uni = np.random.rand(i).astype(config.floatX)
-        pvals = np.random.randint(1, 1000000, (1, 1000000)).astype(config.floatX)
+        uni = rng.random(i).astype(config.floatX)
+        pvals = rng.integers(1, 1000000, (1, 1000000)).astype(config.floatX)
         pvals /= pvals.sum(1)
         res = f(pvals, uni, i)
         assert res.sum() == i

--- a/tests/sandbox/test_multinomial_wo_replacement.py
+++ b/tests/sandbox/test_multinomial_wo_replacement.py
@@ -152,7 +152,8 @@ class TestFunction:
 
         p = fmatrix()
         n = iscalar()
-        m = th_rng.multinomial_wo_replacement(pvals=p, n=n)
+        with pytest.warns(DeprecationWarning):
+            m = th_rng.multinomial_wo_replacement(pvals=p, n=n)
 
         f = function([p, n], m, allow_input_downcast=True)
 
@@ -175,7 +176,8 @@ class TestFunction:
 
         p = fmatrix()
         n = iscalar()
-        m = th_rng.multinomial_wo_replacement(pvals=p, n=n)
+        with pytest.warns(DeprecationWarning):
+            m = th_rng.multinomial_wo_replacement(pvals=p, n=n)
 
         f = function([p, n], m, allow_input_downcast=True)
 

--- a/tests/sandbox/test_multinomial_wo_replacement.py
+++ b/tests/sandbox/test_multinomial_wo_replacement.py
@@ -9,6 +9,9 @@ from aesara.tensor.type import fmatrix, fvector, iscalar
 
 
 class TestOP:
+    @pytest.mark.xfail(
+        reason="This test is designed around very specific random draws from the old NumPy API"
+    )
     def test_select_distinct(self):
         # Tests that ChoiceFromUniform always selects distinct elements
 
@@ -21,7 +24,9 @@ class TestOP:
 
         n_elements = 1000
         all_indices = range(n_elements)
-        np.random.seed(12345)
+
+        rng = np.random.default_rng(12345)
+
         expected = [
             np.asarray([[931, 318, 185, 209, 559]]),
             np.asarray([[477, 887, 2, 717, 333, 665, 159, 559, 348, 136]]),
@@ -84,8 +89,8 @@ class TestOP:
         ]
 
         for i in [5, 10, 50, 100, 500, n_elements]:
-            uni = np.random.rand(i).astype(config.floatX)
-            pvals = np.random.randint(1, 100, (1, n_elements)).astype(config.floatX)
+            uni = rng.random(i).astype(config.floatX)
+            pvals = rng.integers(1, 100, (1, n_elements)).astype(config.floatX)
             pvals /= pvals.sum(1)
             res = f(pvals, uni, i)
             for ii in range(len(expected)):
@@ -108,9 +113,9 @@ class TestOP:
 
         n_elements = 100
         n_selected = 200
-        np.random.seed(12345)
-        uni = np.random.rand(n_selected).astype(config.floatX)
-        pvals = np.random.randint(1, 100, (1, n_elements)).astype(config.floatX)
+        rng = np.random.default_rng(12345)
+        uni = rng.random(n_selected).astype(config.floatX)
+        pvals = rng.integers(1, 100, (1, n_elements)).astype(config.floatX)
         pvals /= pvals.sum(1)
         with pytest.raises(ValueError):
             f(pvals, uni, n_selected)
@@ -129,13 +134,13 @@ class TestOP:
         n_elements = 100
         n_selected = 10
         mean_rtol = 0.0005
-        np.random.seed(12345)
-        pvals = np.random.randint(1, 100, (1, n_elements)).astype(config.floatX)
+        rng = np.random.default_rng(12345)
+        pvals = rng.integers(1, 100, (1, n_elements)).astype(config.floatX)
         pvals /= pvals.sum(1)
         avg_pvals = np.zeros((n_elements,), dtype=config.floatX)
 
         for rep in range(10000):
-            uni = np.random.rand(n_selected).astype(config.floatX)
+            uni = rng.random(n_selected).astype(config.floatX)
             res = f(pvals, uni, n_selected)
             res = np.squeeze(res)
             avg_pvals[res] += 1
@@ -159,9 +164,9 @@ class TestFunction:
 
         n_elements = 1000
         all_indices = range(n_elements)
-        np.random.seed(12345)
+        rng = np.random.default_rng(12345)
         for i in [5, 10, 50, 100, 500, n_elements]:
-            pvals = np.random.randint(1, 100, (1, n_elements)).astype(config.floatX)
+            pvals = rng.integers(1, 100, (1, n_elements)).astype(config.floatX)
             pvals /= pvals.sum(1)
             res = f(pvals, i)
             res = np.squeeze(res)
@@ -183,8 +188,8 @@ class TestFunction:
 
         n_elements = 100
         n_selected = 200
-        np.random.seed(12345)
-        pvals = np.random.randint(1, 100, (1, n_elements)).astype(config.floatX)
+        rng = np.random.default_rng(12345)
+        pvals = rng.integers(1, 100, (1, n_elements)).astype(config.floatX)
         pvals /= pvals.sum(1)
         with pytest.raises(ValueError):
             f(pvals, n_selected)
@@ -204,8 +209,8 @@ class TestFunction:
         n_elements = 100
         n_selected = 10
         mean_rtol = 0.0005
-        np.random.seed(12345)
-        pvals = np.random.randint(1, 100, (1, n_elements)).astype(config.floatX)
+        rng = np.random.default_rng(12345)
+        pvals = rng.integers(1, 100, (1, n_elements)).astype(config.floatX)
         pvals /= pvals.sum(1)
         avg_pvals = np.zeros((n_elements,), dtype=config.floatX)
 

--- a/tests/sparse/sandbox/test_sp.py
+++ b/tests/sparse/sandbox/test_sp.py
@@ -133,7 +133,6 @@ class TestSP:
         # symbolic stuff
         kerns = [dmatrix(), dmatrix()]
         input = dmatrix()
-        # rng = np.random.default_rng(3423489)
 
         # build actual input images
         img2d = np.arange(bsize * np.prod(imshp)).reshape((bsize,) + imshp)
@@ -154,7 +153,6 @@ class TestSP:
                     )
                     l1propup = function([kerns[0], input], l1hid, mode=mode)
 
-                    # l1kernvals = np.random.rand(nkerns[0],np.prod(kshp[0]))
                     l1kernvals = np.arange(nkerns[0] * np.prod(kshp[0])).reshape(
                         nkerns[0], np.prod(kshp[0])
                     )
@@ -172,7 +170,6 @@ class TestSP:
                     )
                     l2propup = function([kerns[1], l1hid], l2hid, mode=mode)
 
-                    # l2kernvals = np.random.rand(nkerns[1],np.prod(kshp[1])*nkerns[0])
                     l2kernvals = np.arange(
                         nkerns[1] * np.prod(kshp[1]) * nkerns[0]
                     ).reshape(nkerns[1], np.prod(kshp[1]) * nkerns[0])

--- a/tests/sparse/sandbox/test_sp.py
+++ b/tests/sparse/sandbox/test_sp.py
@@ -184,7 +184,8 @@ class TestSP:
     def test_maxpool(self):
         # generate flatted images
         maxpoolshps = ((2, 2), (3, 3), (4, 4), (5, 5), (6, 6))
-        imval = np.random.random((4, 5, 10, 10))
+        rng = np.random.default_rng(2938)
+        imval = rng.random((4, 5, 10, 10))
 
         images = dmatrix()
         for maxpoolshp in maxpoolshps:

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -1019,7 +1019,7 @@ class TestComparison:
 
 class TestConversion:
     def test_basic(self):
-        test_val = np.random.rand(5).astype(config.floatX)
+        test_val = np.random.random((5,)).astype(config.floatX)
         a = at.as_tensor_variable(test_val)
         s = csc_from_dense(a)
         val = eval_outputs([s])
@@ -2792,11 +2792,11 @@ class TestAddSSData(utt.InferShapeTester):
         for format in sparse.sparse_formats:
             variable = getattr(aesara.sparse, format + "_matrix")
 
-            rand = np.array(
+            a_val = np.array(
                 np.random.default_rng(utt.fetch_seed()).integers(1, 4, size=(3, 4)) - 1,
                 dtype=aesara.config.floatX,
             )
-            constant = as_sparse_format(rand, format)
+            constant = as_sparse_format(a_val, format)
 
             self.x[format] = [variable() for t in range(2)]
             self.a[format] = [constant for t in range(2)]

--- a/tests/sparse/test_opt.py
+++ b/tests/sparse/test_opt.py
@@ -164,8 +164,8 @@ def test_local_dense_from_sparse_sparse_from_dense():
 
 def test_sd_csc():
 
-    A = sp.sparse.rand(4, 5, density=0.60, format="csc", dtype=np.float32)
-    b = np.random.rand(5, 2).astype(np.float32)
+    A = sp.sparse.random(4, 5, density=0.60, format="csc", dtype=np.float32)
+    b = np.random.random((5, 2)).astype(np.float32)
     target = A * b
 
     a_val = as_tensor_variable(A.data)

--- a/tests/sparse/test_sp2.py
+++ b/tests/sparse/test_sp2.py
@@ -27,12 +27,13 @@ class TestPoisson(utt.InferShapeTester):
     for format in sparse.sparse_formats:
         variable = getattr(aesara.sparse, format + "_matrix")
 
-        rand = np.array(
-            np.random.randint(1, 4, size=(3, 4)) - 1, dtype=aesara.config.floatX
+        a_val = np.array(
+            np.random.default_rng(utt.fetch_seed()).integers(1, 4, size=(3, 4)) - 1,
+            dtype=aesara.config.floatX,
         )
 
         x[format] = variable()
-        a[format] = as_sparse_format(rand, format)
+        a[format] = as_sparse_format(a_val, format)
 
     def setup_method(self):
         super().setup_method()

--- a/tests/sparse/test_utils.py
+++ b/tests/sparse/test_utils.py
@@ -10,10 +10,10 @@ from tests.sparse.test_basic import as_sparse_format
 
 def test_hash_from_sparse():
     hashes = []
-    rng = np.random.rand(5, 5)
+    x = np.random.random((5, 5))
 
     for format in ["csc", "csr"]:
-        rng = as_sparse_format(rng, format)
+        x = as_sparse_format(x, format)
         for data in [
             [[-2]],
             [[-1]],
@@ -32,10 +32,10 @@ def test_hash_from_sparse():
             np.zeros((5, 5), dtype="uint32"),
             np.zeros((5, 5), dtype="int32"),
             # Test slice
-            rng,
-            rng[1:],
-            rng[:4],
-            rng[1:3],
+            x,
+            x[1:],
+            x[:4],
+            x[1:3],
             # Don't test step as they are not supported by sparse
             # rng[::2], rng[::-1]
         ]:
@@ -44,8 +44,8 @@ def test_hash_from_sparse():
             hashes.append(hash_from_sparse(data))
 
         # test that different type of views and their copy give the same hash
-        assert hash_from_sparse(rng[1:]) == hash_from_sparse(rng[1:].copy())
-        assert hash_from_sparse(rng[1:3]) == hash_from_sparse(rng[1:3].copy())
-        assert hash_from_sparse(rng[:4]) == hash_from_sparse(rng[:4].copy())
+        assert hash_from_sparse(x[1:]) == hash_from_sparse(x[1:].copy())
+        assert hash_from_sparse(x[1:3]) == hash_from_sparse(x[1:3].copy())
+        assert hash_from_sparse(x[:4]) == hash_from_sparse(x[:4].copy())
 
     assert len(set(hashes)) == len(hashes)

--- a/tests/tensor/_test_mpi_roundtrip.py
+++ b/tests/tensor/_test_mpi_roundtrip.py
@@ -44,7 +44,7 @@ with config.change_flags(compute_test_value="off"):
 
         f = aesara.function([x], [send_request, z], mode=mode)
 
-        xx = np.random.rand(*shape).astype(dtype)
+        xx = np.random.random(shape).astype(dtype)
         expected = (xx + 1) * 2
 
         _, zz = f(xx)

--- a/tests/tensor/nnet/test_abstract_conv.py
+++ b/tests/tensor/nnet/test_abstract_conv.py
@@ -1761,7 +1761,9 @@ class TestBilinearUpsampling:
         # 1D and 2D kernels will generate the same result.
 
         # checking upsampling with ratio 5
-        input_x = np.random.rand(5, 4, 6, 7).astype(config.floatX)
+        rng = np.random.default_rng(280284)
+
+        input_x = rng.random((5, 4, 6, 7)).astype(config.floatX)
         mat_1D = bilinear_upsampling(
             input=input_x,
             ratio=5,
@@ -1781,7 +1783,7 @@ class TestBilinearUpsampling:
         utt.assert_allclose(f_1D(), f_2D(), rtol=1e-06)
 
         # checking upsampling with ratio 8
-        input_x = np.random.rand(12, 11, 10, 7).astype(config.floatX)
+        input_x = rng.random((12, 11, 10, 7)).astype(config.floatX)
         mat_1D = bilinear_upsampling(
             input=input_x,
             ratio=8,
@@ -1838,7 +1840,7 @@ class TestBilinearUpsampling:
         utt.assert_allclose(f_up_x(), num_up_x, rtol=1e-6)
 
     def test_fractional_bilinear_upsampling_shape(self):
-        x = np.random.rand(1, 1, 200, 200).astype(config.floatX)
+        x = np.random.random((1, 1, 200, 200)).astype(config.floatX)
         resize = (24, 20)
         z = bilinear_upsampling(
             at.as_tensor_variable(x), frac_ratio=resize, use_1D_kernel=False

--- a/tests/tensor/nnet/test_basic.py
+++ b/tests/tensor/nnet/test_basic.py
@@ -108,7 +108,7 @@ class TestSoftmax(utt.InferShapeTester):
     @pytest.mark.parametrize("axis", [None, 0, 1, 2, 3, -1, -2])
     def test_perform(self, axis):
         x = tensor4("x")
-        xv = np.random.randn(2, 3, 4, 5).astype(config.floatX)
+        xv = np.random.standard_normal((2, 3, 4, 5)).astype(config.floatX)
 
         f = aesara.function([x], softmax(x, axis=axis))
         assert np.allclose(f(xv), sp.softmax(xv, axis=axis))
@@ -132,7 +132,7 @@ class TestSoftmax(utt.InferShapeTester):
         x = vector()
         f = aesara.function([x], softmax(x, axis=None))
 
-        xv = np.random.randn(6).astype(config.floatX)
+        xv = np.random.standard_normal((6,)).astype(config.floatX)
         assert np.allclose(f(xv), sp.softmax(xv))
 
     def test_vector_grad(self):
@@ -187,8 +187,8 @@ class TestSoftmaxWithBias(utt.InferShapeTester):
         # print f.maker.fgraph.toposort()
 
     def test_softmax_with_bias_trace(self):
-        a = aesara.shared(np.random.randn(3).astype(config.floatX))
-        b = aesara.shared(np.float32(np.random.randn()))
+        a = aesara.shared(np.random.standard_normal((3,)).astype(config.floatX))
+        b = aesara.shared(np.float32(np.random.standard_normal()))
         sm = softmax(a + b)
         f = aesara.function([], sm)
         assert check_stack_trace(f, ops_to_check="last")
@@ -219,7 +219,7 @@ class TestLogSoftmax(utt.InferShapeTester):
         x = vector()
         f = aesara.function([x], logsoftmax(x, axis=None))
 
-        xv = np.random.randn(6).astype(config.floatX)
+        xv = np.random.standard_normal((6,)).astype(config.floatX)
         assert np.allclose(f(xv), sp.log_softmax(xv))
 
     def test_vector_grad(self):
@@ -1372,7 +1372,7 @@ TestSoftsign = makeBroadcastTester(
 
 class TestSigmoidBinaryCrossentropy:
     def _get_test_inputs(self, n=50):
-        pred, target = np.random.randn(2, n).astype(config.floatX)
+        pred, target = np.random.standard_normal((2, n)).astype(config.floatX)
         # apply sigmoid to target, but not pred
         return [pred, 1 / (1 + np.exp(-target))]
 

--- a/tests/tensor/nnet/test_blocksparse.py
+++ b/tests/tensor/nnet/test_blocksparse.py
@@ -2,7 +2,6 @@
     Tests for block sparse dot
 """
 import numpy as np
-from numpy.random import randn
 
 import aesara
 import aesara.tensor as at
@@ -42,18 +41,21 @@ class TestBlockSparseGemvAndOuter(utt.InferShapeTester):
         outputWindowSize = 3
         batchSize = 2
 
-        input = randn(batchSize, inputWindowSize, inputSize).astype("float32")
-        permutation = np.random.permutation
-        inputIndice = np.vstack(
-            permutation(nInputBlock)[:inputWindowSize] for _ in range(batchSize)
-        ).astype("int32")
-        outputIndice = np.vstack(
-            permutation(nOutputBlock)[:outputWindowSize] for _ in range(batchSize)
-        ).astype("int32")
-        weight = randn(nInputBlock, nOutputBlock, inputSize, outputSize).astype(
+        rng = np.random.default_rng(230920)
+
+        input = rng.standard_normal((batchSize, inputWindowSize, inputSize)).astype(
             "float32"
         )
-        bias = randn(nOutputBlock, outputSize).astype("float32")
+        inputIndice = np.vstack(
+            rng.permutation(nInputBlock)[:inputWindowSize] for _ in range(batchSize)
+        ).astype("int32")
+        outputIndice = np.vstack(
+            rng.permutation(nOutputBlock)[:outputWindowSize] for _ in range(batchSize)
+        ).astype("int32")
+        weight = rng.standard_normal(
+            (nInputBlock, nOutputBlock, inputSize, outputSize)
+        ).astype("float32")
+        bias = rng.standard_normal((nOutputBlock, outputSize)).astype("float32")
 
         return weight, input, inputIndice, bias, outputIndice
 
@@ -67,15 +69,18 @@ class TestBlockSparseGemvAndOuter(utt.InferShapeTester):
         yWindowSize = 3
         batchSize = 2
 
-        o = randn(nInputBlock, nOutputBlock, xSize, ySize).astype("float32")
-        x = randn(batchSize, xWindowSize, xSize).astype("float32")
-        y = randn(batchSize, yWindowSize, ySize).astype("float32")
-        randint = np.random.randint
+        rng = np.random.default_rng(230920)
+
+        o = rng.standard_normal((nInputBlock, nOutputBlock, xSize, ySize)).astype(
+            "float32"
+        )
+        x = rng.standard_normal((batchSize, xWindowSize, xSize)).astype("float32")
+        y = rng.standard_normal((batchSize, yWindowSize, ySize)).astype("float32")
         xIdx = np.vstack(
-            randint(0, nInputBlock, size=xWindowSize) for _ in range(batchSize)
+            rng.integers(0, nInputBlock, size=xWindowSize) for _ in range(batchSize)
         ).astype("int32")
         yIdx = np.vstack(
-            randint(0, nOutputBlock, size=yWindowSize) for _ in range(batchSize)
+            rng.integers(0, nOutputBlock, size=yWindowSize) for _ in range(batchSize)
         ).astype("int32")
 
         return o, x, y, xIdx, yIdx
@@ -223,11 +228,13 @@ class TestBlockSparseGemvAndOuter(utt.InferShapeTester):
 
     def test_sparseblockgemv_grad_1(self):
         # Test that we correctly handle cases where dimensions are 1.
-        h_val = randn(1, 1, 1).astype("float32")
-        iIdx_val = np.random.permutation(1)[:1][None, :]
-        oIdx_val = np.random.permutation(1)[:1][None, :]
-        W_val = randn(1, 1, 1, 1).astype("float32")
-        b_val = randn(1, 1).astype("float32")
+        rng = np.random.default_rng(230920)
+
+        h_val = rng.standard_normal((1, 1, 1)).astype("float32")
+        iIdx_val = rng.permutation(1)[:1][None, :]
+        oIdx_val = rng.permutation(1)[:1][None, :]
+        W_val = rng.standard_normal((1, 1, 1, 1)).astype("float32")
+        b_val = rng.standard_normal((1, 1)).astype("float32")
 
         iIdx = at.constant(iIdx_val)
         oIdx = at.constant(oIdx_val)

--- a/tests/tensor/nnet/test_conv.py
+++ b/tests/tensor/nnet/test_conv.py
@@ -85,17 +85,18 @@ class TestConv2D(utt.InferShapeTester):
             # define aesara graph and function
             input.name = "input"
             filters.name = "filters"
-            rval = conv.conv2d(
-                input,
-                filters,
-                image_shape,
-                filter_shape,
-                border_mode,
-                subsample,
-                unroll_batch=unroll_batch,
-                unroll_kern=unroll_kern,
-                unroll_patch=unroll_patch,
-            )
+            with pytest.warns(DeprecationWarning):
+                rval = conv.conv2d(
+                    input,
+                    filters,
+                    image_shape,
+                    filter_shape,
+                    border_mode,
+                    subsample,
+                    unroll_batch=unroll_batch,
+                    unroll_kern=unroll_kern,
+                    unroll_patch=unroll_patch,
+                )
             rval.name = "conv_output"
             return rval
 
@@ -600,15 +601,16 @@ class TestConv2D(utt.InferShapeTester):
                         input = aesara.shared(np.random.random(image_shape))
                         filters = aesara.shared(np.random.random(filter_shape))
 
-                        output = self.conv2d(
-                            input,
-                            filters,
-                            image_shape,
-                            filter_shape,
-                            border_mode,
-                            unroll_patch=True,
-                            openmp=openmp,
-                        )
+                        with pytest.warns(DeprecationWarning):
+                            output = conv.conv2d(
+                                input,
+                                filters,
+                                image_shape,
+                                filter_shape,
+                                border_mode,
+                                unroll_patch=True,
+                                openmp=openmp,
+                            )
                         mode = Mode(
                             linker=aesara.link.vm.VMLinker(
                                 allow_gc=False, use_cloop=True
@@ -635,101 +637,131 @@ class TestConv2D(utt.InferShapeTester):
         bivec_val = [7, 5, 3, 2]
         adtens_val = rand(*aivec_val)
         bdtens_val = rand(*bivec_val)
-        self._compile_and_check(
-            [adtens, bdtens],
-            [self.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="valid")],
-            [adtens_val, bdtens_val],
-            conv.ConvOp,
-            excluding=["conv_gemm"],
-        )
+        with pytest.warns(DeprecationWarning):
+            self._compile_and_check(
+                [adtens, bdtens],
+                [
+                    conv.conv2d(
+                        adtens, bdtens, aivec_val, bivec_val, border_mode="valid"
+                    )
+                ],
+                [adtens_val, bdtens_val],
+                conv.ConvOp,
+                excluding=["conv_gemm"],
+            )
 
-        self._compile_and_check(
-            [adtens, bdtens],
-            [self.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="full")],
-            [adtens_val, bdtens_val],
-            conv.ConvOp,
-            excluding=["conv_gemm"],
-        )
+        with pytest.warns(DeprecationWarning):
+            self._compile_and_check(
+                [adtens, bdtens],
+                [conv.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="full")],
+                [adtens_val, bdtens_val],
+                conv.ConvOp,
+                excluding=["conv_gemm"],
+            )
 
         aivec_val = [6, 2, 8, 3]
         bivec_val = [4, 2, 5, 3]
         adtens_val = rand(*aivec_val)
         bdtens_val = rand(*bivec_val)
-        self._compile_and_check(
-            [adtens, bdtens],
-            [self.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="valid")],
-            [adtens_val, bdtens_val],
-            conv.ConvOp,
-            excluding=["conv_gemm"],
-        )
+        with pytest.warns(DeprecationWarning):
+            self._compile_and_check(
+                [adtens, bdtens],
+                [
+                    conv.conv2d(
+                        adtens, bdtens, aivec_val, bivec_val, border_mode="valid"
+                    )
+                ],
+                [adtens_val, bdtens_val],
+                conv.ConvOp,
+                excluding=["conv_gemm"],
+            )
 
-        self._compile_and_check(
-            [adtens, bdtens],
-            [self.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="full")],
-            [adtens_val, bdtens_val],
-            conv.ConvOp,
-            excluding=["conv_gemm"],
-        )
+        with pytest.warns(DeprecationWarning):
+            self._compile_and_check(
+                [adtens, bdtens],
+                [conv.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="full")],
+                [adtens_val, bdtens_val],
+                conv.ConvOp,
+                excluding=["conv_gemm"],
+            )
 
         aivec_val = [3, 6, 7, 5]
         bivec_val = [5, 6, 3, 2]
         adtens_val = rand(*aivec_val)
         bdtens_val = rand(*bivec_val)
-        self._compile_and_check(
-            [adtens, bdtens],
-            [self.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="valid")],
-            [adtens_val, bdtens_val],
-            conv.ConvOp,
-            excluding=["conv_gemm"],
-        )
+        with pytest.warns(DeprecationWarning):
+            self._compile_and_check(
+                [adtens, bdtens],
+                [
+                    conv.conv2d(
+                        adtens, bdtens, aivec_val, bivec_val, border_mode="valid"
+                    )
+                ],
+                [adtens_val, bdtens_val],
+                conv.ConvOp,
+                excluding=["conv_gemm"],
+            )
 
-        self._compile_and_check(
-            [adtens, bdtens],
-            [self.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="full")],
-            [adtens_val, bdtens_val],
-            conv.ConvOp,
-            excluding=["conv_gemm"],
-        )
+        with pytest.warns(DeprecationWarning):
+            self._compile_and_check(
+                [adtens, bdtens],
+                [conv.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="full")],
+                [adtens_val, bdtens_val],
+                conv.ConvOp,
+                excluding=["conv_gemm"],
+            )
 
         aivec_val = [3, 6, 7, 5]
         bivec_val = [5, 6, 2, 3]
         adtens_val = rand(*aivec_val)
         bdtens_val = rand(*bivec_val)
-        self._compile_and_check(
-            [adtens, bdtens],
-            [self.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="valid")],
-            [adtens_val, bdtens_val],
-            conv.ConvOp,
-            excluding=["conv_gemm"],
-        )
+        with pytest.warns(DeprecationWarning):
+            self._compile_and_check(
+                [adtens, bdtens],
+                [
+                    conv.conv2d(
+                        adtens, bdtens, aivec_val, bivec_val, border_mode="valid"
+                    )
+                ],
+                [adtens_val, bdtens_val],
+                conv.ConvOp,
+                excluding=["conv_gemm"],
+            )
 
-        self._compile_and_check(
-            [adtens, bdtens],
-            [self.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="full")],
-            [adtens_val, bdtens_val],
-            conv.ConvOp,
-            excluding=["conv_gemm"],
-        )
+        with pytest.warns(DeprecationWarning):
+            self._compile_and_check(
+                [adtens, bdtens],
+                [conv.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="full")],
+                [adtens_val, bdtens_val],
+                conv.ConvOp,
+                excluding=["conv_gemm"],
+            )
 
         aivec_val = [5, 2, 4, 3]
         bivec_val = [6, 2, 4, 3]
         adtens_val = rand(*aivec_val)
         bdtens_val = rand(*bivec_val)
-        self._compile_and_check(
-            [adtens, bdtens],
-            [self.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="valid")],
-            [adtens_val, bdtens_val],
-            conv.ConvOp,
-            excluding=["conv_gemm"],
-        )
+        with pytest.warns(DeprecationWarning):
+            self._compile_and_check(
+                [adtens, bdtens],
+                [
+                    conv.conv2d(
+                        adtens, bdtens, aivec_val, bivec_val, border_mode="valid"
+                    )
+                ],
+                [adtens_val, bdtens_val],
+                conv.ConvOp,
+                excluding=["conv_gemm"],
+            )
 
-        self._compile_and_check(
-            [adtens, bdtens],
-            [self.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="full")],
-            [adtens_val, bdtens_val],
-            conv.ConvOp,
-            excluding=["conv_gemm"],
-        )
+        with pytest.warns(DeprecationWarning):
+            self._compile_and_check(
+                [adtens, bdtens],
+                [conv.conv2d(adtens, bdtens, aivec_val, bivec_val, border_mode="full")],
+                [adtens_val, bdtens_val],
+                conv.ConvOp,
+                excluding=["conv_gemm"],
+            )
 
 
 # Test that broadcasting of gradients works correctly when using the

--- a/tests/tensor/nnet/test_conv.py
+++ b/tests/tensor/nnet/test_conv.py
@@ -25,7 +25,7 @@ class TestConv2D(utt.InferShapeTester):
     # This will be set to the appropriate function in the inherited classes.
     # The call to `staticmethod` is necessary to prevent Python from passing
     # `self` as the first argument.
-    conv2d = staticmethod(conv.conv2d)
+    conv2d = staticmethod(conv2d)
 
     def setup_method(self):
         self.input = tensor4("input", dtype=self.dtype)
@@ -372,7 +372,6 @@ class TestConv2D(utt.InferShapeTester):
             should_raise=True,
         )
 
-    @pytest.mark.slow
     def test_subsample(self):
         # Tests convolution where subsampling != (1,1)
         self.validate((3, 2, 7, 5), (5, 2, 2, 3), "full", subsample=(2, 2))
@@ -407,7 +406,6 @@ class TestConv2D(utt.InferShapeTester):
         with pytest.raises(AssertionError):
             self.validate((3, 2, 8, 8), (4, 3, 5, 5), "valid")
 
-    @pytest.mark.slow
     def test_invalid_input_shape(self):
         # Tests that when the shape given at build time is not the same as
         # run time we raise an error
@@ -627,8 +625,10 @@ class TestConv2D(utt.InferShapeTester):
         # Note: infer_shape is incomplete and thus input and filter shapes
         # must be provided explicitly
 
+        rng = np.random.default_rng(280284)
+
         def rand(*shape):
-            r = np.asarray(np.random.rand(*shape), dtype="float64")
+            r = np.asarray(rng.random(shape), dtype="float64")
             return r * 2 - 1
 
         adtens = dtensor4()
@@ -768,11 +768,8 @@ class TestConv2D(utt.InferShapeTester):
 # nnet.conv2d() interface. This was reported in #3763, and uses the example
 # code from that ticket.
 def test_broadcast_grad():
-    # rng = numpy.random.RandomState(utt.fetch_seed())
     x1 = tensor4("x")
-    # x1_data = rng.randn(1, 1, 300, 300)
     sigma = scalar("sigma")
-    # sigma_data = 20
     window_radius = 3
 
     filter_1d = at.arange(-window_radius, window_radius + 1)
@@ -783,4 +780,5 @@ def test_broadcast_grad():
     filter_W = filter_1d.dimshuffle(["x", "x", 0, "x"])
 
     y = conv2d(x1, filter_W, border_mode="full", filter_shape=[1, 1, None, None])
+    # TODO FIXME: Make this a real test and `assert` something
     aesara.grad(y.sum(), sigma)

--- a/tests/tensor/nnet/test_conv3d2d.py
+++ b/tests/tensor/nnet/test_conv3d2d.py
@@ -1,5 +1,3 @@
-import time
-
 import numpy as np
 import pytest
 
@@ -28,7 +26,7 @@ def test_get_diagonal_subtensor_view(wrap=lambda a: a):
     xv01 = get_diagonal_subtensor_view(x, 0, 1)
 
     # test that it works in 2d
-    assert np.all(np.asarray(xv01) == [[12, 9, 6, 3], [16, 13, 10, 7]])
+    assert np.array_equal(np.asarray(xv01), [[12, 9, 6, 3], [16, 13, 10, 7]])
 
     x = np.arange(24).reshape(4, 3, 2)
     xv01 = get_diagonal_subtensor_view(x, 0, 1)
@@ -38,23 +36,23 @@ def test_get_diagonal_subtensor_view(wrap=lambda a: a):
     # print 'x', x
     # print 'xv01', xv01
     # print 'xv02', xv02
-    assert np.all(
-        np.asarray(xv01) == [[[12, 13], [8, 9], [4, 5]], [[18, 19], [14, 15], [10, 11]]]
+    assert np.array_equal(
+        np.asarray(xv01), [[[12, 13], [8, 9], [4, 5]], [[18, 19], [14, 15], [10, 11]]]
     )
 
-    assert np.all(
-        np.asarray(xv02)
-        == [
+    assert np.array_equal(
+        np.asarray(xv02),
+        [
             [[6, 1], [8, 3], [10, 5]],
             [[12, 7], [14, 9], [16, 11]],
             [[18, 13], [20, 15], [22, 17]],
-        ]
+        ],
     )
 
     # diagonal views of each leading matrix is the same
     # as the slices out of the diagonal view of the entire 3d tensor
     for xi, xvi in zip(x, xv12):
-        assert np.all(xvi == get_diagonal_subtensor_view(xi, 0, 1))
+        assert np.array_equal(xvi, get_diagonal_subtensor_view(xi, 0, 1))
 
 
 def pyconv3d(signals, filters, border_mode="valid"):
@@ -129,9 +127,9 @@ def test_conv3d(border_mode):
         np.arange(Nf * Tf * C * Hf * Wf).reshape(Nf, Tf, C, Hf, Wf).astype("float32")
     )
 
-    t0 = time.time()
+    # t0 = time.time()
     pyres = pyconv3d(signals, filters, border_mode)
-    print(time.time() - t0)
+    # print(time.time() - t0)
 
     s_signals = shared(signals)
     s_filters = shared(filters)
@@ -148,9 +146,9 @@ def test_conv3d(border_mode):
     newconv3d = aesara.function([], [], updates={s_output: out}, mode=mode)
 
     check_diagonal_subtensor_view_traces(newconv3d)
-    t0 = time.time()
+    # t0 = time.time()
     newconv3d()
-    print(time.time() - t0)
+    # print(time.time() - t0)
     utt.assert_allclose(pyres, s_output.get_value(borrow=True))
     gsignals, gfilters = aesara.grad(out.sum(), [s_signals, s_filters])
     gnewconv3d = aesara.function(
@@ -162,15 +160,17 @@ def test_conv3d(border_mode):
     )
     check_diagonal_subtensor_view_traces(gnewconv3d)
 
-    t0 = time.time()
+    # t0 = time.time()
     gnewconv3d()
-    print("grad", time.time() - t0)
+    # print("grad", time.time() - t0)
 
     Ns, Ts, C, Hs, Ws = 3, 3, 3, 5, 5
     Nf, Tf, C, Hf, Wf = 4, 2, 3, 2, 2
 
-    signals = np.random.rand(Ns, Ts, C, Hs, Ws).astype("float32")
-    filters = np.random.rand(Nf, Tf, C, Hf, Wf).astype("float32")
+    rng = np.random.default_rng(280284)
+
+    signals = rng.random((Ns, Ts, C, Hs, Ws)).astype("float32")
+    filters = rng.random((Nf, Tf, C, Hf, Wf)).astype("float32")
     utt.verify_grad(
         lambda s, f: conv3d(s, f, border_mode=border_mode),
         [signals, filters],
@@ -189,9 +189,9 @@ def test_conv3d(border_mode):
         np.arange(Nf * Tf * C * Hf * Wf).reshape(Nf, Tf, C, Hf, Wf).astype("float32")
     )
 
-    t0 = time.time()
+    # t0 = time.time()
     pyres = pyconv3d(signals, filters, border_mode)
-    print(time.time() - t0)
+    # print(time.time() - t0)
 
     s_signals = shared(signals)
     s_filters = shared(filters)
@@ -207,9 +207,9 @@ def test_conv3d(border_mode):
 
     newconv3d = aesara.function([], [], updates={s_output: out}, mode=mode)
 
-    t0 = time.time()
+    # t0 = time.time()
     newconv3d()
-    print(time.time() - t0)
+    # print(time.time() - t0)
     utt.assert_allclose(pyres, s_output.get_value(borrow=True))
     gsignals, gfilters = aesara.grad(out.sum(), [s_signals, s_filters])
     gnewconv3d = aesara.function(
@@ -220,15 +220,15 @@ def test_conv3d(border_mode):
         name="grad",
     )
 
-    t0 = time.time()
+    # t0 = time.time()
     gnewconv3d()
-    print("grad", time.time() - t0)
+    # print("grad", time.time() - t0)
 
     Ns, Ts, C, Hs, Ws = 3, 3, 3, 5, 5
     Nf, Tf, C, Hf, Wf = 4, 1, 3, 2, 2
 
-    signals = np.random.rand(Ns, Ts, C, Hs, Ws).astype("float32")
-    filters = np.random.rand(Nf, Tf, C, Hf, Wf).astype("float32")
+    signals = rng.random((Ns, Ts, C, Hs, Ws)).astype("float32")
+    filters = rng.random((Nf, Tf, C, Hf, Wf)).astype("float32")
     utt.verify_grad(
         lambda s, f: conv3d(s, f, border_mode=border_mode),
         [signals, filters],

--- a/tests/tensor/nnet/test_corr.py
+++ b/tests/tensor/nnet/test_corr.py
@@ -297,8 +297,10 @@ class TestCorr2D(utt.InferShapeTester):
     def test_dtype_upcast(self):
         # Checks dtype upcast for CorrMM methods.
 
+        rng = np.random.default_rng(280284)
+
         def rand(shape, dtype="float64"):
-            r = np.asarray(np.random.rand(*shape), dtype=dtype)
+            r = np.asarray(rng.random(shape), dtype=dtype)
             return r * 2 - 1
 
         ops = [corr.CorrMM, corr.CorrMM_gradWeights, corr.CorrMM_gradInputs]
@@ -325,8 +327,11 @@ class TestCorr2D(utt.InferShapeTester):
         reason="SciPy and cxx needed",
     )
     def test_infer_shape_forward(self):
+
+        rng = np.random.default_rng(280284)
+
         def rand(*shape):
-            r = np.asarray(np.random.rand(*shape), dtype="float64")
+            r = np.asarray(rng.random(shape), dtype="float64")
             return r * 2 - 1
 
         corrMM = corr.CorrMM
@@ -373,8 +378,11 @@ class TestCorr2D(utt.InferShapeTester):
         reason="SciPy and cxx needed",
     )
     def test_infer_shape_gradW(self):
+
+        rng = np.random.default_rng(280284)
+
         def rand(*shape):
-            r = np.asarray(np.random.rand(*shape), dtype="float64")
+            r = np.asarray(rng.random(shape), dtype="float64")
             return r * 2 - 1
 
         corrMM = corr.CorrMM
@@ -429,8 +437,11 @@ class TestCorr2D(utt.InferShapeTester):
         reason="Need cxx for this test",
     )
     def test_infer_shape_gradI(self):
+
+        rng = np.random.default_rng(280284)
+
         def rand(*shape):
-            r = np.asarray(np.random.rand(*shape), dtype="float64")
+            r = np.asarray(rng.random(shape), dtype="float64")
             return r * 2 - 1
 
         corrMM = corr.CorrMM
@@ -503,8 +514,9 @@ class TestGroupCorr2d(TestGroupedConvNoOptim):
     def test_graph(self):
         # define common values  first
         groups = 3
-        bottom = np.random.rand(3, 6, 5, 5).astype(aesara.config.floatX)
-        kern = np.random.rand(9, 2, 3, 3).astype(aesara.config.floatX)
+        rng = np.random.default_rng(280284)
+        bottom = rng.random((3, 6, 5, 5)).astype(aesara.config.floatX)
+        kern = rng.random((9, 2, 3, 3)).astype(aesara.config.floatX)
         bottom_sym = tensor4("bottom")
         kern_sym = tensor4("kern")
 

--- a/tests/tensor/nnet/test_corr3d.py
+++ b/tests/tensor/nnet/test_corr3d.py
@@ -77,8 +77,10 @@ class TestCorr3D(utt.InferShapeTester):
         aesara_corr = aesara.function([input, filters], output, mode=self.mode)
 
         # initialize input and compute result
-        image_data = np.random.random(N_image_shape).astype(self.dtype)
-        filter_data = np.random.random(N_filter_shape).astype(self.dtype)
+        rng = np.random.default_rng(28483)
+
+        image_data = rng.random(N_image_shape).astype(self.dtype)
+        filter_data = rng.random(N_filter_shape).astype(self.dtype)
         image_data /= 10
         filter_data /= 10
         if non_contiguous:
@@ -337,8 +339,10 @@ class TestCorr3D(utt.InferShapeTester):
     def test_dtype_upcast(self):
         # Checks dtype upcast for Corr3dMM methods.
 
+        rng = np.random.default_rng(28483)
+
         def rand(shape, dtype="float64"):
-            r = np.asarray(np.random.rand(*shape), dtype=dtype)
+            r = np.asarray(rng.random(shape), dtype=dtype)
             return r * 2 - 1
 
         ops = [corr3d.Corr3dMM, corr3d.Corr3dMMGradWeights, corr3d.Corr3dMMGradInputs]
@@ -365,8 +369,11 @@ class TestCorr3D(utt.InferShapeTester):
         reason="Need cxx for this test",
     )
     def test_infer_shape_forward(self):
+
+        rng = np.random.default_rng(28483)
+
         def rand(*shape):
-            r = np.asarray(np.random.rand(*shape), dtype="float64")
+            r = np.asarray(rng.random(shape), dtype="float64")
             return r * 2 - 1
 
         corr3dMM = corr3d.Corr3dMM
@@ -413,8 +420,11 @@ class TestCorr3D(utt.InferShapeTester):
         reason="Need cxx for this test",
     )
     def test_infer_shape_gradW(self):
+
+        rng = np.random.default_rng(28483)
+
         def rand(*shape):
-            r = np.asarray(np.random.rand(*shape), dtype="float64")
+            r = np.asarray(rng.random(shape), dtype="float64")
             return r * 2 - 1
 
         corr3dMM = corr3d.Corr3dMM
@@ -473,8 +483,11 @@ class TestCorr3D(utt.InferShapeTester):
         reason="Need cxx for this test",
     )
     def test_infer_shape_gradI(self):
+
+        rng = np.random.default_rng(28483)
+
         def rand(*shape):
-            r = np.asarray(np.random.rand(*shape), dtype="float64")
+            r = np.asarray(rng.random(shape), dtype="float64")
             return r * 2 - 1
 
         corr3dMM = corr3d.Corr3dMM

--- a/tests/tensor/nnet/test_neighbours.py
+++ b/tests/tensor/nnet/test_neighbours.py
@@ -297,7 +297,7 @@ class TestImages2Neibs(unittest_tools.InferShapeTester):
         ):
             for neib_shape in neib_shapes:
                 for dtype in self.dtypes:
-                    x = aesara.shared(np.random.randn(*shape).astype(dtype))
+                    x = aesara.shared(np.random.standard_normal(shape).astype(dtype))
                     extra = (neib_shape[0] // 2, neib_shape[1] // 2)
                     padded_shape = (
                         x.shape[0],
@@ -334,7 +334,7 @@ class TestImages2Neibs(unittest_tools.InferShapeTester):
         ):
             for neib_shape in neib_shapes:
                 for dtype in self.dtypes:
-                    x = aesara.shared(np.random.randn(*shape).astype(dtype))
+                    x = aesara.shared(np.random.standard_normal(shape).astype(dtype))
                     extra = (neib_shape[0] - 1, neib_shape[1] - 1)
                     padded_shape = (
                         x.shape[0],
@@ -398,7 +398,7 @@ class TestImages2Neibs(unittest_tools.InferShapeTester):
     def test_grad_wrap_centered(self):
         # It is not implemented for now. So test that we raise an error.
         shape = (2, 3, 6, 6)
-        images_val = np.random.rand(*shape).astype("float32")
+        images_val = np.random.random(shape).astype("float32")
 
         def fn(images):
             return images2neibs(images, (3, 3), mode="wrap_centered")
@@ -409,7 +409,8 @@ class TestImages2Neibs(unittest_tools.InferShapeTester):
     def test_grad_half(self):
         # It is not implemented for now. So test that we raise an error.
         shape = (2, 3, 6, 6)
-        images_val = np.random.rand(*shape).astype("float32")
+        rng = np.random.default_rng(28483)
+        images_val = rng.random(shape).astype("float32")
 
         def fn(images):
             return images2neibs(images, (3, 3), mode="half")
@@ -420,7 +421,8 @@ class TestImages2Neibs(unittest_tools.InferShapeTester):
     def test_grad_full(self):
         # It is not implemented for now. So test that we raise an error.
         shape = (2, 3, 6, 6)
-        images_val = np.random.rand(*shape).astype("float32")
+        rng = np.random.default_rng(28483)
+        images_val = rng.random(shape).astype("float32")
 
         def fn(images):
             return images2neibs(images, (3, 3), mode="full")
@@ -430,7 +432,8 @@ class TestImages2Neibs(unittest_tools.InferShapeTester):
 
     def test_grad_valid(self):
         shape = (2, 3, 6, 6)
-        images_val = np.random.rand(*shape).astype("float32")
+        rng = np.random.default_rng(28483)
+        images_val = rng.random(shape).astype("float32")
 
         def fn(images):
             return images2neibs(images, (2, 2))
@@ -449,7 +452,8 @@ class TestImages2Neibs(unittest_tools.InferShapeTester):
 
     def test_grad_ignore_border(self):
         shape = (2, 3, 5, 5)
-        images_val = np.random.rand(*shape).astype("float32")
+        rng = np.random.default_rng(28483)
+        images_val = rng.random(shape).astype("float32")
 
         def fn(images):
             return images2neibs(images, (2, 2), mode="ignore_borders")
@@ -459,7 +463,8 @@ class TestImages2Neibs(unittest_tools.InferShapeTester):
     def test_neibs2images_grad(self):
         # say we had images of size (2, 3, 10, 10)
         # then we extracted 2x2 neighbors on this, we get (2 * 3 * 5 * 5, 4)
-        neibs_val = np.random.rand(150, 4)
+        rng = np.random.default_rng(28483)
+        neibs_val = rng.random((150, 4))
 
         def fn(neibs):
             return neibs2images(neibs, (2, 2), (2, 3, 10, 10))
@@ -519,7 +524,10 @@ class TestImages2Neibs(unittest_tools.InferShapeTester):
 
             im_val = np.ones((1, 3, 320, 320), dtype=np.float32)
             neibs = extractPatches(im_val)
+
+            # TODO FIXME: Make this a real test and `assert` something
             f(neibs, im_val.shape)
+
             # Wrong number of dimensions
             with pytest.raises(ValueError):
                 f(neibs, (1, 1, 3, 320, 320))

--- a/tests/tensor/test_blas.py
+++ b/tests/tensor/test_blas.py
@@ -3,19 +3,6 @@ from itertools import product
 
 import numpy as np
 import pytest
-from numpy import (
-    arange,
-    array,
-    common_type,
-    complex64,
-    complex128,
-    float32,
-    float64,
-    newaxis,
-    shape,
-    transpose,
-    zeros,
-)
 from numpy.testing import assert_array_almost_equal
 
 import aesara
@@ -1505,11 +1492,11 @@ class TestGemv(unittest_tools.OptimizationTestMixin):
 def matrixmultiply(a, b):
     if len(b.shape) == 1:
         b_is_vector = True
-        b = b[:, newaxis]
+        b = b[:, np.newaxis]
     else:
         b_is_vector = False
     assert a.shape[1] == b.shape[0]
-    c = zeros((a.shape[0], b.shape[1]), common_type(a, b))
+    c = np.zeros((a.shape[0], b.shape[1]), np.common_type(a, b))
     for i in range(a.shape[0]):
         for j in range(b.shape[1]):
             s = 0
@@ -1527,14 +1514,14 @@ class BaseGemv:
 
     def get_data(self, x_stride=1, y_stride=1):
         rng = np.random.default_rng(unittest_tools.fetch_seed())
-        mult = array(1, dtype=self.dtype)
-        if self.dtype in [complex64, complex128]:
-            mult = array(1 + 1j, dtype=self.dtype)
-        alpha = array(1.0, dtype=self.dtype) * mult
-        beta = array(1.0, dtype=self.dtype) * mult
+        mult = np.array(1, dtype=self.dtype)
+        if self.dtype in [np.complex64, np.complex128]:
+            mult = np.array(1 + 1j, dtype=self.dtype)
+        alpha = np.array(1.0, dtype=self.dtype) * mult
+        beta = np.array(1.0, dtype=self.dtype) * mult
         a = rng.standard_normal((3, 3)).astype(self.dtype) * mult
-        x = arange(shape(a)[0] * x_stride, dtype=self.dtype) * mult
-        y = arange(shape(a)[1] * y_stride, dtype=self.dtype) * mult
+        x = np.arange(np.shape(a)[0] * x_stride, dtype=self.dtype) * mult
+        y = np.arange(np.shape(a)[1] * y_stride, dtype=self.dtype) * mult
         return alpha, beta, a, x, y
 
     def test_simple(self):
@@ -1578,7 +1565,7 @@ class BaseGemv:
         alpha_v, beta_v, a_v, x_v, y_v = vs
         alpha, beta, a, x, y = [shared(v) for v in vs]
 
-        desired_oy = alpha_v * matrixmultiply(transpose(a_v), x_v) + beta_v * y_v
+        desired_oy = alpha_v * matrixmultiply(np.transpose(a_v), x_v) + beta_v * y_v
 
         oy = alpha * dot(a.T, x) + beta * y
 
@@ -1610,7 +1597,9 @@ class BaseGemv:
         alpha_v, beta_v, a_v, x_v, y_v = vs
         alpha, beta, a, x, y = [shared(v) for v in vs]
 
-        desired_oy = alpha_v * matrixmultiply(transpose(a_v), x_v[::2]) + beta_v * y_v
+        desired_oy = (
+            alpha_v * matrixmultiply(np.transpose(a_v), x_v[::2]) + beta_v * y_v
+        )
 
         oy = alpha * dot(a.T, x[::2]) + beta * y
 
@@ -1642,7 +1631,9 @@ class BaseGemv:
         alpha_v, beta_v, a_v, x_v, y_v = vs
         alpha, beta, a, x, y = [shared(v) for v in vs]
 
-        desired_oy = alpha_v * matrixmultiply(transpose(a_v), x_v) + beta_v * y_v[::2]
+        desired_oy = (
+            alpha_v * matrixmultiply(np.transpose(a_v), x_v) + beta_v * y_v[::2]
+        )
 
         oy = alpha * dot(a.T, x) + beta * y[::2]
 
@@ -1682,7 +1673,7 @@ class BaseGemv:
             a.get_value(borrow=True, return_internal_type=True)[::-1, ::-1], borrow=True
         )
 
-        desired_oy = alpha_v * matrixmultiply(transpose(a_v), x_v) + beta_v * y_v
+        desired_oy = alpha_v * matrixmultiply(np.transpose(a_v), x_v) + beta_v * y_v
 
         oy = alpha * dot(a.T, x) + beta * y
 
@@ -1728,13 +1719,13 @@ class BaseGemv:
 
 
 class TestSgemv(BaseGemv, unittest_tools.OptimizationTestMixin):
-    dtype = float32
+    dtype = np.float32
     gemv = gemv_no_inplace
     gemv_inplace = gemv_inplace
 
 
 class TestDgemv(BaseGemv, unittest_tools.OptimizationTestMixin):
-    dtype = float64
+    dtype = np.float64
     gemv = gemv_no_inplace
     gemv_inplace = gemv_inplace
 
@@ -2269,25 +2260,25 @@ class TestBlasStrides:
                 assert np.allclose(a.get_value(), a_n)
 
                 a_t.set_value(
-                    transpose(a_dev.copy())[::a_step2, ::a_step1], borrow=True
+                    np.transpose(a_dev.copy())[::a_step2, ::a_step1], borrow=True
                 )
                 f_tnn()
                 assert np.allclose(a_t.get_value(), at_n)
 
                 a_t.set_value(
-                    transpose(a_dev.copy())[::a_step2, ::a_step1], borrow=True
+                    np.transpose(a_dev.copy())[::a_step2, ::a_step1], borrow=True
                 )
                 f_tnt()
                 assert np.allclose(a_t.get_value(), at_n)
 
                 a_t.set_value(
-                    transpose(a_dev.copy())[::a_step2, ::a_step1], borrow=True
+                    np.transpose(a_dev.copy())[::a_step2, ::a_step1], borrow=True
                 )
                 f_ttn()
                 assert np.allclose(a_t.get_value(), at_n)
 
                 a_t.set_value(
-                    transpose(a_dev.copy())[::a_step2, ::a_step1], borrow=True
+                    np.transpose(a_dev.copy())[::a_step2, ::a_step1], borrow=True
                 )
                 f_ttt()
                 assert np.allclose(a_t.get_value(), at_n)
@@ -2335,7 +2326,7 @@ class TestBlasStrides:
                 a.set_value(a_dev.copy()[::a_step], borrow=True)
                 b.set_value(b_dev.copy()[::b_step1, ::b_step2], borrow=True)
                 b_t.set_value(
-                    transpose(b_dev.copy())[::b_step2, ::b_step1], borrow=True
+                    np.transpose(b_dev.copy())[::b_step2, ::b_step1], borrow=True
                 )
                 c.set_value(c_dev.copy()[::c_step], borrow=True)
 
@@ -2386,7 +2377,7 @@ class TestBlasStrides:
 
                 a.set_value(a_dev.copy()[::a_step1, ::a_step2], borrow=True)
                 a_t.set_value(
-                    transpose(a_dev.copy())[::a_step1, ::a_step2], borrow=True
+                    np.transpose(a_dev.copy())[::a_step1, ::a_step2], borrow=True
                 )
                 b.set_value(b_dev.copy()[::b_step], borrow=True)
                 c.set_value(c_dev.copy()[::c_step], borrow=True)

--- a/tests/tensor/test_casting.py
+++ b/tests/tensor/test_casting.py
@@ -1,11 +1,13 @@
 import numpy as np
+import pytest
 
 import aesara
-import aesara.tensor.basic as basic
 from aesara import function
 from aesara.compile.io import In
 from aesara.misc.safe_asarray import _asarray
 from aesara.tensor.basic import (
+    _convert_to_complex64,
+    _convert_to_complex128,
     _convert_to_float32,
     _convert_to_float64,
     _convert_to_int8,
@@ -26,29 +28,26 @@ from aesara.tensor.type import (
 
 
 class TestCasting:
-    def test_0(self):
-        for op_fn in [_convert_to_int32, _convert_to_float32, _convert_to_float64]:
-            for type_fn in bvector, ivector, fvector, dvector:
-                x = type_fn()
-                f = function([x], op_fn(x))
+    @pytest.mark.parametrize(
+        "op_fn", [_convert_to_int32, _convert_to_float32, _convert_to_float64]
+    )
+    @pytest.mark.parametrize("type_fn", [bvector, ivector, fvector, dvector])
+    def test_0(self, op_fn, type_fn):
+        x = type_fn()
+        f = function([x], op_fn(x))
 
-                xval = _asarray(np.random.rand(10) * 10, dtype=type_fn.dtype)
-                yval = f(xval)
-                assert (
-                    str(yval.dtype)
-                    == op_fn.scalar_op.output_types_preference.spec[0].dtype
-                )
+        xval = _asarray(np.random.random(10) * 10, dtype=type_fn.dtype)
+        yval = f(xval)
+        assert str(yval.dtype) == op_fn.scalar_op.output_types_preference.spec[0].dtype
 
     def test_illegal(self):
-        try:
-            x = zmatrix()
+        x = zmatrix()
+        with pytest.raises(TypeError):
             function([x], cast(x, "float64"))(np.ones((2, 3), dtype="complex128"))
-        except TypeError:
-            return
-        assert 0
 
-    def test_basic(self):
-        for type1 in [
+    @pytest.mark.parametrize(
+        "type1",
+        [
             "uint8",
             "uint16",
             "uint32",
@@ -59,24 +58,29 @@ class TestCasting:
             "int64",
             "float32",
             "float64",
-        ]:
-            x = TensorType(dtype=type1, shape=(False,))()
-            for type2, converter in zip(
-                ["int8", "int16", "int32", "int64", "float32", "float64"],
-                [
-                    _convert_to_int8,
-                    _convert_to_int16,
-                    _convert_to_int32,
-                    _convert_to_int64,
-                    _convert_to_float32,
-                    _convert_to_float64,
-                ],
-            ):
-                y = converter(x)
-                f = function([In(x, strict=True)], y)
-                a = np.arange(10, dtype=type1)
-                b = f(a)
-                assert np.all(b == np.arange(10, dtype=type2))
+        ],
+    )
+    @pytest.mark.parametrize(
+        "type2, converter",
+        zip(
+            ["int8", "int16", "int32", "int64", "float32", "float64"],
+            [
+                _convert_to_int8,
+                _convert_to_int16,
+                _convert_to_int32,
+                _convert_to_int64,
+                _convert_to_float32,
+                _convert_to_float64,
+            ],
+        ),
+    )
+    def test_basic(self, type1, type2, converter):
+        x = TensorType(dtype=type1, shape=(False,))()
+        y = converter(x)
+        f = function([In(x, strict=True)], y)
+        a = np.arange(10, dtype=type1)
+        b = f(a)
+        assert np.array_equal(b, np.arange(10, dtype=type2))
 
     def test_convert_to_complex(self):
         val64 = np.ones(3, dtype="complex64") + 0.5j
@@ -85,46 +89,44 @@ class TestCasting:
         vec64 = TensorType("complex64", (False,))()
         vec128 = TensorType("complex128", (False,))()
 
-        f = function([vec64], basic._convert_to_complex128(vec64))
+        f = function([vec64], _convert_to_complex128(vec64))
         # we need to compare with the same type.
         assert vec64.type.values_eq_approx(val128, f(val64))
 
-        f = function([vec128], basic._convert_to_complex128(vec128))
+        f = function([vec128], _convert_to_complex128(vec128))
         assert vec64.type.values_eq_approx(val128, f(val128))
 
-        f = function([vec64], basic._convert_to_complex64(vec64))
+        f = function([vec64], _convert_to_complex64(vec64))
         assert vec64.type.values_eq_approx(val64, f(val64))
 
-        f = function([vec128], basic._convert_to_complex64(vec128))
+        f = function([vec128], _convert_to_complex64(vec128))
         assert vec128.type.values_eq_approx(val64, f(val128))
 
         # upcasting to complex128
         for t in ["int8", "int16", "int32", "int64", "float32", "float64"]:
             a = aesara.shared(np.ones(3, dtype=t))
             b = aesara.shared(np.ones(3, dtype="complex128"))
-            f = function([], basic._convert_to_complex128(a))
+            f = function([], _convert_to_complex128(a))
             assert a.type.values_eq_approx(b.get_value(), f())
 
         # upcasting to complex64
         for t in ["int8", "int16", "int32", "int64", "float32"]:
             a = aesara.shared(np.ones(3, dtype=t))
             b = aesara.shared(np.ones(3, dtype="complex64"))
-            f = function([], basic._convert_to_complex64(a))
+            f = function([], _convert_to_complex64(a))
             assert a.type.values_eq_approx(b.get_value(), f())
 
         # downcast to complex64
         for t in ["float64"]:
             a = aesara.shared(np.ones(3, dtype=t))
             b = aesara.shared(np.ones(3, dtype="complex64"))
-            f = function([], basic._convert_to_complex64(a))
+            f = function([], _convert_to_complex64(a))
             assert a.type.values_eq_approx(b.get_value(), f())
 
     def test_bug_complext_10_august_09(self):
         v0 = dmatrix()
-        v1 = basic._convert_to_complex128(v0)
+        v1 = _convert_to_complex128(v0)
 
-        inputs = [v0]
-        outputs = [v1]
-        f = function(inputs, outputs)
+        f = function([v0], v1)
         i = np.zeros((2, 2))
-        assert (f(i) == np.zeros((2, 2))).all()
+        assert np.array_equal(f(i), i)

--- a/tests/tensor/test_complex.py
+++ b/tests/tensor/test_complex.py
@@ -4,7 +4,8 @@ import pytest
 import aesara
 from aesara.gradient import GradientError
 from aesara.tensor.basic import cast
-from aesara.tensor.math import complex, complex_from_polar, imag, real
+from aesara.tensor.math import complex as at_complex
+from aesara.tensor.math import complex_from_polar, imag, real
 from aesara.tensor.type import cvector, dvector, fmatrix, fvector, imatrix, zvector
 from tests import unittest_tools as utt
 
@@ -15,8 +16,7 @@ class TestRealImag:
         rng = np.random.default_rng(23)
         xval = np.asarray(
             list(
-                np.complex(rng.standard_normal(), rng.standard_normal())
-                for i in range(10)
+                complex(rng.standard_normal(), rng.standard_normal()) for i in range(10)
             )
         )
         assert np.all(xval.real == aesara.function([x], real(x))(xval))
@@ -42,7 +42,7 @@ class TestRealImag:
     def test_complex(self):
         rng = np.random.default_rng(2333)
         m = fmatrix()
-        c = complex(m[0], m[1])
+        c = at_complex(m[0], m[1])
         assert c.type == cvector
         r, i = [real(c), imag(c)]
         assert r.type == fvector
@@ -57,7 +57,7 @@ class TestRealImag:
     @pytest.mark.skip(reason="Complex grads not enabled, see #178")
     def test_complex_grads(self):
         def f(m):
-            c = complex(m[0], m[1])
+            c = at_complex(m[0], m[1])
             return 0.5 * real(c) + 0.9 * imag(c)
 
         rng = np.random.default_rng(9333)
@@ -67,7 +67,7 @@ class TestRealImag:
     @pytest.mark.skip(reason="Complex grads not enabled, see #178")
     def test_mul_mixed0(self):
         def f(a):
-            ac = complex(a[0], a[1])
+            ac = at_complex(a[0], a[1])
             return abs((ac) ** 2).sum()
 
         rng = np.random.default_rng(9333)
@@ -82,7 +82,7 @@ class TestRealImag:
     @pytest.mark.skip(reason="Complex grads not enabled, see #178")
     def test_mul_mixed1(self):
         def f(a):
-            ac = complex(a[0], a[1])
+            ac = at_complex(a[0], a[1])
             return abs(ac).sum()
 
         rng = np.random.default_rng(9333)
@@ -97,7 +97,7 @@ class TestRealImag:
     @pytest.mark.skip(reason="Complex grads not enabled, see #178")
     def test_mul_mixed(self):
         def f(a, b):
-            ac = complex(a[0], a[1])
+            ac = at_complex(a[0], a[1])
             return abs((ac * b) ** 2).sum()
 
         rng = np.random.default_rng(9333)
@@ -123,7 +123,7 @@ class TestRealImag:
     @pytest.mark.skip(reason="Complex grads not enabled, see #178")
     def test_abs_grad(self):
         def f(m):
-            c = complex(m[0], m[1])
+            c = at_complex(m[0], m[1])
             return 0.5 * abs(c)
 
         rng = np.random.default_rng(9333)

--- a/tests/tensor/test_keepdims.py
+++ b/tests/tensor/test_keepdims.py
@@ -17,9 +17,9 @@ from aesara.tensor.math import var
 from aesara.tensor.type import dtensor3
 
 
-# this tests other ops to ensure they keep the dimensions of their
-# inputs correctly
 class TestKeepDims:
+    r"""This tests other `Op`\s to ensure they keep the dimensions of their inputs correctly."""
+
     def makeKeepDims_local(self, x, y, axis):
         if axis is None:
             newaxis = list(range(x.ndim))
@@ -45,18 +45,9 @@ class TestKeepDims:
 
         return DimShuffle(y.type.broadcastable, new_dims)(y)
 
-    @pytest.mark.slow
-    def test_keepdims(self):
-
-        x = dtensor3()
-        a = np.random.rand(3, 2, 4)
-        # We don't need to test all opt and C code, as this is tested
-        # by the ops tests.
-        mode = Mode(optimizer="fast_compile", linker="py")
-
-        # 'max_and_argmax' has two outputs and can be specified with either
-        # a single or every axis:
-        for axis in [
+    @pytest.mark.parametrize(
+        "axis",
+        [
             0,
             1,
             2,
@@ -71,124 +62,92 @@ class TestKeepDims:
             [-1, -2, -3],
             [0, -1, -2],
             [-2, -3, 2],
-        ]:
-
-            op = max_and_argmax
-            f = function(
-                [x],
-                [
-                    op(x, axis=axis, keepdims=True)[0],
-                    self.makeKeepDims_local(
-                        x, op(x, axis=axis, keepdims=False)[0], axis
-                    ),
-                ],
-                mode=mode,
-            )
-            ans1, ans2 = f(a)
-            assert np.allclose(ans1, ans2)
-            assert ans1.shape == ans2.shape
-
-            f = function(
-                [x],
-                [
-                    op(x, axis=axis, keepdims=True)[1],
-                    self.makeKeepDims_local(
-                        x, op(x, axis=axis, keepdims=False)[1], axis
-                    ),
-                ],
-                mode=mode,
-            )
-            ans1, ans2 = f(a)
-            assert np.allclose(ans1, ans2)
-            assert ans1.shape == ans2.shape
-
-        # the following ops can be specified with either a single axis or every
-        # axis:
-        for op in [argmax, argmin]:
-            for axis in [
-                0,
-                1,
-                2,
-                [0],
-                [1],
-                [2],
-                None,
-                [0, 1, 2],
-                [-1],
-                [-2],
-                [-3],
-                [-1, -2, -3],
-                [0, -2, 2],
-            ]:
-
-                f = function(
-                    [x],
-                    [
-                        op(x, axis=axis, keepdims=True),
-                        self.makeKeepDims_local(
-                            x, op(x, axis=axis, keepdims=False), axis
-                        ),
-                    ],
-                    mode=mode,
-                )
-                ans1, ans2 = f(a)
-                assert np.allclose(ans1, ans2)
-                assert ans1.shape == ans2.shape
-
-        # the following ops can be specified with a freely specified axis
-        # parameter
-        for op in [
-            at_sum,
-            prod,
-            mean,
-            var,
-            std,
-            at_all,
-            at_any,
-            at_max,
-            at_min,
-        ]:
-            for axis in [
-                0,
-                1,
-                2,
-                [0],
-                [1],
-                [2],
-                None,
-                [0, 1],
-                [1, 2],
-                [0, 1, 2],
-                [-1],
-                [-2],
-                [-3],
-                [-1, -2],
-                [-1, -2, -3],
-                [0, -2, 2],
-            ]:
-
-                f = function(
-                    [x],
-                    [
-                        op(x, axis=axis, keepdims=True),
-                        self.makeKeepDims_local(
-                            x, op(x, axis=axis, keepdims=False), axis
-                        ),
-                    ],
-                    mode=mode,
-                )
-
-                ans1, ans2 = f(a)
-                assert np.allclose(ans1, ans2)
-                assert ans1.shape == ans2.shape
-
-    def test_norm(self):
+        ],
+    )
+    @pytest.mark.parametrize(
+        "op",
+        [max_and_argmax],
+    )
+    def test_max_and_argmax(self, axis, op):
 
         x = dtensor3()
-        a = np.random.rand(3, 2, 4).astype(aesara.config.floatX)
+        a = np.random.random((3, 2, 4))
+        # We don't need to test all opt and C code, as this is tested
+        # by the ops tests.
         mode = Mode(optimizer="fast_compile", linker="py")
 
-        for axis in [
+        # 'max_and_argmax' has two outputs and can be specified with either
+        # a single or every axis:
+        f = function(
+            [x],
+            [
+                op(x, axis=axis, keepdims=True)[0],
+                self.makeKeepDims_local(x, op(x, axis=axis, keepdims=False)[0], axis),
+            ],
+            mode=mode,
+        )
+        ans1, ans2 = f(a)
+        assert np.allclose(ans1, ans2)
+        assert ans1.shape == ans2.shape
+
+        f = function(
+            [x],
+            [
+                op(x, axis=axis, keepdims=True)[1],
+                self.makeKeepDims_local(x, op(x, axis=axis, keepdims=False)[1], axis),
+            ],
+            mode=mode,
+        )
+        ans1, ans2 = f(a)
+        assert np.allclose(ans1, ans2)
+        assert ans1.shape == ans2.shape
+
+    @pytest.mark.parametrize(
+        "axis",
+        [
+            0,
+            1,
+            2,
+            [0],
+            [1],
+            [2],
+            None,
+            [0, 1, 2],
+            [-1],
+            [-2],
+            [-3],
+            [-1, -2, -3],
+            [0, -2, 2],
+        ],
+    )
+    @pytest.mark.parametrize(
+        "op",
+        [argmax, argmin],
+    )
+    def test_single_or_any_axis(self, axis, op):
+        # the following ops can be specified with either a single axis or every
+        # axis:
+        x = dtensor3()
+        a = np.random.random((3, 2, 4))
+        # We don't need to test all opt and C code, as this is tested
+        # by the ops tests.
+        mode = Mode(optimizer="fast_compile", linker="py")
+
+        f = function(
+            [x],
+            [
+                op(x, axis=axis, keepdims=True),
+                self.makeKeepDims_local(x, op(x, axis=axis, keepdims=False), axis),
+            ],
+            mode=mode,
+        )
+        ans1, ans2 = f(a)
+        assert np.allclose(ans1, ans2)
+        assert ans1.shape == ans2.shape
+
+    @pytest.mark.parametrize(
+        "axis",
+        [
             0,
             1,
             2,
@@ -205,34 +164,98 @@ class TestKeepDims:
             [-1, -2],
             [-1, -2, -3],
             [0, -2, 2],
-        ]:
+        ],
+    )
+    @pytest.mark.parametrize(
+        "op",
+        [
+            at_sum,
+            prod,
+            mean,
+            var,
+            std,
+            at_all,
+            at_any,
+            at_max,
+            at_min,
+        ],
+    )
+    def test_free_axis(self, axis, op):
 
-            f = function(
-                [x],
-                [
-                    x.norm(L=1, axis=axis, keepdims=True),
-                    self.makeKeepDims_local(
-                        x, x.norm(L=1, axis=axis, keepdims=False), axis
-                    ),
-                ],
-                mode=mode,
-            )
+        x = dtensor3()
+        a = np.random.random((3, 2, 4))
+        # We don't need to test all opt and C code, as this is tested
+        # by the ops tests.
+        mode = Mode(optimizer="fast_compile", linker="py")
 
-            ans1, ans2 = f(a)
-            assert np.allclose(ans1, ans2)
-            assert ans1.shape == ans2.shape
+        # the following ops can be specified with a freely specified axis
+        # parameter
+        f = function(
+            [x],
+            [
+                op(x, axis=axis, keepdims=True),
+                self.makeKeepDims_local(x, op(x, axis=axis, keepdims=False), axis),
+            ],
+            mode=mode,
+        )
 
-            g = function(
-                [x],
-                [
-                    x.norm(L=2, axis=axis, keepdims=True),
-                    self.makeKeepDims_local(
-                        x, x.norm(L=2, axis=axis, keepdims=False), axis
-                    ),
-                ],
-                mode=mode,
-            )
+        ans1, ans2 = f(a)
+        assert np.allclose(ans1, ans2)
+        assert ans1.shape == ans2.shape
 
-            ans1, ans2 = g(a)
-            assert np.allclose(ans1, ans2)
-            assert ans1.shape == ans2.shape
+    @pytest.mark.parametrize(
+        "axis",
+        [
+            0,
+            1,
+            2,
+            [0],
+            [1],
+            [2],
+            None,
+            [0, 1],
+            [1, 2],
+            [0, 1, 2],
+            [-1],
+            [-2],
+            [-3],
+            [-1, -2],
+            [-1, -2, -3],
+            [0, -2, 2],
+        ],
+    )
+    def test_norm(self, axis):
+
+        x = dtensor3()
+        a = np.random.random((3, 2, 4)).astype(aesara.config.floatX)
+        mode = Mode(optimizer="fast_compile", linker="py")
+
+        f = function(
+            [x],
+            [
+                x.norm(L=1, axis=axis, keepdims=True),
+                self.makeKeepDims_local(
+                    x, x.norm(L=1, axis=axis, keepdims=False), axis
+                ),
+            ],
+            mode=mode,
+        )
+
+        ans1, ans2 = f(a)
+        assert np.allclose(ans1, ans2)
+        assert ans1.shape == ans2.shape
+
+        g = function(
+            [x],
+            [
+                x.norm(L=2, axis=axis, keepdims=True),
+                self.makeKeepDims_local(
+                    x, x.norm(L=2, axis=axis, keepdims=False), axis
+                ),
+            ],
+            mode=mode,
+        )
+
+        ans1, ans2 = g(a)
+        assert np.allclose(ans1, ans2)
+        assert ans1.shape == ans2.shape

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -1832,12 +1832,8 @@ class TestDivimpl:
         assert np.allclose(function([i, ii], ii // i)(5, 3), (3 // 5))
         assert np.allclose(function([i, ii], true_div(i, ii))(5, 3), (5.0 / 3.0))
         assert np.allclose(function([i, ii], true_div(ii, i))(5, 3), (3.0 / 5.0))
-        assert np.allclose(
-            function([i, c], i / c)(5, np.complex(5, 3)), (5.0 / (5 + 3j))
-        )
-        assert np.allclose(
-            function([i, c], c / i)(5, np.complex(5, 3)), ((5 + 3j) / 5.0)
-        )
+        assert np.allclose(function([i, c], i / c)(5, complex(5, 3)), (5.0 / (5 + 3j)))
+        assert np.allclose(function([i, c], c / i)(5, complex(5, 3)), ((5 + 3j) / 5.0))
 
 
 class TestMean:
@@ -1929,17 +1925,17 @@ class TestDot:
                 # This strange way of doing things is the only way that worked
                 # on NumPy 1.4.1.
                 if r.ndim == 0:
-                    return np.asarray(np.complex(1.1, 2.1), dtype=r.dtype)
+                    return np.asarray(complex(1.1, 2.1), dtype=r.dtype)
                 if r.ndim == 1:
                     if r.dtype == "complex64":
-                        return np.complex64([np.complex(1.2, 2.2)])
+                        return np.complex64([complex(1.2, 2.2)])
                     elif r.dtype == "complex128":
-                        return np.complex128([np.complex(1.2, 2.2)])
+                        return np.complex128([complex(1.2, 2.2)])
                 elif r.ndim == 2:
                     if r.dtype == "complex64":
-                        return np.complex64([[np.complex(1.3, 2.3)]])
+                        return np.complex64([[complex(1.3, 2.3)]])
                     elif r.dtype == "complex128":
-                        return np.complex128([[np.complex(1.3, 2.3)]])
+                        return np.complex128([[complex(1.3, 2.3)]])
 
             if r.ndim == 0:
                 return np.asarray(1.1, dtype=r.dtype)

--- a/tests/tensor/test_mlp.py
+++ b/tests/tensor/test_mlp.py
@@ -20,18 +20,19 @@ from aesara.tensor.type import ivector, lscalar, matrix
 
 def gen_data():
 
+    rng = np.random.default_rng(249820)
     # generate the dataset
     train_set = (
-        np.asarray(np.random.rand(10000, 784), dtype="float32"),
-        np.asarray(np.random.rand(10000) * 10, dtype="int64"),
+        np.asarray(rng.random((10000, 784)), dtype="float32"),
+        np.asarray(rng.random((10000,)) * 10, dtype="int64"),
     )
     valid_set = (
-        np.asarray(np.random.rand(10000, 784), dtype="float32"),
-        np.asarray(np.random.rand(10000) * 10, dtype="int64"),
+        np.asarray(rng.random((10000, 784)), dtype="float32"),
+        np.asarray(rng.random((10000,)) * 10, dtype="int64"),
     )
     test_set = (
-        np.asarray(np.random.rand(10000, 784), dtype="float32"),
-        np.asarray(np.random.rand(10000) * 10, dtype="int64"),
+        np.asarray(rng.random((10000, 784)), dtype="float32"),
+        np.asarray(rng.random((10000,)) * 10, dtype="int64"),
     )
 
     def shared_dataset(data_xy):

--- a/tests/tensor/test_opt_uncanonicalize.py
+++ b/tests/tensor/test_opt_uncanonicalize.py
@@ -53,7 +53,7 @@ class TestMinMax:
         )
 
     def test_optimization_max(self):
-        data = np.asarray(np.random.rand(2, 3), dtype=config.floatX)
+        data = np.asarray(np.random.random((2, 3)), dtype=config.floatX)
         n = matrix()
 
         for axis in [0, 1, -1]:
@@ -86,7 +86,7 @@ class TestMinMax:
             f(data)
 
     def test_optimization_min(self):
-        data = np.asarray(np.random.rand(2, 3), dtype=config.floatX)
+        data = np.asarray(np.random.random((2, 3)), dtype=config.floatX)
         n = matrix()
 
         for axis in [0, 1, -1]:
@@ -209,7 +209,7 @@ def test_local_dimshuffle_subtensor():
 
     topo = f.maker.fgraph.toposort()
     assert not all(isinstance(x, DimShuffle) for x in topo)
-    assert f(np.random.rand(5, 1, 4, 1), 2).shape == (4,)
+    assert f(np.random.random((5, 1, 4, 1)), 2).shape == (4,)
 
     # Test a corner case that had Aesara return a bug.
     x = dtensor4("x")

--- a/tests/tensor/test_subtensor_opt.py
+++ b/tests/tensor/test_subtensor_opt.py
@@ -69,8 +69,8 @@ if mode_opt == "FAST_COMPILE":
 mode_opt = get_mode(mode_opt)
 
 
-y = create_aesara_param(np.random.randint(0, 4, size=(2,)))
-z = create_aesara_param(np.random.randint(0, 4, size=(2, 2)))
+y = create_aesara_param(np.random.default_rng().integers(0, 4, size=(2,)))
+z = create_aesara_param(np.random.default_rng().integers(0, 4, size=(2, 2)))
 
 
 @pytest.mark.parametrize(

--- a/tests/tensor/test_utils.py
+++ b/tests/tensor/test_utils.py
@@ -9,7 +9,7 @@ from aesara.tensor.utils import hash_from_ndarray, shape_of_variables
 
 def test_hash_from_ndarray():
     hashes = []
-    rng = np.random.rand(5, 5)
+    x = np.random.random((5, 5))
 
     for data in [
         -2,
@@ -29,12 +29,12 @@ def test_hash_from_ndarray():
         np.zeros((5, 5), dtype="uint32"),
         np.zeros((5, 5), dtype="int32"),
         # Test slice
-        rng,
-        rng[1:],
-        rng[:4],
-        rng[1:3],
-        rng[::2],
-        rng[::-1],
+        x,
+        x[1:],
+        x[:4],
+        x[1:3],
+        x[::2],
+        x[::-1],
     ]:
         data = np.asarray(data)
         hashes.append(hash_from_ndarray(data))
@@ -42,11 +42,11 @@ def test_hash_from_ndarray():
     assert len(set(hashes)) == len(hashes)
 
     # test that different type of views and their copy give the same hash
-    assert hash_from_ndarray(rng[1:]) == hash_from_ndarray(rng[1:].copy())
-    assert hash_from_ndarray(rng[1:3]) == hash_from_ndarray(rng[1:3].copy())
-    assert hash_from_ndarray(rng[:4]) == hash_from_ndarray(rng[:4].copy())
-    assert hash_from_ndarray(rng[::2]) == hash_from_ndarray(rng[::2].copy())
-    assert hash_from_ndarray(rng[::-1]) == hash_from_ndarray(rng[::-1].copy())
+    assert hash_from_ndarray(x[1:]) == hash_from_ndarray(x[1:].copy())
+    assert hash_from_ndarray(x[1:3]) == hash_from_ndarray(x[1:3].copy())
+    assert hash_from_ndarray(x[:4]) == hash_from_ndarray(x[:4].copy())
+    assert hash_from_ndarray(x[::2]) == hash_from_ndarray(x[::2].copy())
+    assert hash_from_ndarray(x[::-1]) == hash_from_ndarray(x[::-1].copy())
 
 
 class TestShapeOfVariables:

--- a/tests/tensor/test_var.py
+++ b/tests/tensor/test_var.py
@@ -93,7 +93,7 @@ def test_empty_list_indexing():
 
 def test_copy():
     x = dmatrix("x")
-    data = np.random.rand(5, 5)
+    data = np.random.random((5, 5))
     y = x.copy(name="y")
     f = aesara.function([x], y)
     assert_equal(f(data), data)

--- a/tests/tensor/test_xlogx.py
+++ b/tests/tensor/test_xlogx.py
@@ -1,4 +1,4 @@
-import numpy.random
+import numpy as np
 
 import aesara
 from aesara.tensor import as_tensor_variable
@@ -6,25 +6,22 @@ from aesara.tensor.xlogx import xlogx, xlogy0
 from tests import unittest_tools as utt
 
 
-class TestXlogX:
-    def test_basic(self):
-        x = as_tensor_variable([1, 0])
-        y = xlogx(x)
-        f = aesara.function([], [y])
-        assert numpy.all(f() == numpy.asarray([0, 0.0]))
+def test_xlogx():
+    x = as_tensor_variable([1, 0])
+    y = xlogx(x)
+    f = aesara.function([], y)
+    assert np.array_equal(f(), np.asarray([0, 0.0]))
 
-        # class Dummy(object):
-        #     def make_node(self, a):
-        #         return [xlogx(a)[:,2]]
-        utt.verify_grad(xlogx, [numpy.random.rand(3, 4)])
+    rng = np.random.default_rng(24982)
+    utt.verify_grad(xlogx, [rng.random((3, 4))])
 
 
-class TestXlogY0:
-    def test_basic(self):
-        utt.verify_grad(xlogy0, [numpy.random.rand(3, 4), numpy.random.rand(3, 4)])
+def test_xlogy0():
+    x = as_tensor_variable([1, 0])
+    y = as_tensor_variable([1, 0])
+    z = xlogy0(x, y)
+    f = aesara.function([], z)
+    assert np.array_equal(f(), np.asarray([0, 0.0]))
 
-        x = as_tensor_variable([1, 0])
-        y = as_tensor_variable([1, 0])
-        z = xlogy0(x, y)
-        f = aesara.function([], z)
-        assert numpy.all(f() == numpy.asarray([0, 0.0]))
+    rng = np.random.default_rng(24982)
+    utt.verify_grad(xlogy0, [rng.random((3, 4)), rng.random((3, 4))])

--- a/tests/typed_list/test_basic.py
+++ b/tests/typed_list/test_basic.py
@@ -31,7 +31,7 @@ from aesara.typed_list.type import TypedListType
 
 def rand_ranged_matrix(minimum, maximum, shape):
     return np.asarray(
-        np.random.rand(*shape) * (maximum - minimum) + minimum,
+        np.random.random(shape) * (maximum - minimum) + minimum,
         dtype=aesara.config.floatX,
     )
 
@@ -42,8 +42,8 @@ def random_lil(shape, dtype, nnz):
     huge = 2**30
     for k in range(nnz):
         # set non-zeros in random locations (row x, col y)
-        idx = np.random.randint(1, huge + 1, size=2) % shape
-        value = np.random.rand()
+        idx = np.random.default_rng().integers(1, huge + 1, size=2) % shape
+        value = np.random.random()
         # if dtype *int*, value will always be zeros!
         if dtype in integer_dtypes:
             value = int(value * 100)
@@ -575,10 +575,10 @@ class TestMakeList:
         x = tensor3()
         y = tensor3()
 
-        A = np.cast[aesara.config.floatX](np.random.rand(5, 3))
-        B = np.cast[aesara.config.floatX](np.random.rand(7, 2))
-        X = np.cast[aesara.config.floatX](np.random.rand(5, 6, 1))
-        Y = np.cast[aesara.config.floatX](np.random.rand(1, 9, 3))
+        A = np.cast[aesara.config.floatX](np.random.random((5, 3)))
+        B = np.cast[aesara.config.floatX](np.random.random((7, 2)))
+        X = np.cast[aesara.config.floatX](np.random.random((5, 6, 1)))
+        Y = np.cast[aesara.config.floatX](np.random.random((1, 9, 3)))
 
         make_list((3.0, 4.0))
         c = make_list((a, b))


### PR DESCRIPTION
This PR updates our usage of `numpy.random` functions to follow NumPy's recommendations a little more closely and performs some related documentation and test refactoring.

This fixes the `test_maxpool` issue observed in https://github.com/aesara-devs/aesara/pull/947.