### PR TITLE
Fix C++11 narrowing error on Mac OS

### DIFF
--- a/aesara/link/c/cmodule.py
+++ b/aesara/link/c/cmodule.py
@@ -2363,6 +2363,12 @@ class GCC_compiler(Compiler):
             # Use the already-loaded python symbols.
             cxxflags.extend(["-undefined", "dynamic_lookup"])
 
+            # Resolves C++11 narrowing error on Mac OS
+            # https://github.com/aesara-devs/aesara/issues/127
+            no_cpp_narrowing_flag = "-Wno-c++11-narrowing"
+            if no_cpp_narrowing_flag not in cxxflags:
+                cxxflags.append(no_cpp_narrowing_flag)
+
         if sys.platform == "win32":
             # Workaround for https://github.com/Theano/Theano/issues/4926.
             # https://github.com/python/cpython/pull/11283/ removed the "hypot"

--- a/tests/link/c/test_cmodule.py
+++ b/tests/link/c/test_cmodule.py
@@ -263,3 +263,19 @@ def test_cache_race_condition():
                 assert not any(
                     exit_code != 0 for exit_code in [proc.exitcode for proc in procs]
                 )
+
+
+@patch("sys.platform", "darwin")
+def test_osx_narrowing_compile_args():
+    no_narrowing_flag = "-Wno-c++11-narrowing"
+    assert no_narrowing_flag in GCC_compiler.compile_args()
+
+    cxxflags = f"{aesara.config.gcc__cxxflags} {no_narrowing_flag}"
+    with aesara.config.change_flags(gcc__cxxflags=cxxflags):
+        print(cxxflags)
+        res = GCC_compiler.compile_args()
+        print(res)
+        flag_idx = res.index(no_narrowing_flag)
+        # Make sure it's not in there twice
+        with pytest.raises(ValueError):
+            res.index(no_narrowing_flag, flag_idx + 1)


### PR DESCRIPTION
Resolves #127

Previously, tests including the following would fail with the following errors:

```
FAILED tests/graph/test_compute_test_value.py::TestComputeTestValue::test_empty_elemwise - aesara.link.c.exceptions.CompileError: Compilation failed (return status=1):
FAILED tests/graph/test_compute_test_value.py::TestComputeTestValue::test_overided_function - aesara.link.c.exceptions.CompileError: Compilation failed (return status=1):
FAILED tests/graph/test_compute_test_value.py::TestComputeTestValue::test_scan_err1 - aesara.link.c.exceptions.CompileError: Compilation failed (return status=1):
FAILED tests/graph/test_compute_test_value.py::TestComputeTestValue::test_scan_err2 - aesara.link.c.exceptions.CompileError: Compilation failed (return status=1):
```


TODO: Add tests to verify modification of `config.gcc__cxxflags`

- [x] No `gcc_cxxflags`
  - Darwin -> Add `-Wno-c++11-narrowing`
  - Other `sys.platform` -> No-Op
- [x] Has `gcc__cxxflags` but no `-Wno-c++11-narrowing`
  - Darwin -> Add `-Wno-c++11-narrowing` and other flags preserved
  - Other platform -> other flags preserved
- [x] Has `gcc_cxxflags` including `-Wno-c++11-narrowing`
  - All platforms -> `gcc__cxxflags` remain the same
