### PR TITLE
Make `Elemwise.infer_shape` return `TensorType`ed values

### DIFF
--- a/aesara/tensor/elemwise.py
+++ b/aesara/tensor/elemwise.py
@@ -1,5 +1,5 @@
 from copy import copy
-from typing import Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 
@@ -29,6 +29,7 @@ from aesara.tensor.type import (
     float_dtypes,
     lvector,
 )
+from aesara.tensor.var import TensorVariable
 from aesara.utils import uniq
 
 
@@ -802,7 +803,7 @@ class Elemwise(OpenMPOp):
             else:
                 storage[0] = variable
 
-    def infer_shape(self, fgraph, node, i_shapes):
+    def infer_shape(self, fgraph, node, i_shapes) -> List[Tuple[TensorVariable, ...]]:
 
         if len(node.outputs) > 1:
             from aesara.tensor.basic_opt import ShapeError
@@ -813,7 +814,8 @@ class Elemwise(OpenMPOp):
 
         out_shape = aesara.tensor.broadcast_shape(*i_shapes, arrays_are_shapes=True)
 
-        return [out_shape]
+        # The `as_tensor_variable` should convert `ScalarType`s to `TensorType`s
+        return [tuple(as_tensor_variable(s) for s in out_shape)]
 
     def _c_all(self, node, nodename, inames, onames, sub):
         # Some `Op`s directly call `Elemwise._c_all` or `Elemwise.c_code`

--- a/aesara/tensor/extra_ops.py
+++ b/aesara/tensor/extra_ops.py
@@ -1441,7 +1441,7 @@ def ravel_multi_index(multi_index, dims, mode="raise", order="C"):
     return RavelMultiIndex(mode=mode, order=order)(*args)
 
 
-def broadcast_shape(*arrays, **kwargs):
+def broadcast_shape(*arrays, **kwargs) -> Tuple[aes.ScalarVariable, ...]:
     """Compute the shape resulting from broadcasting arrays.
 
     Parameters
@@ -1462,7 +1462,7 @@ def broadcast_shape(*arrays, **kwargs):
 def broadcast_shape_iter(
     arrays: Iterable[Union[TensorVariable, Tuple[TensorVariable, ...]]],
     arrays_are_shapes: bool = False,
-):
+) -> Tuple[aes.ScalarVariable, ...]:
     r"""Compute the shape resulting from broadcasting arrays.
 
 


### PR DESCRIPTION
This PR fixes a source of some `Op.infer_shape` issues that can occur when shapes tracked by `ShapeFeature` are expected to be `TensorType`ed (e.g. `ifelse` assumes this).