### PR TITLE
Allow newlines in `__str__` output printed by `fgraph_to_python`

### DIFF
--- a/aesara/link/utils.py
+++ b/aesara/link/utils.py
@@ -760,9 +760,9 @@ def fgraph_to_python(
 
         node_output_names = [unique_name(v) for v in node.outputs]
 
-        body_assigns.append(
-            f"# {node}\n{', '.join(node_output_names)} = {local_compiled_func_name}({', '.join(node_input_names)})"
-        )
+        assign_comment_str = f"{indent(str(node), '# ')}"
+        assign_str = f"{', '.join(node_output_names)} = {local_compiled_func_name}({', '.join(node_input_names)})"
+        body_assigns.append(f"{assign_comment_str}\n{assign_str}")
 
     fgraph_input_names = [unique_name(v) for v in fgraph.inputs]
     fgraph_output_names = [unique_name(v) for v in fgraph.outputs]


### PR DESCRIPTION
This PR fixes a bug in `aesara.link.utils.fgraph_to_python` that doesn't handle multi-line `Apply` and/or `Op` `__str__`s.