### PR TITLE
Clone inner-graph before compiling in `OpFromGraph`

### DIFF
--- a/aesara/compile/builders.py
+++ b/aesara/compile/builders.py
@@ -5,8 +5,8 @@ from functools import partial
 from typing import List, Optional, Sequence, cast
 
 import aesara.tensor as at
+from aesara import function
 from aesara.compile.function.pfunc import rebuild_collect_shared
-from aesara.compile.function.types import orig_function
 from aesara.compile.mode import optdb
 from aesara.compile.sharedvalue import SharedVariable
 from aesara.configdefaults import config
@@ -326,7 +326,7 @@ class OpFromGraph(Op, HasInnerGraph):
         name
             A name for debugging purposes.
         kwargs
-            Check :func:`orig_function` for more arguments, only works when not
+            Check :func:`aesara.function` for more arguments, only works when not
             inline.
         """
 
@@ -903,7 +903,7 @@ class OpFromGraph(Op, HasInnerGraph):
         if getattr(self, "_fn", None) is not None:
             return self._fn
 
-        self._fn = orig_function(self.inner_inputs, self.inner_outputs, **self.kwargs)
+        self._fn = function(self.inner_inputs, self.inner_outputs, **self.kwargs)
         self._fn.trust_input = True
 
         return self._fn


### PR DESCRIPTION
This PR changes the behavior or `OpFromGraph.fn` so that it clones the inner-graph before compiling.  Without this clone step, `aesara.graph.op.compute_test_value` would change the form of `OpFromGraph.inner_outputs` by updating the inner-`FunctionGraph` in-place.  Such changes could&mdash;in turn&mdash;affect the "differentiability" of `OpFromGraph` instances, by, for instance, replacing `Op`s in inner-graphs with "optimized" non-differentiable counterparts.