### PR TITLE
Add dtype option to identity_like

### DIFF
--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -1422,8 +1422,22 @@ def eye(n, m=None, k=0, dtype=None):
     return localop(n, m, k)
 
 
-def identity_like(x):
-    return eye(x.shape[0], x.shape[1], k=0, dtype=x.dtype)
+def identity_like(x, dtype: Optional[Union[str, np.generic, np.dtype]] = None):
+    """Create a tensor with ones on main diagonal and zeroes elsewhere.
+
+    Parameters
+    ----------
+    x : tensor
+    dtype : data-type, optional
+
+    Returns
+    -------
+    tensor
+        tensor the shape of x with ones on main diagonal and zeroes elsewhere of type of dtype.
+    """
+    if dtype is None:
+        dtype = x.dtype
+    return eye(x.shape[0], x.shape[1], k=0, dtype=dtype)
 
 
 def infer_broadcastable(shape):

--- a/doc/library/tensor/basic.rst
+++ b/doc/library/tensor/basic.rst
@@ -777,12 +777,13 @@ Creating Tensors
     :returns: An array where all elements are equal to zero, except for the `k`-th
               diagonal, whose values are equal to one.
 
-.. function:: identity_like(x)
+.. function:: identity_like(x, dtype=None)
 
     :param x: tensor
+    :param dtype: The dtype of the returned tensor. If `None`, default to dtype of `x`
     :returns: A tensor of same shape as `x` that is filled with zeros everywhere
               except for the main diagonal, whose values are equal to one. The output
-              will have same dtype as `x`.
+              will have same dtype as `x` unless overridden in `dtype`.
 
 .. function:: stack(tensors, axis=0)
 

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -59,6 +59,7 @@ from aesara.tensor.basic import (
     get_scalar_constant_value,
     get_vector_length,
     horizontal_stack,
+    identity_like,
     infer_broadcastable,
     inverse_permutation,
     join,
@@ -4390,6 +4391,15 @@ def test_empty():
     res = aesara.function([], empty_at)()
     assert res.shape == (2, 3)
     assert res.dtype == "int64"
+
+
+def test_identity_like_dtype():
+    # Test that we allocate eye correctly via identity_like
+    m = matrix(dtype="int64")
+    m_out = identity_like(m)
+    assert m_out.dtype == m.dtype
+    m_out_float = identity_like(m, dtype=np.float64)
+    assert m_out_float.dtype == "float64"
 
 
 def test_atleast_Nd():


### PR DESCRIPTION
Resolves #816 - adds optional dtype parameter to identity_like which makes it more like the existing *_like functions. 

This is a relatively minor improvement that I pulled off the "good first issue" task. New here (but interested in being more involved) so apologies for any annoying formatting fixes needed. 

Note that mypy seemed to trigger one unrelated problem:

    aesara/link/c/cmodule.py:2439: error: Unused "type: ignore" comment

**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [ ] There is an informative high-level description of the changes.
+ [ ] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [ ] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [ ] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ ] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
