### PR TITLE
Print inner-graphs only once in `debugprint`

### DIFF
--- a/aesara/printing.py
+++ b/aesara/printing.py
@@ -271,7 +271,7 @@ N.B.:
     for r, p, s, o in zip(results_to_print, profile_list, smap, order):
 
         if hasattr(r.owner, "op"):
-            if isinstance(r.owner.op, HasInnerGraph):
+            if isinstance(r.owner.op, HasInnerGraph) and r not in inner_graph_ops:
                 inner_graph_ops.append(r)
             if print_op_info:
                 op_information.update(op_debug_information(r.owner.op, r.owner))
@@ -354,7 +354,10 @@ N.B.:
 
             for idx, i in enumerate(inner_outputs):
 
-                if isinstance(getattr(i.owner, "op", None), HasInnerGraph):
+                if (
+                    isinstance(getattr(i.owner, "op", None), HasInnerGraph)
+                    and i not in inner_graph_ops
+                ):
                     inner_graph_ops.append(i)
 
                 _debugprint(
@@ -595,7 +598,10 @@ def _debugprint(
                     new_prefix_child = prefix_child + "  "
 
                 if hasattr(i, "owner") and hasattr(i.owner, "op"):
-                    if isinstance(i.owner.op, HasInnerGraph):
+                    if (
+                        isinstance(i.owner.op, HasInnerGraph)
+                        and i not in inner_graph_ops
+                    ):
                         inner_graph_ops.append(i)
 
                 _debugprint(

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -489,19 +489,7 @@ def test_debugprint_mitmot():
     for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
     >Elemwise{mul,no_inplace} [id CV] (inner_out_sit_sot-0)
     > |*0-<TensorType(float64, (None,))> [id CT] -> [id H] (inner_in_sit_sot-0)
-    > |*1-<TensorType(float64, (None,))> [id CW] -> [id P] (inner_in_non_seqs-0)
-
-    for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
-    >Elemwise{mul,no_inplace} [id CV] (inner_out_sit_sot-0)
-
-    for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
-    >Elemwise{mul,no_inplace} [id CV] (inner_out_sit_sot-0)
-
-    for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
-    >Elemwise{mul,no_inplace} [id CV] (inner_out_sit_sot-0)
-
-    for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
-    >Elemwise{mul,no_inplace} [id CV] (inner_out_sit_sot-0)"""
+    > |*1-<TensorType(float64, (None,))> [id CW] -> [id P] (inner_in_non_seqs-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()


### PR DESCRIPTION
This PR prevents `debugprint` from printing inner-graphs more than once.