### PR TITLE
Make `Apply.itypes`'s `Type` signature covariant

### DIFF
--- a/aesara/graph/op.py
+++ b/aesara/graph/op.py
@@ -222,21 +222,22 @@ class Op(MetaObject):
         """
         if self.itypes is None:
             raise NotImplementedError(
-                "You can either define itypes and otypes,\
-             or implement make_node"
+                "You can either define itypes and otypes, or implement make_node"
             )
 
         if self.otypes is None:
             raise NotImplementedError(
-                "You can either define itypes and otypes,\
-             or implement make_node"
+                "You can either define itypes and otypes, or implement make_node"
             )
 
         if len(inputs) != len(self.itypes):
             raise ValueError(
                 f"We expected {len(self.itypes)} inputs but got {len(inputs)}."
             )
-        if not all(it.in_same_class(inp.type) for inp, it in zip(inputs, self.itypes)):
+        if not all(
+            expected_type.is_super(var.type)
+            for var, expected_type in zip(inputs, self.itypes)
+        ):
             raise TypeError(
                 f"Invalid input types for Op {self}:\n"
                 + "\n".join(

--- a/tests/graph/test_op.py
+++ b/tests/graph/test_op.py
@@ -223,3 +223,16 @@ def test_op_invalid_input_types():
     msg = r"^Invalid input types for Op.*"
     with pytest.raises(TypeError, match=msg):
         TestOp()(dvector(), dscalar(), dvector())
+
+
+def test_op_input_broadcastable():
+    # Test that we can create an op with a broadcastable subtype as input
+    class SomeOp(aesara.tensor.Op):
+        itypes = [at.dvector]
+        otypes = [at.dvector]
+
+        def perform(self, *_):
+            raise NotImplementedError()
+
+    x = at.TensorType(dtype="float64", shape=(1,))("x")
+    assert SomeOp()(x).type == at.dvector


### PR DESCRIPTION
Here are a few important guidelines and requirements to check before your PR can be merged:
+ [ ] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [ ] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts). (I won't but I called black manually)
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.

Currently this fails, because `SomeOp` expects an input of type `TensorType(f64, [None])`, but gets one of type `TensorType(f64, [1])`. Shouldn't we be a bit more permissive by default and expect things that are subtypes of what we expect?
```python
import aesara
import aesara.tensor as at


class SomeOp(aesara.tensor.Op):
    itypes = [at.dvector]
    otypes = [at.dvector]
    
    def perform(self, node, inputs, outputs):
        raise NotImplementedError()


x = at.dscalar("x")
SomeOp()(x[None])
```

This fails with error:
```
TypeError: Invalid input types for Op SomeOp:
Input 1/1: Expected TensorType(float64, (None,)), got TensorType(float64, (1,))
```