### PR TITLE
Fix `Op.perform` type hint

### DIFF
--- a/aesara/graph/op.py
+++ b/aesara/graph/op.py
@@ -418,7 +418,7 @@ class Op(MetaObject):
     def perform(
         self,
         node: Apply,
-        inputs: List[Variable],
+        inputs: Sequence[Any],
         output_storage: OutputStorageType,
         params: ParamsInputType = None,
     ) -> None:


### PR DESCRIPTION
The type hint of the `inputs` parameter to `Op.perform` was wrong.
The docstring was correct.

This PR fixes the type hint.
