### PR TITLE
Add ARM dev environment dependencies

### DIFF
--- a/environment-arm.yml
+++ b/environment-arm.yml
@@ -1,0 +1,47 @@
+# To use:
+#
+#   $ conda env create -f environment.yml  # `mamba` works too for this command
+#   $ conda activate aesara-dev
+#
+name: aesara-dev
+channels:
+  - conda-forge
+dependencies:
+  - python
+  - compilers
+  - numpy>=1.17.0
+  - scipy>=0.14
+  - filelock
+  - etuples
+  - logical-unification
+  - miniKanren
+  - cons
+  # Non-Intel BLAS
+  - nomkl
+  - openblas
+  - libblas=*=*openblas
+  # numba backend
+  - numba>=0.55.2
+  - llvmlite>=0.38.1
+  - numba-scipy
+  # For testing
+  - coveralls
+  - diff-cover
+  - pytest
+  - pytest-cov
+  - pytest-xdist
+  # For building docs
+  - sphinx>=1.3
+  - sphinx_rtd_theme
+  - pygments
+  - pydot
+  - ipython
+  # developer tools
+  - pre-commit
+  - packaging
+  - typing_extensions
+  # optional
+  - sympy
+  - cython
+  - jax
+  - jaxlib


### PR DESCRIPTION
The `environment-arm.yml` file is a copy of `environment.yml` with
Intel MKL dependencies replaced with OpenBLAS.

We may want to update the documentation on installing `aesara` on
Mac OS or complete the fix for #127 before merging this PR. Without
resolving #127, `aesara` will continue to have problems on Mac OS.

I have started a branch re: #127 [here](https://github.com/dgerlanc/aesara/tree/fix-narrowing-error).

Currently, with this environment, you can create a working OS X
environment for `aesara` so long as you update the `cxxflags`, e.g.
setting `~/.aesararc` to:

```
[global]

[gcc]
cxxflags=-Wno-c++11-narrowing
```

Resolves: #934
