### PR TITLE
Parameterize the types of some core graph objects

### DIFF
--- a/aesara/graph/op.py
+++ b/aesara/graph/op.py
@@ -509,7 +509,7 @@ class Op(MetaObject):
         node_output_storage = [storage_map[r] for r in node.outputs]
 
         if debug and hasattr(self, "debug_perform"):
-            p = node.op.debug_perform  # type: ignore
+            p = node.op.debug_perform
         else:
             p = node.op.perform
 

--- a/aesara/graph/type.py
+++ b/aesara/graph/type.py
@@ -197,7 +197,7 @@ class Type(MetaObject):
             A pretty string for printing and debugging.
 
         """
-        return self.variable_type(self, name=name)
+        return self.variable_type(self, None, name=name)
 
     def make_constant(self, value: D, name: Optional[Text] = None) -> constant_type:
         """Return a new `Constant` instance of this `Type`.

--- a/aesara/graph/type.py
+++ b/aesara/graph/type.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Optional, Text, Tuple, TypeVar, Union
+from typing import Any, Generic, Optional, Text, Tuple, TypeVar, Union
 
 from typing_extensions import TypeAlias
 
@@ -11,7 +11,7 @@ from aesara.graph.utils import MetaObject
 D = TypeVar("D")
 
 
-class Type(MetaObject):
+class Type(MetaObject, Generic[D]):
     """
     Interface specification for variable type instances.
 
@@ -77,8 +77,8 @@ class Type(MetaObject):
 
     @abstractmethod
     def filter(
-        self, data: D, strict: bool = False, allow_downcast: Optional[bool] = None
-    ) -> Union[D, Any]:
+        self, data: Any, strict: bool = False, allow_downcast: Optional[bool] = None
+    ) -> D:
         """Return data or an appropriately wrapped/converted data.
 
         Subclass implementations should raise a TypeError exception if
@@ -103,7 +103,7 @@ class Type(MetaObject):
 
     def filter_inplace(
         self,
-        value: D,
+        value: Any,
         storage: Any,
         strict: bool = False,
         allow_downcast: Optional[bool] = None,
@@ -212,7 +212,7 @@ class Type(MetaObject):
         """
         return self.constant_type(type=self, data=value, name=name)
 
-    def clone(self, *args, **kwargs):
+    def clone(self, *args, **kwargs) -> "Type":
         """Clone a copy of this type with the given arguments/keyword values, if any."""
         return type(self)(*args, **kwargs)
 
@@ -228,7 +228,7 @@ class Type(MetaObject):
         return utils.add_tag_trace(self.make_variable(name))
 
     @classmethod
-    def values_eq(cls, a: "Type", b: "Type") -> bool:
+    def values_eq(cls, a: D, b: D) -> bool:
         """Return ``True`` if `a` and `b` can be considered exactly equal.
 
         `a` and `b` are assumed to be valid values of this `Type`.
@@ -237,7 +237,7 @@ class Type(MetaObject):
         return a == b
 
     @classmethod
-    def values_eq_approx(cls, a: Any, b: Any):
+    def values_eq_approx(cls, a: D, b: D) -> bool:
         """Return ``True`` if `a` and `b` can be considered approximately equal.
 
         This function is used by Aesara debugging tools to decide

--- a/aesara/link/basic.py
+++ b/aesara/link/basic.py
@@ -207,7 +207,7 @@ class Linker(ABC):
 
         Examples
         --------
-        x, y = Variable(Double), Variable(Double)
+        x, y = Variable(Double, None), Variable(Double, None)
         e = x + y
         fgraph = FunctionGraph([x, y], [e])
         fn, (new_x, new_y), (new_e, ) = MyLinker(fgraph).make_thunk(inplace)

--- a/aesara/link/c/type.py
+++ b/aesara/link/c/type.py
@@ -1,6 +1,7 @@
 import ctypes
 import platform
 import re
+from typing import TypeVar
 
 from aesara.graph.basic import Constant
 from aesara.graph.type import Type
@@ -8,7 +9,11 @@ from aesara.link.c.interface import CLinkerType
 from aesara.utils import Singleton
 
 
-class CType(Type, CLinkerType):
+D = TypeVar("D")
+T = TypeVar("T", bound=Type)
+
+
+class CType(Type[D], CLinkerType):
     """Convenience wrapper combining `Type` and `CLinkerType`.
 
     Aesara comes with several subclasses of such as:
@@ -120,7 +125,7 @@ if platform.python_implementation() != "PyPy":
     ).value
 
 
-class CDataType(CType):
+class CDataType(CType[D]):
     """
     Represents opaque C data to be passed around. The intent is to
     ease passing arbitrary data between ops C code.
@@ -286,7 +291,7 @@ void _capsule_destructor(PyObject *o) {
             self.version = None
 
 
-class CDataTypeConstant(Constant):
+class CDataTypeConstant(Constant[T]):
     def merge_signature(self):
         # We don't want to merge constants that don't point to the
         # same object.

--- a/aesara/scalar/basic.py
+++ b/aesara/scalar/basic.py
@@ -28,7 +28,7 @@ from aesara.gradient import DisconnectedType, grad_undefined
 from aesara.graph.basic import Apply, Constant, Variable, clone, list_of_nodes
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.opt import MergeOptimizer
-from aesara.graph.type import HasDataType
+from aesara.graph.type import HasDataType, HasShape
 from aesara.graph.utils import MetaObject, MethodNotDefined
 from aesara.link.c.op import COp
 from aesara.link.c.type import CType
@@ -268,7 +268,7 @@ def convert(x, dtype=None):
     return x_
 
 
-class ScalarType(CType, HasDataType):
+class ScalarType(CType, HasDataType, HasShape):
 
     """
     Internal class, should not be used by clients.

--- a/aesara/scalar/basic.py
+++ b/aesara/scalar/basic.py
@@ -415,7 +415,7 @@ class ScalarType(CType, HasDataType, HasShape):
         return upcast(*[x.dtype for x in [self] + list(others)])
 
     def make_variable(self, name=None):
-        return ScalarVariable(self, name=name)
+        return ScalarVariable(self, None, name=name)
 
     def __str__(self):
         return str(self.dtype)

--- a/aesara/scan/op.py
+++ b/aesara/scan/op.py
@@ -1483,7 +1483,7 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
     def inner_outputs(self):
         return self.fgraph.outputs
 
-    def clone(self):
+    def clone(self) -> "Scan":
         res = copy(self)
         res.fgraph = res.fgraph.clone()
         return res

--- a/aesara/tensor/io.py
+++ b/aesara/tensor/io.py
@@ -82,7 +82,7 @@ def load(path, dtype, broadcastable, mmap_mode=None):
     Examples
     --------
     >>> from aesara import *
-    >>> path = Variable(Generic())
+    >>> path = Variable(Generic(), None)
     >>> x = tensor.load(path, 'int64', (False,))
     >>> y = x*2
     >>> fn = function([path], y)
@@ -136,7 +136,7 @@ class MPIRecv(Op):
             self,
             [],
             [
-                Variable(Generic()),
+                Variable(Generic(), None),
                 tensor(self.dtype, shape=self.broadcastable),
             ],
         )
@@ -222,7 +222,7 @@ class MPISend(Op):
         self.tag = tag
 
     def make_node(self, data):
-        return Apply(self, [data], [Variable(Generic()), data.type()])
+        return Apply(self, [data], [Variable(Generic(), None), data.type()])
 
     view_map = {1: [0]}
 
@@ -259,7 +259,7 @@ class MPISendWait(Op):
         self.tag = tag
 
     def make_node(self, request, data):
-        return Apply(self, [request, data], [Variable(Generic())])
+        return Apply(self, [request, data], [Variable(Generic(), None)])
 
     def perform(self, node, inp, out):
         request = inp[0]

--- a/aesara/tensor/random/type.py
+++ b/aesara/tensor/random/type.py
@@ -1,4 +1,4 @@
-from typing import Generic, TypeVar
+from typing import TypeVar
 
 import numpy as np
 
@@ -23,7 +23,7 @@ gen_states_keys = {
 numpy_bit_gens = {0: "MT19937", 1: "PCG64", 2: "Philox", 3: "SFC64"}
 
 
-class RandomType(Type, Generic[T]):
+class RandomType(Type[T]):
     r"""A Type wrapper for `numpy.random.Generator` and `numpy.random.RandomState`."""
 
     @staticmethod

--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -48,7 +48,7 @@ dtype_specs_map = {
 }
 
 
-class TensorType(CType, HasDataType, HasShape):
+class TensorType(CType[np.ndarray], HasDataType, HasShape):
     r"""Symbolic `Type` representing `numpy.ndarray`\s."""
 
     __props__: Tuple[str, ...] = ("dtype", "shape")
@@ -108,7 +108,9 @@ class TensorType(CType, HasDataType, HasShape):
         self.name = name
         self.numpy_dtype = np.dtype(self.dtype)
 
-    def clone(self, dtype=None, shape=None, broadcastable=None, **kwargs):
+    def clone(
+        self, dtype=None, shape=None, broadcastable=None, **kwargs
+    ) -> "TensorType":
         if broadcastable is not None:
             warnings.warn(
                 "The `broadcastable` keyword is deprecated; use `shape`.",

--- a/aesara/tensor/type_other.py
+++ b/aesara/tensor/type_other.py
@@ -51,7 +51,7 @@ class MakeSlice(Op):
 make_slice = MakeSlice()
 
 
-class SliceType(Type):
+class SliceType(Type[slice]):
     def clone(self, **kwargs):
         return type(self)()
 

--- a/doc/sandbox/how_to_make_ops.rst
+++ b/doc/sandbox/how_to_make_ops.rst
@@ -65,8 +65,8 @@ Example:
 	    #...
 	    def make_node(self, x, y):
 	        # note 1: constant, int64 and ScalarType are defined in aesara.scalar
-	        # note 2: constant(x) is equivalent to Constant(type = int64, data = x)
-	        # note 3: the call int64() is equivalent to Variable(type = int64) or Variable(type = ScalarType(dtype = 'int64'))
+	        # note 2: constant(x) is equivalent to Constant(type=int64, data=x)
+	        # note 3: the call int64() is equivalent to Variable(type=int64, None) or Variable(type=ScalarType(dtype = 'int64'), None)
 	        if isinstance(x, int):
 	            x = constant(x)
 	        elif not isinstance(x, Variable) or not x.type == int64:

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -339,7 +339,7 @@ class TestAutoName:
         autoname_id = next(Variable.__count__)
         Variable.__count__ = count(autoname_id)
         r1 = TensorType(dtype="int32", shape=())("myvar")
-        r2 = TensorVariable(TensorType(dtype="int32", shape=()))
+        r2 = TensorVariable(TensorType(dtype="int32", shape=()), None)
         r3 = shared(np.random.standard_normal((3, 4)))
         assert r1.auto_name == "auto_" + str(autoname_id)
         assert r2.auto_name == "auto_" + str(autoname_id + 1)

--- a/tests/tensor/test_io.py
+++ b/tests/tensor/test_io.py
@@ -17,7 +17,7 @@ class TestLoadTensor:
         np.save(self.filename, self.data)
 
     def test_basic(self):
-        path = Variable(Generic())
+        path = Variable(Generic(), None)
         # Not specifying mmap_mode defaults to None, and the data is
         # copied into main memory
         x = load(path, "int32", (False,))
@@ -29,13 +29,13 @@ class TestLoadTensor:
         # Modes 'r+', 'r', and 'w+' cannot work with Aesara, becausei
         # the output array may be modified inplace, and that should not
         # modify the original file.
-        path = Variable(Generic())
+        path = Variable(Generic(), None)
         for mmap_mode in ("r+", "r", "w+", "toto"):
             with pytest.raises(ValueError):
                 load(path, "int32", (False,), mmap_mode)
 
     def test1(self):
-        path = Variable(Generic())
+        path = Variable(Generic(), None)
         # 'c' means "copy-on-write", which allow the array to be overwritten
         # by an inplace Op in the graph, without modifying the underlying
         # file.
@@ -48,7 +48,7 @@ class TestLoadTensor:
         assert (fn(self.filename) == (self.data**2).sum()).all()
 
     def test_memmap(self):
-        path = Variable(Generic())
+        path = Variable(Generic(), None)
         x = load(path, "int32", (False,), mmap_mode="c")
         fn = function([path], x)
         assert type(fn(self.filename)) == np.core.memmap

--- a/tests/tensor/test_shape.py
+++ b/tests/tensor/test_shape.py
@@ -63,7 +63,7 @@ def test_shape_basic():
         def __eq__(self, other):
             return isinstance(other, MyType) and other.thingy == self.thingy
 
-    s = shape(Variable(MyType()))
+    s = shape(Variable(MyType(), None))
     assert s.type.broadcastable == (False,)
 
     s = shape(np.array(1))
@@ -475,7 +475,7 @@ class TestSpecifyShape(utt.InferShapeTester):
     def test_infer_shape(self):
         rng = np.random.default_rng(3453)
         adtens4 = dtensor4()
-        aivec = TensorVariable(TensorType("int64", (4,)))
+        aivec = TensorVariable(TensorType("int64", (4,)), None)
         aivec_val = [3, 4, 2, 5]
         adtens4_val = rng.random(aivec_val)
         self._compile_and_check(

--- a/tests/tensor/test_var.py
+++ b/tests/tensor/test_var.py
@@ -234,7 +234,7 @@ def test__getitem__newaxis(x, indices, new_order):
 
 
 def test_fixed_shape_variable_basic():
-    x = TensorVariable(TensorType("int64", (4,)))
+    x = TensorVariable(TensorType("int64", (4,)), None)
     assert isinstance(x.shape, Constant)
     assert np.array_equal(x.shape.data, (4,))
 
@@ -246,11 +246,11 @@ def test_fixed_shape_variable_basic():
 
 
 def test_get_vector_length():
-    x = TensorVariable(TensorType("int64", (4,)))
+    x = TensorVariable(TensorType("int64", (4,)), None)
     res = get_vector_length(x)
     assert res == 4
 
-    x = TensorVariable(TensorType("int64", (None,)))
+    x = TensorVariable(TensorType("int64", (None,)), None)
     with pytest.raises(ValueError):
         get_vector_length(x)
 


### PR DESCRIPTION
This PR adds parameterized generic types for some of the core graph objects (e.g. `Apply`, `Variable`).  These changes improve type inference for expressions like `node.op`, which is currently only as specific as the broad type `Op`&mdash;complicating type inference for attributes and methods specific to `Op` subclasses.

There is one major code-related change in this PR: the `owner` argument to `Variable.__init__` is no longer optional.  This change was required because of the following Mypy issue: https://github.com/python/mypy/issues/3737.  As far as interface changes are concerned, creating a `Variable` instance using `Variable.__init__`&mdash;including subclasses&mdash;is pretty rare (and basically unnecessary), so this is a very low-impact change.