### PR TITLE
Fix a `Scan` Cython issue involving output storage lengths

### DIFF
--- a/aesara/scan/c_code/scan_perform.c
+++ b/aesara/scan/c_code/scan_perform.c
@@ -2506,6 +2506,7 @@ static const char __pyx_k_MemoryView_of_r_object[] = "<MemoryView of %r object>"
 static const char __pyx_k_mit_mot_out_to_tap_idx[] = "mit_mot_out_to_tap_idx";
 static const char __pyx_k_MemoryView_of_r_at_0x_x[] = "<MemoryView of %r at 0x%x>";
 static const char __pyx_k_contiguous_and_indirect[] = "<contiguous and indirect>";
+static const char __pyx_k_outer_inputs_offset_idx[] = "outer_inputs_offset_idx";
 static const char __pyx_k_Cannot_index_with_type_s[] = "Cannot index with type '%s'";
 static const char __pyx_k_aesara_scan_scan_perform[] = "aesara.scan.scan_perform";
 static const char __pyx_k_old_mitmot_input_storage[] = "old_mitmot_input_storage";
@@ -2660,6 +2661,7 @@ static PyObject *__pyx_n_s_old_output_storage;
 static PyObject *__pyx_n_s_old_var;
 static PyObject *__pyx_n_s_other_args;
 static PyObject *__pyx_n_s_outer_inputs;
+static PyObject *__pyx_n_s_outer_inputs_offset_idx;
 static PyObject *__pyx_n_s_outer_output_dtypes;
 static PyObject *__pyx_n_s_outer_output_ndims;
 static PyObject *__pyx_n_s_outer_outputs;
@@ -2773,7 +2775,7 @@ static PyObject *__pyx_tp_new_Enum(PyTypeObject *t, PyObject *a, PyObject *k); /
 static PyObject *__pyx_tp_new_memoryview(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
 static PyObject *__pyx_tp_new__memoryviewslice(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
 static PyObject *__pyx_float_0_0;
-static PyObject *__pyx_float_0_325;
+static PyObject *__pyx_float_0_326;
 static PyObject *__pyx_int_0;
 static PyObject *__pyx_int_1;
 static PyObject *__pyx_int_184977713;
@@ -2817,7 +2819,7 @@ static PyObject *__pyx_codeobj__33;
  * 
  * 
  * def get_version():             # <<<<<<<<<<<<<<
- *     return 0.325
+ *     return 0.326
  * 
  */
 
@@ -2843,20 +2845,20 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_get_version(CYTHON_UNUSED
   /* "aesara/scan/scan_perform.pyx":65
  * 
  * def get_version():
- *     return 0.325             # <<<<<<<<<<<<<<
+ *     return 0.326             # <<<<<<<<<<<<<<
  * 
  * 
  */
   __Pyx_XDECREF(__pyx_r);
-  __Pyx_INCREF(__pyx_float_0_325);
-  __pyx_r = __pyx_float_0_325;
+  __Pyx_INCREF(__pyx_float_0_326);
+  __pyx_r = __pyx_float_0_326;
   goto __pyx_L0;
 
   /* "aesara/scan/scan_perform.pyx":64
  * 
  * 
  * def get_version():             # <<<<<<<<<<<<<<
- *     return 0.325
+ *     return 0.326
  * 
  */
 
@@ -3336,6 +3338,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   unsigned int __pyx_v_pos_idx;
   PyObject *__pyx_v_outer_outputs_idx = NULL;
   PyObject *__pyx_v_outer_outputs_idx_0 = NULL;
+  PyObject *__pyx_v_outer_inputs_offset_idx = NULL;
   PyObject *__pyx_v_other_args = NULL;
   unsigned int __pyx_v_nb_mitmot_in;
   PyObject *__pyx_v_old_mitmot_input_storage = NULL;
@@ -3819,19 +3822,32 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *             continue
  * 
  *         outer_outputs_idx_0 = outer_outputs_idx[0]             # <<<<<<<<<<<<<<
+ *         outer_inputs_offset_idx = outer_inputs[<unsigned int>(seqs_arg_offset + idx)]
  * 
- *         if ( outer_outputs_idx_0 is not None and
  */
     __pyx_t_2 = __Pyx_GetItemInt(__pyx_v_outer_outputs_idx, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 255, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_XDECREF_SET(__pyx_v_outer_outputs_idx_0, __pyx_t_2);
     __pyx_t_2 = 0;
 
-    /* "aesara/scan/scan_perform.pyx":257
+    /* "aesara/scan/scan_perform.pyx":256
+ * 
  *         outer_outputs_idx_0 = outer_outputs_idx[0]
+ *         outer_inputs_offset_idx = outer_inputs[<unsigned int>(seqs_arg_offset + idx)]             # <<<<<<<<<<<<<<
+ * 
+ * 
+ */
+    __pyx_t_13 = ((unsigned int)(__pyx_v_seqs_arg_offset + __pyx_v_idx));
+    __pyx_t_2 = PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_13);
+    __Pyx_INCREF(__pyx_t_2);
+    __Pyx_XDECREF_SET(__pyx_v_outer_inputs_offset_idx, __pyx_t_2);
+    __pyx_t_2 = 0;
+
+    /* "aesara/scan/scan_perform.pyx":259
+ * 
  * 
  *         if ( outer_outputs_idx_0 is not None and             # <<<<<<<<<<<<<<
- *               outer_outputs_idx_0.shape[1:] == outer_inputs[<unsigned int>(1+ n_seqs + idx)].shape[1:]
+ *               outer_outputs_idx_0.shape[1:] == outer_inputs_offset_idx.shape[1:]
  *               and outer_outputs_idx_0.shape[0] >= store_steps[idx] ):
  */
     __pyx_t_14 = (__pyx_v_outer_outputs_idx_0 != Py_None);
@@ -3842,28 +3858,27 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       goto __pyx_L15_bool_binop_done;
     }
 
-    /* "aesara/scan/scan_perform.pyx":258
+    /* "aesara/scan/scan_perform.pyx":260
  * 
  *         if ( outer_outputs_idx_0 is not None and
- *               outer_outputs_idx_0.shape[1:] == outer_inputs[<unsigned int>(1+ n_seqs + idx)].shape[1:]             # <<<<<<<<<<<<<<
+ *               outer_outputs_idx_0.shape[1:] == outer_inputs_offset_idx.shape[1:]             # <<<<<<<<<<<<<<
  *               and outer_outputs_idx_0.shape[0] >= store_steps[idx] ):
  *             # Put in the values of the initial state
  */
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_idx_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 258, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_idx_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 260, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_t_2, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 258, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_t_2, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 260, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    __pyx_t_13 = ((unsigned int)((1 + __pyx_v_n_seqs) + __pyx_v_idx));
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_13), __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 258, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_inputs_offset_idx, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 260, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_t_2, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 258, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_t_2, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 260, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    __pyx_t_2 = PyObject_RichCompare(__pyx_t_3, __pyx_t_1, Py_EQ); __Pyx_XGOTREF(__pyx_t_2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 258, __pyx_L1_error)
+    __pyx_t_2 = PyObject_RichCompare(__pyx_t_3, __pyx_t_1, Py_EQ); __Pyx_XGOTREF(__pyx_t_2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 260, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_2); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 258, __pyx_L1_error)
+    __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_2); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 260, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     if (__pyx_t_15) {
     } else {
@@ -3871,130 +3886,133 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       goto __pyx_L15_bool_binop_done;
     }
 
-    /* "aesara/scan/scan_perform.pyx":259
+    /* "aesara/scan/scan_perform.pyx":261
  *         if ( outer_outputs_idx_0 is not None and
- *               outer_outputs_idx_0.shape[1:] == outer_inputs[<unsigned int>(1+ n_seqs + idx)].shape[1:]
+ *               outer_outputs_idx_0.shape[1:] == outer_inputs_offset_idx.shape[1:]
  *               and outer_outputs_idx_0.shape[0] >= store_steps[idx] ):             # <<<<<<<<<<<<<<
  *             # Put in the values of the initial state
- *             outer_outputs_idx[0] = outer_outputs_idx_0[:store_steps[idx]]
+ * 
  */
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_idx_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 259, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_idx_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 261, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_2, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 259, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_2, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 261, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_12 = __pyx_v_idx;
-    __pyx_t_2 = __Pyx_PyInt_From_unsigned_int((*((unsigned int *) ( /* dim=0 */ (__pyx_v_store_steps.data + __pyx_t_12 * __pyx_v_store_steps.strides[0]) )))); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 259, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyInt_From_unsigned_int((*((unsigned int *) ( /* dim=0 */ (__pyx_v_store_steps.data + __pyx_t_12 * __pyx_v_store_steps.strides[0]) )))); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 261, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = PyObject_RichCompare(__pyx_t_1, __pyx_t_2, Py_GE); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 259, __pyx_L1_error)
+    __pyx_t_3 = PyObject_RichCompare(__pyx_t_1, __pyx_t_2, Py_GE); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 261, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 259, __pyx_L1_error)
+    __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 261, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_t_5 = __pyx_t_15;
     __pyx_L15_bool_binop_done:;
 
-    /* "aesara/scan/scan_perform.pyx":257
- *         outer_outputs_idx_0 = outer_outputs_idx[0]
+    /* "aesara/scan/scan_perform.pyx":259
+ * 
  * 
  *         if ( outer_outputs_idx_0 is not None and             # <<<<<<<<<<<<<<
- *               outer_outputs_idx_0.shape[1:] == outer_inputs[<unsigned int>(1+ n_seqs + idx)].shape[1:]
+ *               outer_outputs_idx_0.shape[1:] == outer_inputs_offset_idx.shape[1:]
  *               and outer_outputs_idx_0.shape[0] >= store_steps[idx] ):
  */
     if (__pyx_t_5) {
 
-      /* "aesara/scan/scan_perform.pyx":261
- *               and outer_outputs_idx_0.shape[0] >= store_steps[idx] ):
+      /* "aesara/scan/scan_perform.pyx":264
  *             # Put in the values of the initial state
- *             outer_outputs_idx[0] = outer_outputs_idx_0[:store_steps[idx]]             # <<<<<<<<<<<<<<
- *             if idx > n_mit_mot:
- *                 l = - mintaps[idx]
+ * 
+ *             outer_outputs_idx_0 = outer_outputs_idx_0[:store_steps[idx]]             # <<<<<<<<<<<<<<
+ *             outer_outputs_idx[0] = outer_outputs_idx_0
+ * 
  */
       __pyx_t_12 = __pyx_v_idx;
-      __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_idx_0, 0, (*((unsigned int *) ( /* dim=0 */ (__pyx_v_store_steps.data + __pyx_t_12 * __pyx_v_store_steps.strides[0]) ))), NULL, NULL, NULL, 0, 1, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 261, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_idx_0, 0, (*((unsigned int *) ( /* dim=0 */ (__pyx_v_store_steps.data + __pyx_t_12 * __pyx_v_store_steps.strides[0]) ))), NULL, NULL, NULL, 0, 1, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 264, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      if (unlikely(__Pyx_SetItemInt(__pyx_v_outer_outputs_idx, 0, __pyx_t_3, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 261, __pyx_L1_error)
-      __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+      __Pyx_DECREF_SET(__pyx_v_outer_outputs_idx_0, __pyx_t_3);
+      __pyx_t_3 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":262
- *             # Put in the values of the initial state
- *             outer_outputs_idx[0] = outer_outputs_idx_0[:store_steps[idx]]
+      /* "aesara/scan/scan_perform.pyx":265
+ * 
+ *             outer_outputs_idx_0 = outer_outputs_idx_0[:store_steps[idx]]
+ *             outer_outputs_idx[0] = outer_outputs_idx_0             # <<<<<<<<<<<<<<
+ * 
+ *             if idx > n_mit_mot:
+ */
+      if (unlikely(__Pyx_SetItemInt(__pyx_v_outer_outputs_idx, 0, __pyx_v_outer_outputs_idx_0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 265, __pyx_L1_error)
+
+      /* "aesara/scan/scan_perform.pyx":267
+ *             outer_outputs_idx[0] = outer_outputs_idx_0
+ * 
  *             if idx > n_mit_mot:             # <<<<<<<<<<<<<<
  *                 l = - mintaps[idx]
- *                 outer_outputs_idx_0[:l] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)][:l]
+ *                 outer_outputs_idx_0[:l] = outer_inputs_offset_idx[:l]
  */
       __pyx_t_5 = ((__pyx_v_idx > __pyx_v_n_mit_mot) != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":263
- *             outer_outputs_idx[0] = outer_outputs_idx_0[:store_steps[idx]]
+        /* "aesara/scan/scan_perform.pyx":268
+ * 
  *             if idx > n_mit_mot:
  *                 l = - mintaps[idx]             # <<<<<<<<<<<<<<
- *                 outer_outputs_idx_0[:l] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)][:l]
+ *                 outer_outputs_idx_0[:l] = outer_inputs_offset_idx[:l]
  *             else:
  */
         __pyx_t_12 = __pyx_v_idx;
         __pyx_v_l = (-(*((int const  *) ( /* dim=0 */ (__pyx_v_mintaps.data + __pyx_t_12 * __pyx_v_mintaps.strides[0]) ))));
 
-        /* "aesara/scan/scan_perform.pyx":264
+        /* "aesara/scan/scan_perform.pyx":269
  *             if idx > n_mit_mot:
  *                 l = - mintaps[idx]
- *                 outer_outputs_idx_0[:l] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)][:l]             # <<<<<<<<<<<<<<
+ *                 outer_outputs_idx_0[:l] = outer_inputs_offset_idx[:l]             # <<<<<<<<<<<<<<
  *             else:
- *                 outer_outputs_idx_0[:] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)]
+ *                 outer_outputs_idx_0[:] = outer_inputs_offset_idx
  */
-        __pyx_t_13 = ((unsigned int)(__pyx_v_seqs_arg_offset + __pyx_v_idx));
-        __pyx_t_3 = __Pyx_PyObject_GetSlice(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_13), 0, __pyx_v_l, NULL, NULL, NULL, 0, 1, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 264, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_v_outer_inputs_offset_idx, 0, __pyx_v_l, NULL, NULL, NULL, 0, 1, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 269, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
-        if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_t_3, 0, __pyx_v_l, NULL, NULL, NULL, 0, 1, 0) < 0) __PYX_ERR(0, 264, __pyx_L1_error)
+        if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_t_3, 0, __pyx_v_l, NULL, NULL, NULL, 0, 1, 0) < 0) __PYX_ERR(0, 269, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":262
- *             # Put in the values of the initial state
- *             outer_outputs_idx[0] = outer_outputs_idx_0[:store_steps[idx]]
+        /* "aesara/scan/scan_perform.pyx":267
+ *             outer_outputs_idx[0] = outer_outputs_idx_0
+ * 
  *             if idx > n_mit_mot:             # <<<<<<<<<<<<<<
  *                 l = - mintaps[idx]
- *                 outer_outputs_idx_0[:l] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)][:l]
+ *                 outer_outputs_idx_0[:l] = outer_inputs_offset_idx[:l]
  */
         goto __pyx_L18;
       }
 
-      /* "aesara/scan/scan_perform.pyx":266
- *                 outer_outputs_idx_0[:l] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)][:l]
+      /* "aesara/scan/scan_perform.pyx":271
+ *                 outer_outputs_idx_0[:l] = outer_inputs_offset_idx[:l]
  *             else:
- *                 outer_outputs_idx_0[:] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)]             # <<<<<<<<<<<<<<
+ *                 outer_outputs_idx_0[:] = outer_inputs_offset_idx             # <<<<<<<<<<<<<<
  *         else:
- *             outer_outputs_idx[0] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)].copy()
+ *             outer_outputs_idx[0] = outer_inputs_offset_idx.copy()
  */
       /*else*/ {
-        __pyx_t_13 = ((unsigned int)(__pyx_v_seqs_arg_offset + __pyx_v_idx));
-        __pyx_t_3 = PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_13);
-        __Pyx_INCREF(__pyx_t_3);
-        if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_t_3, 0, 0, NULL, NULL, &__pyx_slice__2, 0, 0, 0) < 0) __PYX_ERR(0, 266, __pyx_L1_error)
-        __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+        if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_v_outer_inputs_offset_idx, 0, 0, NULL, NULL, &__pyx_slice__2, 0, 0, 0) < 0) __PYX_ERR(0, 271, __pyx_L1_error)
       }
       __pyx_L18:;
 
-      /* "aesara/scan/scan_perform.pyx":257
- *         outer_outputs_idx_0 = outer_outputs_idx[0]
+      /* "aesara/scan/scan_perform.pyx":259
+ * 
  * 
  *         if ( outer_outputs_idx_0 is not None and             # <<<<<<<<<<<<<<
- *               outer_outputs_idx_0.shape[1:] == outer_inputs[<unsigned int>(1+ n_seqs + idx)].shape[1:]
+ *               outer_outputs_idx_0.shape[1:] == outer_inputs_offset_idx.shape[1:]
  *               and outer_outputs_idx_0.shape[0] >= store_steps[idx] ):
  */
       goto __pyx_L14;
     }
 
-    /* "aesara/scan/scan_perform.pyx":268
- *                 outer_outputs_idx_0[:] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)]
+    /* "aesara/scan/scan_perform.pyx":273
+ *                 outer_outputs_idx_0[:] = outer_inputs_offset_idx
  *         else:
- *             outer_outputs_idx[0] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)].copy()             # <<<<<<<<<<<<<<
+ *             outer_outputs_idx[0] = outer_inputs_offset_idx.copy()             # <<<<<<<<<<<<<<
  * 
  *     if n_steps == 0:
  */
     /*else*/ {
-      __pyx_t_13 = ((unsigned int)(__pyx_v_seqs_arg_offset + __pyx_v_idx));
-      __pyx_t_2 = __Pyx_PyObject_GetAttrStr(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_13), __pyx_n_s_copy); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 268, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_inputs_offset_idx, __pyx_n_s_copy); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 273, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __pyx_t_1 = NULL;
       if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_2))) {
@@ -4008,18 +4026,18 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       }
       __pyx_t_3 = (__pyx_t_1) ? __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_1) : __Pyx_PyObject_CallNoArg(__pyx_t_2);
       __Pyx_XDECREF(__pyx_t_1); __pyx_t_1 = 0;
-      if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 268, __pyx_L1_error)
+      if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 273, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-      if (unlikely(__Pyx_SetItemInt(__pyx_v_outer_outputs_idx, 0, __pyx_t_3, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 268, __pyx_L1_error)
+      if (unlikely(__Pyx_SetItemInt(__pyx_v_outer_outputs_idx, 0, __pyx_t_3, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 273, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     }
     __pyx_L14:;
     __pyx_L11_continue:;
   }
 
-  /* "aesara/scan/scan_perform.pyx":270
- *             outer_outputs_idx[0] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)].copy()
+  /* "aesara/scan/scan_perform.pyx":275
+ *             outer_outputs_idx[0] = outer_inputs_offset_idx.copy()
  * 
  *     if n_steps == 0:             # <<<<<<<<<<<<<<
  *         for idx in range(n_outs, n_outs + n_nit_sot):
@@ -4028,7 +4046,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __pyx_t_5 = ((__pyx_v_n_steps == 0) != 0);
   if (__pyx_t_5) {
 
-    /* "aesara/scan/scan_perform.pyx":271
+    /* "aesara/scan/scan_perform.pyx":276
  * 
  *     if n_steps == 0:
  *         for idx in range(n_outs, n_outs + n_nit_sot):             # <<<<<<<<<<<<<<
@@ -4040,7 +4058,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = __pyx_v_n_outs; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":272
+      /* "aesara/scan/scan_perform.pyx":277
  *     if n_steps == 0:
  *         for idx in range(n_outs, n_outs + n_nit_sot):
  *             if outs_is_tensor[idx]:             # <<<<<<<<<<<<<<
@@ -4051,41 +4069,41 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_5 = ((*((npy_bool const  *) ( /* dim=0 */ (__pyx_v_outs_is_tensor.data + __pyx_t_12 * __pyx_v_outs_is_tensor.strides[0]) ))) != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":273
+        /* "aesara/scan/scan_perform.pyx":278
  *         for idx in range(n_outs, n_outs + n_nit_sot):
  *             if outs_is_tensor[idx]:
  *                 outer_outputs[idx][0] = numpy.empty((0,) * outer_output_ndims[idx], dtype=outer_output_dtypes[idx])             # <<<<<<<<<<<<<<
  *             else:
  *                 outer_outputs[idx][0] = None
  */
-        __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 273, __pyx_L1_error)
+        __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_numpy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 278, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_empty); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 273, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_empty); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 278, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         __pyx_t_12 = __pyx_v_idx;
-        __pyx_t_3 = __Pyx_PyInt_From_unsigned_int((*((unsigned int const  *) ( /* dim=0 */ (__pyx_v_outer_output_ndims.data + __pyx_t_12 * __pyx_v_outer_output_ndims.strides[0]) )))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 273, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyInt_From_unsigned_int((*((unsigned int const  *) ( /* dim=0 */ (__pyx_v_outer_output_ndims.data + __pyx_t_12 * __pyx_v_outer_output_ndims.strides[0]) )))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 278, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_1 = PyNumber_Multiply(__pyx_tuple__3, __pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 273, __pyx_L1_error)
+        __pyx_t_1 = PyNumber_Multiply(__pyx_tuple__3, __pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 278, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-        __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 273, __pyx_L1_error)
+        __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 278, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_GIVEREF(__pyx_t_1);
         PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
         __pyx_t_1 = 0;
-        __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 273, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 278, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, PyTuple_GET_ITEM(__pyx_v_outer_output_dtypes, __pyx_v_idx)) < 0) __PYX_ERR(0, 273, __pyx_L1_error)
-        __pyx_t_16 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 273, __pyx_L1_error)
+        if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, PyTuple_GET_ITEM(__pyx_v_outer_output_dtypes, __pyx_v_idx)) < 0) __PYX_ERR(0, 278, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 278, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 273, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 278, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":272
+        /* "aesara/scan/scan_perform.pyx":277
  *     if n_steps == 0:
  *         for idx in range(n_outs, n_outs + n_nit_sot):
  *             if outs_is_tensor[idx]:             # <<<<<<<<<<<<<<
@@ -4095,7 +4113,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L22;
       }
 
-      /* "aesara/scan/scan_perform.pyx":275
+      /* "aesara/scan/scan_perform.pyx":280
  *                 outer_outputs[idx][0] = numpy.empty((0,) * outer_output_ndims[idx], dtype=outer_output_dtypes[idx])
  *             else:
  *                 outer_outputs[idx][0] = None             # <<<<<<<<<<<<<<
@@ -4103,12 +4121,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  * 
  */
       /*else*/ {
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 275, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_idx), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 280, __pyx_L1_error)
       }
       __pyx_L22:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":276
+    /* "aesara/scan/scan_perform.pyx":281
  *             else:
  *                 outer_outputs[idx][0] = None
  *         return 0.0, 0             # <<<<<<<<<<<<<<
@@ -4120,8 +4138,8 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_r = __pyx_tuple__4;
     goto __pyx_L0;
 
-    /* "aesara/scan/scan_perform.pyx":270
- *             outer_outputs_idx[0] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)].copy()
+    /* "aesara/scan/scan_perform.pyx":275
+ *             outer_outputs_idx[0] = outer_inputs_offset_idx.copy()
  * 
  *     if n_steps == 0:             # <<<<<<<<<<<<<<
  *         for idx in range(n_outs, n_outs + n_nit_sot):
@@ -4129,7 +4147,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   }
 
-  /* "aesara/scan/scan_perform.pyx":278
+  /* "aesara/scan/scan_perform.pyx":283
  *         return 0.0, 0
  * 
  *     for idx in range(lenpos):             # <<<<<<<<<<<<<<
@@ -4141,7 +4159,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
     __pyx_v_idx = __pyx_t_7;
 
-    /* "aesara/scan/scan_perform.pyx":279
+    /* "aesara/scan/scan_perform.pyx":284
  * 
  *     for idx in range(lenpos):
  *         pos[idx] = pymod(-mintaps[idx], store_steps[idx])             # <<<<<<<<<<<<<<
@@ -4154,7 +4172,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     *((unsigned int *) ( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_18 * __pyx_v_pos.strides[0]) )) = __pyx_f_6aesara_4scan_12scan_perform_pymod((-(*((int const  *) ( /* dim=0 */ (__pyx_v_mintaps.data + __pyx_t_12 * __pyx_v_mintaps.strides[0]) )))), (*((unsigned int *) ( /* dim=0 */ (__pyx_v_store_steps.data + __pyx_t_17 * __pyx_v_store_steps.strides[0]) ))));
   }
 
-  /* "aesara/scan/scan_perform.pyx":281
+  /* "aesara/scan/scan_perform.pyx":286
  *         pos[idx] = pymod(-mintaps[idx], store_steps[idx])
  * 
  *     offset = nit_sot_arg_offset + n_nit_sot             # <<<<<<<<<<<<<<
@@ -4163,19 +4181,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_offset = (__pyx_v_nit_sot_arg_offset + __pyx_v_n_nit_sot);
 
-  /* "aesara/scan/scan_perform.pyx":282
+  /* "aesara/scan/scan_perform.pyx":287
  * 
  *     offset = nit_sot_arg_offset + n_nit_sot
  *     other_args = outer_inputs[offset:]             # <<<<<<<<<<<<<<
  * 
  *     cdef unsigned int nb_mitmot_in = 0
  */
-  __pyx_t_16 = __Pyx_PyList_GetSlice(__pyx_v_outer_inputs, __pyx_v_offset, PY_SSIZE_T_MAX); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 282, __pyx_L1_error)
+  __pyx_t_16 = __Pyx_PyList_GetSlice(__pyx_v_outer_inputs, __pyx_v_offset, PY_SSIZE_T_MAX); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 287, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_16);
   __pyx_v_other_args = ((PyObject*)__pyx_t_16);
   __pyx_t_16 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":284
+  /* "aesara/scan/scan_perform.pyx":289
  *     other_args = outer_inputs[offset:]
  * 
  *     cdef unsigned int nb_mitmot_in = 0             # <<<<<<<<<<<<<<
@@ -4184,7 +4202,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_nb_mitmot_in = 0;
 
-  /* "aesara/scan/scan_perform.pyx":285
+  /* "aesara/scan/scan_perform.pyx":290
  * 
  *     cdef unsigned int nb_mitmot_in = 0
  *     for idx in range(n_mit_mot):             # <<<<<<<<<<<<<<
@@ -4196,7 +4214,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
     __pyx_v_idx = __pyx_t_7;
 
-    /* "aesara/scan/scan_perform.pyx":286
+    /* "aesara/scan/scan_perform.pyx":291
  *     cdef unsigned int nb_mitmot_in = 0
  *     for idx in range(n_mit_mot):
  *         nb_mitmot_in += tap_array_len[idx]             # <<<<<<<<<<<<<<
@@ -4207,14 +4225,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_v_nb_mitmot_in = (__pyx_v_nb_mitmot_in + (*((unsigned int const  *) ( /* dim=0 */ (__pyx_v_tap_array_len.data + __pyx_t_17 * __pyx_v_tap_array_len.strides[0]) ))));
   }
 
-  /* "aesara/scan/scan_perform.pyx":288
+  /* "aesara/scan/scan_perform.pyx":293
  *         nb_mitmot_in += tap_array_len[idx]
  * 
  *     old_mitmot_input_storage = [None] * nb_mitmot_in             # <<<<<<<<<<<<<<
  *     old_mitmot_input_data = [None] * nb_mitmot_in
  *     old_output_storage = [None] * len_output_storage
  */
-  __pyx_t_16 = PyList_New(1 * (__pyx_v_nb_mitmot_in)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 288, __pyx_L1_error)
+  __pyx_t_16 = PyList_New(1 * (__pyx_v_nb_mitmot_in)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 293, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_16);
   { Py_ssize_t __pyx_temp;
     for (__pyx_temp=0; __pyx_temp < __pyx_v_nb_mitmot_in; __pyx_temp++) {
@@ -4226,14 +4244,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __pyx_v_old_mitmot_input_storage = ((PyObject*)__pyx_t_16);
   __pyx_t_16 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":289
+  /* "aesara/scan/scan_perform.pyx":294
  * 
  *     old_mitmot_input_storage = [None] * nb_mitmot_in
  *     old_mitmot_input_data = [None] * nb_mitmot_in             # <<<<<<<<<<<<<<
  *     old_output_storage = [None] * len_output_storage
  *     old_output_data = [None] * len_output_storage
  */
-  __pyx_t_16 = PyList_New(1 * (__pyx_v_nb_mitmot_in)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 289, __pyx_L1_error)
+  __pyx_t_16 = PyList_New(1 * (__pyx_v_nb_mitmot_in)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 294, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_16);
   { Py_ssize_t __pyx_temp;
     for (__pyx_temp=0; __pyx_temp < __pyx_v_nb_mitmot_in; __pyx_temp++) {
@@ -4245,14 +4263,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __pyx_v_old_mitmot_input_data = ((PyObject*)__pyx_t_16);
   __pyx_t_16 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":290
+  /* "aesara/scan/scan_perform.pyx":295
  *     old_mitmot_input_storage = [None] * nb_mitmot_in
  *     old_mitmot_input_data = [None] * nb_mitmot_in
  *     old_output_storage = [None] * len_output_storage             # <<<<<<<<<<<<<<
  *     old_output_data = [None] * len_output_storage
  *     offset = n_seqs
  */
-  __pyx_t_16 = PyList_New(1 * (__pyx_v_len_output_storage)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 290, __pyx_L1_error)
+  __pyx_t_16 = PyList_New(1 * (__pyx_v_len_output_storage)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 295, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_16);
   { Py_ssize_t __pyx_temp;
     for (__pyx_temp=0; __pyx_temp < __pyx_v_len_output_storage; __pyx_temp++) {
@@ -4264,14 +4282,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __pyx_v_old_output_storage = ((PyObject*)__pyx_t_16);
   __pyx_t_16 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":291
+  /* "aesara/scan/scan_perform.pyx":296
  *     old_mitmot_input_data = [None] * nb_mitmot_in
  *     old_output_storage = [None] * len_output_storage
  *     old_output_data = [None] * len_output_storage             # <<<<<<<<<<<<<<
  *     offset = n_seqs
  *     for idx in range(n_outs):
  */
-  __pyx_t_16 = PyList_New(1 * (__pyx_v_len_output_storage)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 291, __pyx_L1_error)
+  __pyx_t_16 = PyList_New(1 * (__pyx_v_len_output_storage)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 296, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_16);
   { Py_ssize_t __pyx_temp;
     for (__pyx_temp=0; __pyx_temp < __pyx_v_len_output_storage; __pyx_temp++) {
@@ -4283,7 +4301,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __pyx_v_old_output_data = ((PyObject*)__pyx_t_16);
   __pyx_t_16 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":292
+  /* "aesara/scan/scan_perform.pyx":297
  *     old_output_storage = [None] * len_output_storage
  *     old_output_data = [None] * len_output_storage
  *     offset = n_seqs             # <<<<<<<<<<<<<<
@@ -4292,7 +4310,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_offset = __pyx_v_n_seqs;
 
-  /* "aesara/scan/scan_perform.pyx":293
+  /* "aesara/scan/scan_perform.pyx":298
  *     old_output_data = [None] * len_output_storage
  *     offset = n_seqs
  *     for idx in range(n_outs):             # <<<<<<<<<<<<<<
@@ -4304,7 +4322,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
     __pyx_v_idx = __pyx_t_7;
 
-    /* "aesara/scan/scan_perform.pyx":294
+    /* "aesara/scan/scan_perform.pyx":299
  *     offset = n_seqs
  *     for idx in range(n_outs):
  *         offset += tap_array_len[idx]             # <<<<<<<<<<<<<<
@@ -4315,7 +4333,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_v_offset = (__pyx_v_offset + (*((unsigned int const  *) ( /* dim=0 */ (__pyx_v_tap_array_len.data + __pyx_t_17 * __pyx_v_tap_array_len.strides[0]) ))));
   }
 
-  /* "aesara/scan/scan_perform.pyx":295
+  /* "aesara/scan/scan_perform.pyx":300
  *     for idx in range(n_outs):
  *         offset += tap_array_len[idx]
  *     offset += n_shared_outs             # <<<<<<<<<<<<<<
@@ -4324,19 +4342,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_offset = (__pyx_v_offset + __pyx_v_n_shared_outs);
 
-  /* "aesara/scan/scan_perform.pyx":297
+  /* "aesara/scan/scan_perform.pyx":302
  *     offset += n_shared_outs
  * 
  *     for idx in range(len(other_args)):             # <<<<<<<<<<<<<<
  *         inner_input_storage[<unsigned int>(idx+offset)][0] = other_args[idx]
  * 
  */
-  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_other_args); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 297, __pyx_L1_error)
+  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_other_args); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 302, __pyx_L1_error)
   __pyx_t_19 = __pyx_t_9;
   for (__pyx_t_4 = 0; __pyx_t_4 < __pyx_t_19; __pyx_t_4+=1) {
     __pyx_v_idx = __pyx_t_4;
 
-    /* "aesara/scan/scan_perform.pyx":298
+    /* "aesara/scan/scan_perform.pyx":303
  * 
  *     for idx in range(len(other_args)):
  *         inner_input_storage[<unsigned int>(idx+offset)][0] = other_args[idx]             # <<<<<<<<<<<<<<
@@ -4346,11 +4364,11 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_16 = PyList_GET_ITEM(__pyx_v_other_args, __pyx_v_idx);
     __Pyx_INCREF(__pyx_t_16);
     __pyx_t_6 = ((unsigned int)(__pyx_v_idx + __pyx_v_offset));
-    if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_t_6), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 298, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_t_6), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 303, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
   }
 
-  /* "aesara/scan/scan_perform.pyx":300
+  /* "aesara/scan/scan_perform.pyx":305
  *         inner_input_storage[<unsigned int>(idx+offset)][0] = other_args[idx]
  * 
  *     i = 0             # <<<<<<<<<<<<<<
@@ -4359,7 +4377,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_i = 0;
 
-  /* "aesara/scan/scan_perform.pyx":301
+  /* "aesara/scan/scan_perform.pyx":306
  * 
  *     i = 0
  *     cond = 1             # <<<<<<<<<<<<<<
@@ -4368,7 +4386,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_cond = 1;
 
-  /* "aesara/scan/scan_perform.pyx":304
+  /* "aesara/scan/scan_perform.pyx":309
  *     ############## THE MAIN LOOP #########################
  *     #for i in range(n_steps):
  *     while (i < n_steps) and cond == 1:             # <<<<<<<<<<<<<<
@@ -4387,7 +4405,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_L33_bool_binop_done:;
     if (!__pyx_t_5) break;
 
-    /* "aesara/scan/scan_perform.pyx":307
+    /* "aesara/scan/scan_perform.pyx":312
  *         # sequences over which scan iterates
  *         # 3. collect input slices
  *         for idx in range(n_seqs):             # <<<<<<<<<<<<<<
@@ -4399,7 +4417,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":308
+      /* "aesara/scan/scan_perform.pyx":313
  *         # 3. collect input slices
  *         for idx in range(n_seqs):
  *             if vector_seqs[idx] == 1:             # <<<<<<<<<<<<<<
@@ -4410,7 +4428,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_5 = (((*((npy_bool const  *) ( /* dim=0 */ (__pyx_v_vector_seqs.data + __pyx_t_17 * __pyx_v_vector_seqs.strides[0]) ))) == 1) != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":310
+        /* "aesara/scan/scan_perform.pyx":315
  *             if vector_seqs[idx] == 1:
  *                 inner_input_storage[idx][0] = outer_inputs[\
  *                             <unsigned int>(1+idx)][i:<unsigned int>(i+1)].reshape(())             # <<<<<<<<<<<<<<
@@ -4419,24 +4437,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         __pyx_t_13 = ((unsigned int)(1 + __pyx_v_idx));
 
-        /* "aesara/scan/scan_perform.pyx":309
+        /* "aesara/scan/scan_perform.pyx":314
  *         for idx in range(n_seqs):
  *             if vector_seqs[idx] == 1:
  *                 inner_input_storage[idx][0] = outer_inputs[\             # <<<<<<<<<<<<<<
  *                             <unsigned int>(1+idx)][i:<unsigned int>(i+1)].reshape(())
  *             else:
  */
-        __pyx_t_1 = __Pyx_PyObject_GetSlice(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_13), __pyx_v_i, ((unsigned int)(__pyx_v_i + 1)), NULL, NULL, NULL, 1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 310, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetSlice(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_13), __pyx_v_i, ((unsigned int)(__pyx_v_i + 1)), NULL, NULL, NULL, 1, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 315, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
 
-        /* "aesara/scan/scan_perform.pyx":310
+        /* "aesara/scan/scan_perform.pyx":315
  *             if vector_seqs[idx] == 1:
  *                 inner_input_storage[idx][0] = outer_inputs[\
  *                             <unsigned int>(1+idx)][i:<unsigned int>(i+1)].reshape(())             # <<<<<<<<<<<<<<
  *             else:
  *                 inner_input_storage[idx][0] = \
  */
-        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_reshape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 310, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_reshape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 315, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __pyx_t_1 = NULL;
@@ -4451,21 +4469,21 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         }
         __pyx_t_16 = (__pyx_t_1) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_1, __pyx_empty_tuple) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_empty_tuple);
         __Pyx_XDECREF(__pyx_t_1); __pyx_t_1 = 0;
-        if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 310, __pyx_L1_error)
+        if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 315, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":309
+        /* "aesara/scan/scan_perform.pyx":314
  *         for idx in range(n_seqs):
  *             if vector_seqs[idx] == 1:
  *                 inner_input_storage[idx][0] = outer_inputs[\             # <<<<<<<<<<<<<<
  *                             <unsigned int>(1+idx)][i:<unsigned int>(i+1)].reshape(())
  *             else:
  */
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_idx), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 309, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_idx), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 314, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":308
+        /* "aesara/scan/scan_perform.pyx":313
  *         # 3. collect input slices
  *         for idx in range(n_seqs):
  *             if vector_seqs[idx] == 1:             # <<<<<<<<<<<<<<
@@ -4475,7 +4493,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L37;
       }
 
-      /* "aesara/scan/scan_perform.pyx":313
+      /* "aesara/scan/scan_perform.pyx":318
  *             else:
  *                 inner_input_storage[idx][0] = \
  *                         outer_inputs[<unsigned int>(idx+1)][i]             # <<<<<<<<<<<<<<
@@ -4484,23 +4502,23 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       /*else*/ {
         __pyx_t_13 = ((unsigned int)(__pyx_v_idx + 1));
-        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_13), __pyx_v_i, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 313, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_13), __pyx_v_i, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 318, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
 
-        /* "aesara/scan/scan_perform.pyx":312
+        /* "aesara/scan/scan_perform.pyx":317
  *                             <unsigned int>(1+idx)][i:<unsigned int>(i+1)].reshape(())
  *             else:
  *                 inner_input_storage[idx][0] = \             # <<<<<<<<<<<<<<
  *                         outer_inputs[<unsigned int>(idx+1)][i]
  * 
  */
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_idx), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 312, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_idx), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 317, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
       }
       __pyx_L37:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":315
+    /* "aesara/scan/scan_perform.pyx":320
  *                         outer_inputs[<unsigned int>(idx+1)][i]
  * 
  *         offset = n_seqs             # <<<<<<<<<<<<<<
@@ -4509,7 +4527,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_offset = __pyx_v_n_seqs;
 
-    /* "aesara/scan/scan_perform.pyx":316
+    /* "aesara/scan/scan_perform.pyx":321
  * 
  *         offset = n_seqs
  *         for idx in range(n_outs):             # <<<<<<<<<<<<<<
@@ -4521,7 +4539,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":317
+      /* "aesara/scan/scan_perform.pyx":322
  *         offset = n_seqs
  *         for idx in range(n_outs):
  *             pos_idx = pos[idx]             # <<<<<<<<<<<<<<
@@ -4531,7 +4549,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_17 = __pyx_v_idx;
       __pyx_v_pos_idx = (*((unsigned int *) ( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_17 * __pyx_v_pos.strides[0]) )));
 
-      /* "aesara/scan/scan_perform.pyx":318
+      /* "aesara/scan/scan_perform.pyx":323
  *         for idx in range(n_outs):
  *             pos_idx = pos[idx]
  *             store_steps_idx = store_steps[idx]             # <<<<<<<<<<<<<<
@@ -4541,7 +4559,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_17 = __pyx_v_idx;
       __pyx_v_store_steps_idx = (*((unsigned int *) ( /* dim=0 */ (__pyx_v_store_steps.data + __pyx_t_17 * __pyx_v_store_steps.strides[0]) )));
 
-      /* "aesara/scan/scan_perform.pyx":319
+      /* "aesara/scan/scan_perform.pyx":324
  *             pos_idx = pos[idx]
  *             store_steps_idx = store_steps[idx]
  *             outer_outputs_idx = outer_outputs[idx]             # <<<<<<<<<<<<<<
@@ -4553,7 +4571,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __Pyx_XDECREF_SET(__pyx_v_outer_outputs_idx, __pyx_t_16);
       __pyx_t_16 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":321
+      /* "aesara/scan/scan_perform.pyx":326
  *             outer_outputs_idx = outer_outputs[idx]
  * 
  *             if vector_outs[idx] == 1:             # <<<<<<<<<<<<<<
@@ -4564,7 +4582,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_5 = (((*((npy_bool const  *) ( /* dim=0 */ (__pyx_v_vector_outs.data + __pyx_t_17 * __pyx_v_vector_outs.strides[0]) ))) == 1) != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":322
+        /* "aesara/scan/scan_perform.pyx":327
  * 
  *             if vector_outs[idx] == 1:
  *                 for tap in tap_array[idx]:             # <<<<<<<<<<<<<<
@@ -4575,26 +4593,26 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           __pyx_t_16 = PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx); __Pyx_INCREF(__pyx_t_16); __pyx_t_9 = 0;
           __pyx_t_20 = NULL;
         } else {
-          __pyx_t_9 = -1; __pyx_t_16 = PyObject_GetIter(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 322, __pyx_L1_error)
+          __pyx_t_9 = -1; __pyx_t_16 = PyObject_GetIter(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 327, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_16);
-          __pyx_t_20 = Py_TYPE(__pyx_t_16)->tp_iternext; if (unlikely(!__pyx_t_20)) __PYX_ERR(0, 322, __pyx_L1_error)
+          __pyx_t_20 = Py_TYPE(__pyx_t_16)->tp_iternext; if (unlikely(!__pyx_t_20)) __PYX_ERR(0, 327, __pyx_L1_error)
         }
         for (;;) {
           if (likely(!__pyx_t_20)) {
             if (likely(PyList_CheckExact(__pyx_t_16))) {
               if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_16)) break;
               #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-              __pyx_t_3 = PyList_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 322, __pyx_L1_error)
+              __pyx_t_3 = PyList_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 327, __pyx_L1_error)
               #else
-              __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 322, __pyx_L1_error)
+              __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 327, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_3);
               #endif
             } else {
               if (__pyx_t_9 >= PyTuple_GET_SIZE(__pyx_t_16)) break;
               #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-              __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 322, __pyx_L1_error)
+              __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 327, __pyx_L1_error)
               #else
-              __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 322, __pyx_L1_error)
+              __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 327, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_3);
               #endif
             }
@@ -4604,17 +4622,17 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
               PyObject* exc_type = PyErr_Occurred();
               if (exc_type) {
                 if (likely(__Pyx_PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-                else __PYX_ERR(0, 322, __pyx_L1_error)
+                else __PYX_ERR(0, 327, __pyx_L1_error)
               }
               break;
             }
             __Pyx_GOTREF(__pyx_t_3);
           }
-          __pyx_t_21 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_21 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 322, __pyx_L1_error)
+          __pyx_t_21 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_21 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 327, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
           __pyx_v_tap = __pyx_t_21;
 
-          /* "aesara/scan/scan_perform.pyx":323
+          /* "aesara/scan/scan_perform.pyx":328
  *             if vector_outs[idx] == 1:
  *                 for tap in tap_array[idx]:
  *                     _idx = pymod(pos_idx + tap, store_steps_idx)             # <<<<<<<<<<<<<<
@@ -4623,19 +4641,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           __pyx_v__idx = __pyx_f_6aesara_4scan_12scan_perform_pymod((__pyx_v_pos_idx + __pyx_v_tap), __pyx_v_store_steps_idx);
 
-          /* "aesara/scan/scan_perform.pyx":325
+          /* "aesara/scan/scan_perform.pyx":330
  *                     _idx = pymod(pos_idx + tap, store_steps_idx)
  *                     inner_input_storage[offset][0] =\
  *                             outer_outputs_idx[0][_idx:<unsigned int>(_idx + 1)].reshape(())             # <<<<<<<<<<<<<<
  *                     offset += 1
  *             else:
  */
-          __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_outer_outputs_idx, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 325, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_outer_outputs_idx, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 330, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
-          __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_t_1, __pyx_v__idx, ((unsigned int)(__pyx_v__idx + 1)), NULL, NULL, NULL, 1, 1, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 325, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_t_1, __pyx_v__idx, ((unsigned int)(__pyx_v__idx + 1)), NULL, NULL, NULL, 1, 1, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 330, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_2);
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-          __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_reshape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 325, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_reshape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 330, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
           __pyx_t_2 = NULL;
@@ -4650,21 +4668,21 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           }
           __pyx_t_3 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_1, __pyx_t_2, __pyx_empty_tuple) : __Pyx_PyObject_CallOneArg(__pyx_t_1, __pyx_empty_tuple);
           __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-          if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 325, __pyx_L1_error)
+          if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 330, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_3);
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":324
+          /* "aesara/scan/scan_perform.pyx":329
  *                 for tap in tap_array[idx]:
  *                     _idx = pymod(pos_idx + tap, store_steps_idx)
  *                     inner_input_storage[offset][0] =\             # <<<<<<<<<<<<<<
  *                             outer_outputs_idx[0][_idx:<unsigned int>(_idx + 1)].reshape(())
  *                     offset += 1
  */
-          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_3, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 324, __pyx_L1_error)
+          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_3, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 329, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":326
+          /* "aesara/scan/scan_perform.pyx":331
  *                     inner_input_storage[offset][0] =\
  *                             outer_outputs_idx[0][_idx:<unsigned int>(_idx + 1)].reshape(())
  *                     offset += 1             # <<<<<<<<<<<<<<
@@ -4673,7 +4691,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           __pyx_v_offset = (__pyx_v_offset + 1);
 
-          /* "aesara/scan/scan_perform.pyx":322
+          /* "aesara/scan/scan_perform.pyx":327
  * 
  *             if vector_outs[idx] == 1:
  *                 for tap in tap_array[idx]:             # <<<<<<<<<<<<<<
@@ -4683,7 +4701,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         }
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":321
+        /* "aesara/scan/scan_perform.pyx":326
  *             outer_outputs_idx = outer_outputs[idx]
  * 
  *             if vector_outs[idx] == 1:             # <<<<<<<<<<<<<<
@@ -4693,7 +4711,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L40;
       }
 
-      /* "aesara/scan/scan_perform.pyx":328
+      /* "aesara/scan/scan_perform.pyx":333
  *                     offset += 1
  *             else:
  *                 for tap in tap_array[idx]:             # <<<<<<<<<<<<<<
@@ -4705,26 +4723,26 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           __pyx_t_16 = PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx); __Pyx_INCREF(__pyx_t_16); __pyx_t_9 = 0;
           __pyx_t_20 = NULL;
         } else {
-          __pyx_t_9 = -1; __pyx_t_16 = PyObject_GetIter(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 328, __pyx_L1_error)
+          __pyx_t_9 = -1; __pyx_t_16 = PyObject_GetIter(PyTuple_GET_ITEM(__pyx_v_tap_array, __pyx_v_idx)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 333, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_16);
-          __pyx_t_20 = Py_TYPE(__pyx_t_16)->tp_iternext; if (unlikely(!__pyx_t_20)) __PYX_ERR(0, 328, __pyx_L1_error)
+          __pyx_t_20 = Py_TYPE(__pyx_t_16)->tp_iternext; if (unlikely(!__pyx_t_20)) __PYX_ERR(0, 333, __pyx_L1_error)
         }
         for (;;) {
           if (likely(!__pyx_t_20)) {
             if (likely(PyList_CheckExact(__pyx_t_16))) {
               if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_16)) break;
               #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-              __pyx_t_3 = PyList_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 328, __pyx_L1_error)
+              __pyx_t_3 = PyList_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 333, __pyx_L1_error)
               #else
-              __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 328, __pyx_L1_error)
+              __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 333, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_3);
               #endif
             } else {
               if (__pyx_t_9 >= PyTuple_GET_SIZE(__pyx_t_16)) break;
               #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-              __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 328, __pyx_L1_error)
+              __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 333, __pyx_L1_error)
               #else
-              __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 328, __pyx_L1_error)
+              __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 333, __pyx_L1_error)
               __Pyx_GOTREF(__pyx_t_3);
               #endif
             }
@@ -4734,17 +4752,17 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
               PyObject* exc_type = PyErr_Occurred();
               if (exc_type) {
                 if (likely(__Pyx_PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-                else __PYX_ERR(0, 328, __pyx_L1_error)
+                else __PYX_ERR(0, 333, __pyx_L1_error)
               }
               break;
             }
             __Pyx_GOTREF(__pyx_t_3);
           }
-          __pyx_t_21 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_21 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 328, __pyx_L1_error)
+          __pyx_t_21 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_21 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 333, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
           __pyx_v_tap = __pyx_t_21;
 
-          /* "aesara/scan/scan_perform.pyx":329
+          /* "aesara/scan/scan_perform.pyx":334
  *             else:
  *                 for tap in tap_array[idx]:
  *                     _idx = pymod(pos_idx + tap, store_steps_idx)             # <<<<<<<<<<<<<<
@@ -4753,22 +4771,22 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           __pyx_v__idx = __pyx_f_6aesara_4scan_12scan_perform_pymod((__pyx_v_pos_idx + __pyx_v_tap), __pyx_v_store_steps_idx);
 
-          /* "aesara/scan/scan_perform.pyx":330
+          /* "aesara/scan/scan_perform.pyx":335
  *                 for tap in tap_array[idx]:
  *                     _idx = pymod(pos_idx + tap, store_steps_idx)
  *                     inner_input_storage[offset][0] = outer_outputs_idx[0][_idx]             # <<<<<<<<<<<<<<
  *                     offset += 1
  * 
  */
-          __pyx_t_3 = __Pyx_GetItemInt(__pyx_v_outer_outputs_idx, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 330, __pyx_L1_error)
+          __pyx_t_3 = __Pyx_GetItemInt(__pyx_v_outer_outputs_idx, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 335, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_3);
-          __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_3, __pyx_v__idx, int, 1, __Pyx_PyInt_From_int, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 330, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_3, __pyx_v__idx, int, 1, __Pyx_PyInt_From_int, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 335, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 330, __pyx_L1_error)
+          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 335, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":331
+          /* "aesara/scan/scan_perform.pyx":336
  *                     _idx = pymod(pos_idx + tap, store_steps_idx)
  *                     inner_input_storage[offset][0] = outer_outputs_idx[0][_idx]
  *                     offset += 1             # <<<<<<<<<<<<<<
@@ -4777,7 +4795,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           __pyx_v_offset = (__pyx_v_offset + 1);
 
-          /* "aesara/scan/scan_perform.pyx":328
+          /* "aesara/scan/scan_perform.pyx":333
  *                     offset += 1
  *             else:
  *                 for tap in tap_array[idx]:             # <<<<<<<<<<<<<<
@@ -4790,7 +4808,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_L40:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":334
+    /* "aesara/scan/scan_perform.pyx":339
  * 
  * 
  *         a_offset = shared_arg_offset             # <<<<<<<<<<<<<<
@@ -4799,7 +4817,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_a_offset = __pyx_v_shared_arg_offset;
 
-    /* "aesara/scan/scan_perform.pyx":335
+    /* "aesara/scan/scan_perform.pyx":340
  * 
  *         a_offset = shared_arg_offset
  *         o_offset = n_outs + n_nit_sot             # <<<<<<<<<<<<<<
@@ -4808,7 +4826,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_o_offset = (__pyx_v_n_outs + __pyx_v_n_nit_sot);
 
-    /* "aesara/scan/scan_perform.pyx":336
+    /* "aesara/scan/scan_perform.pyx":341
  *         a_offset = shared_arg_offset
  *         o_offset = n_outs + n_nit_sot
  *         if i == 0:             # <<<<<<<<<<<<<<
@@ -4818,7 +4836,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_5 = ((__pyx_v_i == 0) != 0);
     if (__pyx_t_5) {
 
-      /* "aesara/scan/scan_perform.pyx":337
+      /* "aesara/scan/scan_perform.pyx":342
  *         o_offset = n_outs + n_nit_sot
  *         if i == 0:
  *             for j in range(n_shared_outs):             # <<<<<<<<<<<<<<
@@ -4830,7 +4848,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
         __pyx_v_j = __pyx_t_7;
 
-        /* "aesara/scan/scan_perform.pyx":338
+        /* "aesara/scan/scan_perform.pyx":343
  *         if i == 0:
  *             for j in range(n_shared_outs):
  *                 inner_input_storage[offset][0] = outer_inputs[<unsigned int>(a_offset+j)]             # <<<<<<<<<<<<<<
@@ -4840,10 +4858,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_t_13 = ((unsigned int)(__pyx_v_a_offset + __pyx_v_j));
         __pyx_t_16 = PyList_GET_ITEM(__pyx_v_outer_inputs, __pyx_t_13);
         __Pyx_INCREF(__pyx_t_16);
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 338, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 343, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":339
+        /* "aesara/scan/scan_perform.pyx":344
  *             for j in range(n_shared_outs):
  *                 inner_input_storage[offset][0] = outer_inputs[<unsigned int>(a_offset+j)]
  *                 offset += 1             # <<<<<<<<<<<<<<
@@ -4853,7 +4871,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_v_offset = (__pyx_v_offset + 1);
       }
 
-      /* "aesara/scan/scan_perform.pyx":336
+      /* "aesara/scan/scan_perform.pyx":341
  *         a_offset = shared_arg_offset
  *         o_offset = n_outs + n_nit_sot
  *         if i == 0:             # <<<<<<<<<<<<<<
@@ -4863,7 +4881,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       goto __pyx_L45;
     }
 
-    /* "aesara/scan/scan_perform.pyx":341
+    /* "aesara/scan/scan_perform.pyx":346
  *                 offset += 1
  *         else:
  *             for j in range(n_shared_outs):             # <<<<<<<<<<<<<<
@@ -4876,7 +4894,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
         __pyx_v_j = __pyx_t_7;
 
-        /* "aesara/scan/scan_perform.pyx":342
+        /* "aesara/scan/scan_perform.pyx":347
  *         else:
  *             for j in range(n_shared_outs):
  *                 inner_input_storage[offset][0] = outer_outputs[<unsigned int>(o_offset+j)][0]             # <<<<<<<<<<<<<<
@@ -4884,12 +4902,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  * 
  */
         __pyx_t_13 = ((unsigned int)(__pyx_v_o_offset + __pyx_v_j));
-        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_t_13), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 342, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_t_13), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 347, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 342, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_offset), 0, __pyx_t_16, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 347, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":343
+        /* "aesara/scan/scan_perform.pyx":348
  *             for j in range(n_shared_outs):
  *                 inner_input_storage[offset][0] = outer_outputs[<unsigned int>(o_offset+j)][0]
  *                 offset += 1             # <<<<<<<<<<<<<<
@@ -4901,7 +4919,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     }
     __pyx_L45:;
 
-    /* "aesara/scan/scan_perform.pyx":348
+    /* "aesara/scan/scan_perform.pyx":353
  * 
  *         # 4.1. Collect slices for mitmots
  *         offset = 0             # <<<<<<<<<<<<<<
@@ -4910,7 +4928,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_offset = 0;
 
-    /* "aesara/scan/scan_perform.pyx":349
+    /* "aesara/scan/scan_perform.pyx":354
  *         # 4.1. Collect slices for mitmots
  *         offset = 0
  *         for idx in range(n_mit_mot_outs):             # <<<<<<<<<<<<<<
@@ -4922,7 +4940,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":350
+      /* "aesara/scan/scan_perform.pyx":355
  *         offset = 0
  *         for idx in range(n_mit_mot_outs):
  *             if not mitmots_preallocated[<unsigned int>idx]:             # <<<<<<<<<<<<<<
@@ -4933,16 +4951,16 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_5 = ((!((*((npy_bool const  *) ( /* dim=0 */ (__pyx_v_mitmots_preallocated.data + __pyx_t_17 * __pyx_v_mitmots_preallocated.strides[0]) ))) != 0)) != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":351
+        /* "aesara/scan/scan_perform.pyx":356
  *         for idx in range(n_mit_mot_outs):
  *             if not mitmots_preallocated[<unsigned int>idx]:
  *                 inner_output_storage[<unsigned int>offset][0] = None             # <<<<<<<<<<<<<<
  *             offset += 1
  * 
  */
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, ((unsigned int)__pyx_v_offset)), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 351, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, ((unsigned int)__pyx_v_offset)), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 356, __pyx_L1_error)
 
-        /* "aesara/scan/scan_perform.pyx":350
+        /* "aesara/scan/scan_perform.pyx":355
  *         offset = 0
  *         for idx in range(n_mit_mot_outs):
  *             if not mitmots_preallocated[<unsigned int>idx]:             # <<<<<<<<<<<<<<
@@ -4951,7 +4969,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       }
 
-      /* "aesara/scan/scan_perform.pyx":352
+      /* "aesara/scan/scan_perform.pyx":357
  *             if not mitmots_preallocated[<unsigned int>idx]:
  *                 inner_output_storage[<unsigned int>offset][0] = None
  *             offset += 1             # <<<<<<<<<<<<<<
@@ -4961,7 +4979,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_v_offset = (__pyx_v_offset + 1);
     }
 
-    /* "aesara/scan/scan_perform.pyx":355
+    /* "aesara/scan/scan_perform.pyx":360
  * 
  *         # 4.2. Collect slices for mitsots, sitsots and nitsots
  *         if i != 0:             # <<<<<<<<<<<<<<
@@ -4971,7 +4989,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_5 = ((__pyx_v_i != 0) != 0);
     if (__pyx_t_5) {
 
-      /* "aesara/scan/scan_perform.pyx":356
+      /* "aesara/scan/scan_perform.pyx":361
  *         # 4.2. Collect slices for mitsots, sitsots and nitsots
  *         if i != 0:
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):             # <<<<<<<<<<<<<<
@@ -4983,7 +5001,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
         __pyx_v_idx = __pyx_t_7;
 
-        /* "aesara/scan/scan_perform.pyx":357
+        /* "aesara/scan/scan_perform.pyx":362
  *         if i != 0:
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):
  *                 if ( store_steps[<unsigned int>(idx+n_mit_mot)] == 1 or             # <<<<<<<<<<<<<<
@@ -4998,7 +5016,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           goto __pyx_L57_bool_binop_done;
         }
 
-        /* "aesara/scan/scan_perform.pyx":358
+        /* "aesara/scan/scan_perform.pyx":363
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):
  *                 if ( store_steps[<unsigned int>(idx+n_mit_mot)] == 1 or
  *                     vector_outs[<unsigned int>(idx+n_mit_mot)] == 1):             # <<<<<<<<<<<<<<
@@ -5010,7 +5028,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_t_5 = __pyx_t_15;
         __pyx_L57_bool_binop_done:;
 
-        /* "aesara/scan/scan_perform.pyx":357
+        /* "aesara/scan/scan_perform.pyx":362
  *         if i != 0:
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):
  *                 if ( store_steps[<unsigned int>(idx+n_mit_mot)] == 1 or             # <<<<<<<<<<<<<<
@@ -5019,7 +5037,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (__pyx_t_5) {
 
-          /* "aesara/scan/scan_perform.pyx":359
+          /* "aesara/scan/scan_perform.pyx":364
  *                 if ( store_steps[<unsigned int>(idx+n_mit_mot)] == 1 or
  *                     vector_outs[<unsigned int>(idx+n_mit_mot)] == 1):
  *                     inner_output_storage[<unsigned int>(idx+offset)][0] = None             # <<<<<<<<<<<<<<
@@ -5027,9 +5045,9 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *                     inner_output_storage[<unsigned int>(idx+offset)][0] =\
  */
           __pyx_t_13 = ((unsigned int)(__pyx_v_idx + __pyx_v_offset));
-          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_13), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 359, __pyx_L1_error)
+          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_13), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 364, __pyx_L1_error)
 
-          /* "aesara/scan/scan_perform.pyx":357
+          /* "aesara/scan/scan_perform.pyx":362
  *         if i != 0:
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):
  *                 if ( store_steps[<unsigned int>(idx+n_mit_mot)] == 1 or             # <<<<<<<<<<<<<<
@@ -5039,7 +5057,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           goto __pyx_L56;
         }
 
-        /* "aesara/scan/scan_perform.pyx":362
+        /* "aesara/scan/scan_perform.pyx":367
  *                 else:
  *                     inner_output_storage[<unsigned int>(idx+offset)][0] =\
  *                         outer_outputs[<unsigned int>(idx+n_mit_mot)][0][pos[\             # <<<<<<<<<<<<<<
@@ -5048,10 +5066,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         /*else*/ {
           __pyx_t_13 = ((unsigned int)(__pyx_v_idx + __pyx_v_n_mit_mot));
-          __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_t_13), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 362, __pyx_L1_error)
+          __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_t_13), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 367, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_16);
 
-          /* "aesara/scan/scan_perform.pyx":363
+          /* "aesara/scan/scan_perform.pyx":368
  *                     inner_output_storage[<unsigned int>(idx+offset)][0] =\
  *                         outer_outputs[<unsigned int>(idx+n_mit_mot)][0][pos[\
  *                                             <unsigned int>(idx+n_mit_mot)]]             # <<<<<<<<<<<<<<
@@ -5060,7 +5078,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           __pyx_t_17 = ((unsigned int)(__pyx_v_idx + __pyx_v_n_mit_mot));
 
-          /* "aesara/scan/scan_perform.pyx":362
+          /* "aesara/scan/scan_perform.pyx":367
  *                 else:
  *                     inner_output_storage[<unsigned int>(idx+offset)][0] =\
  *                         outer_outputs[<unsigned int>(idx+n_mit_mot)][0][pos[\             # <<<<<<<<<<<<<<
@@ -5068,11 +5086,11 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *         else:
  */
           __pyx_t_13 = (*((unsigned int *) ( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_17 * __pyx_v_pos.strides[0]) )));
-          __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_16, __pyx_t_13, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 362, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_16, __pyx_t_13, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 367, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":361
+          /* "aesara/scan/scan_perform.pyx":366
  *                     inner_output_storage[<unsigned int>(idx+offset)][0] = None
  *                 else:
  *                     inner_output_storage[<unsigned int>(idx+offset)][0] =\             # <<<<<<<<<<<<<<
@@ -5080,13 +5098,13 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *                                             <unsigned int>(idx+n_mit_mot)]]
  */
           __pyx_t_13 = ((unsigned int)(__pyx_v_idx + __pyx_v_offset));
-          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_13), 0, __pyx_t_1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 361, __pyx_L1_error)
+          if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_13), 0, __pyx_t_1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 366, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         }
         __pyx_L56:;
       }
 
-      /* "aesara/scan/scan_perform.pyx":355
+      /* "aesara/scan/scan_perform.pyx":360
  * 
  *         # 4.2. Collect slices for mitsots, sitsots and nitsots
  *         if i != 0:             # <<<<<<<<<<<<<<
@@ -5096,7 +5114,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       goto __pyx_L53;
     }
 
-    /* "aesara/scan/scan_perform.pyx":365
+    /* "aesara/scan/scan_perform.pyx":370
  *                                             <unsigned int>(idx+n_mit_mot)]]
  *         else:
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):             # <<<<<<<<<<<<<<
@@ -5109,7 +5127,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
         __pyx_v_idx = __pyx_t_7;
 
-        /* "aesara/scan/scan_perform.pyx":366
+        /* "aesara/scan/scan_perform.pyx":371
  *         else:
  *             for idx in range(n_outs + n_nit_sot - n_mit_mot):
  *                 inner_output_storage[<unsigned int>(idx+offset)][0] = None             # <<<<<<<<<<<<<<
@@ -5117,12 +5135,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *         # 4.3. Collect slices for shared outputs
  */
         __pyx_t_13 = ((unsigned int)(__pyx_v_idx + __pyx_v_offset));
-        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_13), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 366, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_13), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 371, __pyx_L1_error)
       }
     }
     __pyx_L53:;
 
-    /* "aesara/scan/scan_perform.pyx":369
+    /* "aesara/scan/scan_perform.pyx":374
  * 
  *         # 4.3. Collect slices for shared outputs
  *         offset += n_outs+n_nit_sot - n_mit_mot             # <<<<<<<<<<<<<<
@@ -5131,7 +5149,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_offset = (__pyx_v_offset + ((__pyx_v_n_outs + __pyx_v_n_nit_sot) - __pyx_v_n_mit_mot));
 
-    /* "aesara/scan/scan_perform.pyx":370
+    /* "aesara/scan/scan_perform.pyx":375
  *         # 4.3. Collect slices for shared outputs
  *         offset += n_outs+n_nit_sot - n_mit_mot
  *         for idx in range(n_shared_outs):             # <<<<<<<<<<<<<<
@@ -5143,7 +5161,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":371
+      /* "aesara/scan/scan_perform.pyx":376
  *         offset += n_outs+n_nit_sot - n_mit_mot
  *         for idx in range(n_shared_outs):
  *             inner_output_storage[<unsigned int>(idx+offset)][0] = None             # <<<<<<<<<<<<<<
@@ -5151,10 +5169,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *         # 4.4. If there is a condition add it to the mix
  */
       __pyx_t_13 = ((unsigned int)(__pyx_v_idx + __pyx_v_offset));
-      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_13), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 371, __pyx_L1_error)
+      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_t_13), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 376, __pyx_L1_error)
     }
 
-    /* "aesara/scan/scan_perform.pyx":374
+    /* "aesara/scan/scan_perform.pyx":379
  * 
  *         # 4.4. If there is a condition add it to the mix
  *         if as_while:             # <<<<<<<<<<<<<<
@@ -5164,7 +5182,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_5 = (__pyx_v_as_while != 0);
     if (__pyx_t_5) {
 
-      /* "aesara/scan/scan_perform.pyx":375
+      /* "aesara/scan/scan_perform.pyx":380
  *         # 4.4. If there is a condition add it to the mix
  *         if as_while:
  *             pdx = offset + n_shared_outs             # <<<<<<<<<<<<<<
@@ -5173,16 +5191,16 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       __pyx_v_pdx = (__pyx_v_offset + __pyx_v_n_shared_outs);
 
-      /* "aesara/scan/scan_perform.pyx":376
+      /* "aesara/scan/scan_perform.pyx":381
  *         if as_while:
  *             pdx = offset + n_shared_outs
  *             inner_output_storage[<unsigned int>pdx][0] = None             # <<<<<<<<<<<<<<
  * 
  *         # 4.5. Keep a reference to the variables (ndarrays,
  */
-      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, ((unsigned int)__pyx_v_pdx)), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 376, __pyx_L1_error)
+      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, ((unsigned int)__pyx_v_pdx)), 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 381, __pyx_L1_error)
 
-      /* "aesara/scan/scan_perform.pyx":374
+      /* "aesara/scan/scan_perform.pyx":379
  * 
  *         # 4.4. If there is a condition add it to the mix
  *         if as_while:             # <<<<<<<<<<<<<<
@@ -5191,7 +5209,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     }
 
-    /* "aesara/scan/scan_perform.pyx":384
+    /* "aesara/scan/scan_perform.pyx":389
  *         # cases where outputs reused the allocated object but alter the
  *         # memory region they refer to.
  *         for idx in range(len_output_storage):             # <<<<<<<<<<<<<<
@@ -5203,28 +5221,28 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":386
+      /* "aesara/scan/scan_perform.pyx":391
  *         for idx in range(len_output_storage):
  * 
  *             var = inner_output_storage[idx][0]             # <<<<<<<<<<<<<<
  *             old_output_storage[idx] = var
  * 
  */
-      __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 386, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 391, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_XDECREF_SET(__pyx_v_var, __pyx_t_1);
       __pyx_t_1 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":387
+      /* "aesara/scan/scan_perform.pyx":392
  * 
  *             var = inner_output_storage[idx][0]
  *             old_output_storage[idx] = var             # <<<<<<<<<<<<<<
  * 
  *             if var is None:
  */
-      if (unlikely(__Pyx_SetItemInt(__pyx_v_old_output_storage, __pyx_v_idx, __pyx_v_var, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 387, __pyx_L1_error)
+      if (unlikely(__Pyx_SetItemInt(__pyx_v_old_output_storage, __pyx_v_idx, __pyx_v_var, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 392, __pyx_L1_error)
 
-      /* "aesara/scan/scan_perform.pyx":389
+      /* "aesara/scan/scan_perform.pyx":394
  *             old_output_storage[idx] = var
  * 
  *             if var is None:             # <<<<<<<<<<<<<<
@@ -5235,16 +5253,16 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_15 = (__pyx_t_5 != 0);
       if (__pyx_t_15) {
 
-        /* "aesara/scan/scan_perform.pyx":390
+        /* "aesara/scan/scan_perform.pyx":395
  * 
  *             if var is None:
  *                 old_output_data[idx] = None             # <<<<<<<<<<<<<<
  *             else:
  *                 old_output_data[idx] = var.data
  */
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_output_data, __pyx_v_idx, Py_None, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 390, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_output_data, __pyx_v_idx, Py_None, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 395, __pyx_L1_error)
 
-        /* "aesara/scan/scan_perform.pyx":389
+        /* "aesara/scan/scan_perform.pyx":394
  *             old_output_storage[idx] = var
  * 
  *             if var is None:             # <<<<<<<<<<<<<<
@@ -5254,7 +5272,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L66;
       }
 
-      /* "aesara/scan/scan_perform.pyx":392
+      /* "aesara/scan/scan_perform.pyx":397
  *                 old_output_data[idx] = None
  *             else:
  *                 old_output_data[idx] = var.data             # <<<<<<<<<<<<<<
@@ -5262,15 +5280,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *         # 4.6. Keep a reference to the variables (ndarrays,
  */
       /*else*/ {
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_var, __pyx_n_s_data); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 392, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_var, __pyx_n_s_data); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 397, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_output_data, __pyx_v_idx, __pyx_t_1, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 392, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_output_data, __pyx_v_idx, __pyx_t_1, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 397, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       }
       __pyx_L66:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":400
+    /* "aesara/scan/scan_perform.pyx":405
  *         # be able to detect cases where outputs reused the allocated object
  *         # but alter the memory region they refer to.
  *         for idx in range(nb_mitmot_in):             # <<<<<<<<<<<<<<
@@ -5282,7 +5300,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":401
+      /* "aesara/scan/scan_perform.pyx":406
  *         # but alter the memory region they refer to.
  *         for idx in range(nb_mitmot_in):
  *             var = inner_input_storage[idx + n_seqs][0]             # <<<<<<<<<<<<<<
@@ -5290,21 +5308,21 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  * 
  */
       __pyx_t_13 = (__pyx_v_idx + __pyx_v_n_seqs);
-      __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_t_13), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 401, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_t_13), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 406, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_XDECREF_SET(__pyx_v_var, __pyx_t_1);
       __pyx_t_1 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":402
+      /* "aesara/scan/scan_perform.pyx":407
  *         for idx in range(nb_mitmot_in):
  *             var = inner_input_storage[idx + n_seqs][0]
  *             old_mitmot_input_storage[idx] = var             # <<<<<<<<<<<<<<
  * 
  *             if var is None:
  */
-      if (unlikely(__Pyx_SetItemInt(__pyx_v_old_mitmot_input_storage, __pyx_v_idx, __pyx_v_var, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 402, __pyx_L1_error)
+      if (unlikely(__Pyx_SetItemInt(__pyx_v_old_mitmot_input_storage, __pyx_v_idx, __pyx_v_var, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 407, __pyx_L1_error)
 
-      /* "aesara/scan/scan_perform.pyx":404
+      /* "aesara/scan/scan_perform.pyx":409
  *             old_mitmot_input_storage[idx] = var
  * 
  *             if var is None:             # <<<<<<<<<<<<<<
@@ -5315,16 +5333,16 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_5 = (__pyx_t_15 != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":405
+        /* "aesara/scan/scan_perform.pyx":410
  * 
  *             if var is None:
  *                 old_mitmot_input_data[idx] = None             # <<<<<<<<<<<<<<
  *             else:
  *                 old_mitmot_input_data[idx] = var.data
  */
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_mitmot_input_data, __pyx_v_idx, Py_None, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 405, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_mitmot_input_data, __pyx_v_idx, Py_None, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 410, __pyx_L1_error)
 
-        /* "aesara/scan/scan_perform.pyx":404
+        /* "aesara/scan/scan_perform.pyx":409
  *             old_mitmot_input_storage[idx] = var
  * 
  *             if var is None:             # <<<<<<<<<<<<<<
@@ -5334,7 +5352,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L69;
       }
 
-      /* "aesara/scan/scan_perform.pyx":407
+      /* "aesara/scan/scan_perform.pyx":412
  *                 old_mitmot_input_data[idx] = None
  *             else:
  *                 old_mitmot_input_data[idx] = var.data             # <<<<<<<<<<<<<<
@@ -5342,15 +5360,15 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *         # 5.1 compute outputs
  */
       /*else*/ {
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_var, __pyx_n_s_data); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 407, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_var, __pyx_n_s_data); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 412, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_mitmot_input_data, __pyx_v_idx, __pyx_t_1, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 407, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_old_mitmot_input_data, __pyx_v_idx, __pyx_t_1, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 1, 0, 0) < 0)) __PYX_ERR(0, 412, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       }
       __pyx_L69:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":410
+    /* "aesara/scan/scan_perform.pyx":415
  * 
  *         # 5.1 compute outputs
  *         t0_fn = time(NULL)             # <<<<<<<<<<<<<<
@@ -5359,7 +5377,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_t0_fn = time(NULL);
 
-    /* "aesara/scan/scan_perform.pyx":412
+    /* "aesara/scan/scan_perform.pyx":417
  *         t0_fn = time(NULL)
  * 
  *         try:             # <<<<<<<<<<<<<<
@@ -5375,7 +5393,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __Pyx_XGOTREF(__pyx_t_24);
       /*try:*/ {
 
-        /* "aesara/scan/scan_perform.pyx":413
+        /* "aesara/scan/scan_perform.pyx":418
  * 
  *         try:
  *             fn()             # <<<<<<<<<<<<<<
@@ -5395,12 +5413,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         }
         __pyx_t_1 = (__pyx_t_3) ? __Pyx_PyObject_CallOneArg(__pyx_t_16, __pyx_t_3) : __Pyx_PyObject_CallNoArg(__pyx_t_16);
         __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
-        if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 413, __pyx_L70_error)
+        if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 418, __pyx_L70_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":412
+        /* "aesara/scan/scan_perform.pyx":417
  *         t0_fn = time(NULL)
  * 
  *         try:             # <<<<<<<<<<<<<<
@@ -5418,7 +5436,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
       __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":414
+      /* "aesara/scan/scan_perform.pyx":419
  *         try:
  *             fn()
  *         except Exception as exc:             # <<<<<<<<<<<<<<
@@ -5428,7 +5446,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_21 = __Pyx_PyErr_ExceptionMatches(((PyObject *)(&((PyTypeObject*)PyExc_Exception)[0])));
       if (__pyx_t_21) {
         __Pyx_AddTraceback("aesara.scan.scan_perform.perform", __pyx_clineno, __pyx_lineno, __pyx_filename);
-        if (__Pyx_GetException(&__pyx_t_1, &__pyx_t_16, &__pyx_t_3) < 0) __PYX_ERR(0, 414, __pyx_L72_except_error)
+        if (__Pyx_GetException(&__pyx_t_1, &__pyx_t_16, &__pyx_t_3) < 0) __PYX_ERR(0, 419, __pyx_L72_except_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_GOTREF(__pyx_t_16);
         __Pyx_GOTREF(__pyx_t_3);
@@ -5436,18 +5454,18 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_v_exc = __pyx_t_16;
         /*try:*/ {
 
-          /* "aesara/scan/scan_perform.pyx":415
+          /* "aesara/scan/scan_perform.pyx":420
  *             fn()
  *         except Exception as exc:
  *             raise InnerFunctionError(exc, sys.exc_info()[2])             # <<<<<<<<<<<<<<
  * 
  *         dt_fn = time(NULL) - t0_fn
  */
-          __Pyx_GetModuleGlobalName(__pyx_t_25, __pyx_n_s_InnerFunctionError); if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 415, __pyx_L83_error)
+          __Pyx_GetModuleGlobalName(__pyx_t_25, __pyx_n_s_InnerFunctionError); if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 420, __pyx_L83_error)
           __Pyx_GOTREF(__pyx_t_25);
-          __Pyx_GetModuleGlobalName(__pyx_t_27, __pyx_n_s_sys); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 415, __pyx_L83_error)
+          __Pyx_GetModuleGlobalName(__pyx_t_27, __pyx_n_s_sys); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 420, __pyx_L83_error)
           __Pyx_GOTREF(__pyx_t_27);
-          __pyx_t_28 = __Pyx_PyObject_GetAttrStr(__pyx_t_27, __pyx_n_s_exc_info); if (unlikely(!__pyx_t_28)) __PYX_ERR(0, 415, __pyx_L83_error)
+          __pyx_t_28 = __Pyx_PyObject_GetAttrStr(__pyx_t_27, __pyx_n_s_exc_info); if (unlikely(!__pyx_t_28)) __PYX_ERR(0, 420, __pyx_L83_error)
           __Pyx_GOTREF(__pyx_t_28);
           __Pyx_DECREF(__pyx_t_27); __pyx_t_27 = 0;
           __pyx_t_27 = NULL;
@@ -5462,10 +5480,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           }
           __pyx_t_26 = (__pyx_t_27) ? __Pyx_PyObject_CallOneArg(__pyx_t_28, __pyx_t_27) : __Pyx_PyObject_CallNoArg(__pyx_t_28);
           __Pyx_XDECREF(__pyx_t_27); __pyx_t_27 = 0;
-          if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 415, __pyx_L83_error)
+          if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 420, __pyx_L83_error)
           __Pyx_GOTREF(__pyx_t_26);
           __Pyx_DECREF(__pyx_t_28); __pyx_t_28 = 0;
-          __pyx_t_28 = __Pyx_GetItemInt(__pyx_t_26, 2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_28)) __PYX_ERR(0, 415, __pyx_L83_error)
+          __pyx_t_28 = __Pyx_GetItemInt(__pyx_t_26, 2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_28)) __PYX_ERR(0, 420, __pyx_L83_error)
           __Pyx_GOTREF(__pyx_t_28);
           __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
           __pyx_t_26 = NULL;
@@ -5483,7 +5501,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           #if CYTHON_FAST_PYCALL
           if (PyFunction_Check(__pyx_t_25)) {
             PyObject *__pyx_temp[3] = {__pyx_t_26, __pyx_v_exc, __pyx_t_28};
-            __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_25, __pyx_temp+1-__pyx_t_21, 2+__pyx_t_21); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 415, __pyx_L83_error)
+            __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_25, __pyx_temp+1-__pyx_t_21, 2+__pyx_t_21); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 420, __pyx_L83_error)
             __Pyx_XDECREF(__pyx_t_26); __pyx_t_26 = 0;
             __Pyx_GOTREF(__pyx_t_2);
             __Pyx_DECREF(__pyx_t_28); __pyx_t_28 = 0;
@@ -5492,14 +5510,14 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           #if CYTHON_FAST_PYCCALL
           if (__Pyx_PyFastCFunction_Check(__pyx_t_25)) {
             PyObject *__pyx_temp[3] = {__pyx_t_26, __pyx_v_exc, __pyx_t_28};
-            __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_25, __pyx_temp+1-__pyx_t_21, 2+__pyx_t_21); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 415, __pyx_L83_error)
+            __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_25, __pyx_temp+1-__pyx_t_21, 2+__pyx_t_21); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 420, __pyx_L83_error)
             __Pyx_XDECREF(__pyx_t_26); __pyx_t_26 = 0;
             __Pyx_GOTREF(__pyx_t_2);
             __Pyx_DECREF(__pyx_t_28); __pyx_t_28 = 0;
           } else
           #endif
           {
-            __pyx_t_27 = PyTuple_New(2+__pyx_t_21); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 415, __pyx_L83_error)
+            __pyx_t_27 = PyTuple_New(2+__pyx_t_21); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 420, __pyx_L83_error)
             __Pyx_GOTREF(__pyx_t_27);
             if (__pyx_t_26) {
               __Pyx_GIVEREF(__pyx_t_26); PyTuple_SET_ITEM(__pyx_t_27, 0, __pyx_t_26); __pyx_t_26 = NULL;
@@ -5510,17 +5528,17 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
             __Pyx_GIVEREF(__pyx_t_28);
             PyTuple_SET_ITEM(__pyx_t_27, 1+__pyx_t_21, __pyx_t_28);
             __pyx_t_28 = 0;
-            __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_25, __pyx_t_27, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 415, __pyx_L83_error)
+            __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_25, __pyx_t_27, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 420, __pyx_L83_error)
             __Pyx_GOTREF(__pyx_t_2);
             __Pyx_DECREF(__pyx_t_27); __pyx_t_27 = 0;
           }
           __Pyx_DECREF(__pyx_t_25); __pyx_t_25 = 0;
           __Pyx_Raise(__pyx_t_2, 0, 0, 0);
           __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-          __PYX_ERR(0, 415, __pyx_L83_error)
+          __PYX_ERR(0, 420, __pyx_L83_error)
         }
 
-        /* "aesara/scan/scan_perform.pyx":414
+        /* "aesara/scan/scan_perform.pyx":419
  *         try:
  *             fn()
  *         except Exception as exc:             # <<<<<<<<<<<<<<
@@ -5570,7 +5588,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       goto __pyx_L72_except_error;
       __pyx_L72_except_error:;
 
-      /* "aesara/scan/scan_perform.pyx":412
+      /* "aesara/scan/scan_perform.pyx":417
  *         t0_fn = time(NULL)
  * 
  *         try:             # <<<<<<<<<<<<<<
@@ -5585,7 +5603,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_L77_try_end:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":417
+    /* "aesara/scan/scan_perform.pyx":422
  *             raise InnerFunctionError(exc, sys.exc_info()[2])
  * 
  *         dt_fn = time(NULL) - t0_fn             # <<<<<<<<<<<<<<
@@ -5594,7 +5612,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_dt_fn = (time(NULL) - __pyx_v_t0_fn);
 
-    /* "aesara/scan/scan_perform.pyx":418
+    /* "aesara/scan/scan_perform.pyx":423
  * 
  *         dt_fn = time(NULL) - t0_fn
  *         t_fn += dt_fn             # <<<<<<<<<<<<<<
@@ -5603,7 +5621,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_t_fn = (__pyx_v_t_fn + __pyx_v_dt_fn);
 
-    /* "aesara/scan/scan_perform.pyx":419
+    /* "aesara/scan/scan_perform.pyx":424
  *         dt_fn = time(NULL) - t0_fn
  *         t_fn += dt_fn
  *         if as_while:             # <<<<<<<<<<<<<<
@@ -5613,7 +5631,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_5 = (__pyx_v_as_while != 0);
     if (__pyx_t_5) {
 
-      /* "aesara/scan/scan_perform.pyx":420
+      /* "aesara/scan/scan_perform.pyx":425
  *         t_fn += dt_fn
  *         if as_while:
  *             pdx = offset + n_shared_outs             # <<<<<<<<<<<<<<
@@ -5622,23 +5640,23 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       __pyx_v_pdx = (__pyx_v_offset + __pyx_v_n_shared_outs);
 
-      /* "aesara/scan/scan_perform.pyx":421
+      /* "aesara/scan/scan_perform.pyx":426
  *         if as_while:
  *             pdx = offset + n_shared_outs
  *             cond = inner_output_storage[pdx][0] == 0             # <<<<<<<<<<<<<<
  * 
  *         offset_out = 0
  */
-      __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_pdx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 421, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_pdx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 426, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_16 = __Pyx_PyInt_EqObjC(__pyx_t_3, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 421, __pyx_L1_error)
+      __pyx_t_16 = __Pyx_PyInt_EqObjC(__pyx_t_3, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 426, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_16);
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-      __pyx_t_29 = __Pyx_PyInt_As_int(__pyx_t_16); if (unlikely((__pyx_t_29 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 421, __pyx_L1_error)
+      __pyx_t_29 = __Pyx_PyInt_As_int(__pyx_t_16); if (unlikely((__pyx_t_29 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 426, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
       __pyx_v_cond = __pyx_t_29;
 
-      /* "aesara/scan/scan_perform.pyx":419
+      /* "aesara/scan/scan_perform.pyx":424
  *         dt_fn = time(NULL) - t0_fn
  *         t_fn += dt_fn
  *         if as_while:             # <<<<<<<<<<<<<<
@@ -5647,7 +5665,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     }
 
-    /* "aesara/scan/scan_perform.pyx":423
+    /* "aesara/scan/scan_perform.pyx":428
  *             cond = inner_output_storage[pdx][0] == 0
  * 
  *         offset_out = 0             # <<<<<<<<<<<<<<
@@ -5656,7 +5674,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_offset_out = 0;
 
-    /* "aesara/scan/scan_perform.pyx":426
+    /* "aesara/scan/scan_perform.pyx":431
  * 
  *         # 5.3 Copy over the values for mit_mot outputs
  *         mitmot_inp_offset = 0             # <<<<<<<<<<<<<<
@@ -5665,7 +5683,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_mitmot_inp_offset = 0;
 
-    /* "aesara/scan/scan_perform.pyx":427
+    /* "aesara/scan/scan_perform.pyx":432
  *         # 5.3 Copy over the values for mit_mot outputs
  *         mitmot_inp_offset = 0
  *         mitmot_out_idx = 0             # <<<<<<<<<<<<<<
@@ -5674,7 +5692,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_mitmot_out_idx = 0;
 
-    /* "aesara/scan/scan_perform.pyx":428
+    /* "aesara/scan/scan_perform.pyx":433
  *         mitmot_inp_offset = 0
  *         mitmot_out_idx = 0
  *         for j in range(n_mit_mot):             # <<<<<<<<<<<<<<
@@ -5686,7 +5704,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_j = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":430
+      /* "aesara/scan/scan_perform.pyx":435
  *         for j in range(n_mit_mot):
  * 
  *             pos_j = pos[j]             # <<<<<<<<<<<<<<
@@ -5696,19 +5714,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_17 = __pyx_v_j;
       __pyx_v_pos_j = (*((unsigned int *) ( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_17 * __pyx_v_pos.strides[0]) )));
 
-      /* "aesara/scan/scan_perform.pyx":431
+      /* "aesara/scan/scan_perform.pyx":436
  * 
  *             pos_j = pos[j]
  *             outer_outputs_j_0 = outer_outputs[j][0]             # <<<<<<<<<<<<<<
  * 
  *             for k in mit_mot_out_slices[j]:
  */
-      __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 431, __pyx_L1_error)
+      __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 436, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_16);
       __Pyx_XDECREF_SET(__pyx_v_outer_outputs_j_0, __pyx_t_16);
       __pyx_t_16 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":433
+      /* "aesara/scan/scan_perform.pyx":438
  *             outer_outputs_j_0 = outer_outputs[j][0]
  * 
  *             for k in mit_mot_out_slices[j]:             # <<<<<<<<<<<<<<
@@ -5719,26 +5737,26 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_t_16 = PyTuple_GET_ITEM(__pyx_v_mit_mot_out_slices, __pyx_v_j); __Pyx_INCREF(__pyx_t_16); __pyx_t_9 = 0;
         __pyx_t_20 = NULL;
       } else {
-        __pyx_t_9 = -1; __pyx_t_16 = PyObject_GetIter(PyTuple_GET_ITEM(__pyx_v_mit_mot_out_slices, __pyx_v_j)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 433, __pyx_L1_error)
+        __pyx_t_9 = -1; __pyx_t_16 = PyObject_GetIter(PyTuple_GET_ITEM(__pyx_v_mit_mot_out_slices, __pyx_v_j)); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 438, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
-        __pyx_t_20 = Py_TYPE(__pyx_t_16)->tp_iternext; if (unlikely(!__pyx_t_20)) __PYX_ERR(0, 433, __pyx_L1_error)
+        __pyx_t_20 = Py_TYPE(__pyx_t_16)->tp_iternext; if (unlikely(!__pyx_t_20)) __PYX_ERR(0, 438, __pyx_L1_error)
       }
       for (;;) {
         if (likely(!__pyx_t_20)) {
           if (likely(PyList_CheckExact(__pyx_t_16))) {
             if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_16)) break;
             #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-            __pyx_t_3 = PyList_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 433, __pyx_L1_error)
+            __pyx_t_3 = PyList_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 438, __pyx_L1_error)
             #else
-            __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 433, __pyx_L1_error)
+            __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 438, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_3);
             #endif
           } else {
             if (__pyx_t_9 >= PyTuple_GET_SIZE(__pyx_t_16)) break;
             #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-            __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 433, __pyx_L1_error)
+            __pyx_t_3 = PyTuple_GET_ITEM(__pyx_t_16, __pyx_t_9); __Pyx_INCREF(__pyx_t_3); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 438, __pyx_L1_error)
             #else
-            __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 433, __pyx_L1_error)
+            __pyx_t_3 = PySequence_ITEM(__pyx_t_16, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 438, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_3);
             #endif
           }
@@ -5748,17 +5766,17 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
             PyObject* exc_type = PyErr_Occurred();
             if (exc_type) {
               if (likely(__Pyx_PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-              else __PYX_ERR(0, 433, __pyx_L1_error)
+              else __PYX_ERR(0, 438, __pyx_L1_error)
             }
             break;
           }
           __Pyx_GOTREF(__pyx_t_3);
         }
-        __pyx_t_29 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_29 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 433, __pyx_L1_error)
+        __pyx_t_29 = __Pyx_PyInt_As_int(__pyx_t_3); if (unlikely((__pyx_t_29 == (int)-1) && PyErr_Occurred())) __PYX_ERR(0, 438, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         __pyx_v_k = __pyx_t_29;
 
-        /* "aesara/scan/scan_perform.pyx":434
+        /* "aesara/scan/scan_perform.pyx":439
  * 
  *             for k in mit_mot_out_slices[j]:
  *                 if mitmots_preallocated[mitmot_out_idx]:             # <<<<<<<<<<<<<<
@@ -5769,7 +5787,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_t_5 = ((*((npy_bool const  *) ( /* dim=0 */ (__pyx_v_mitmots_preallocated.data + __pyx_t_17 * __pyx_v_mitmots_preallocated.strides[0]) ))) != 0);
         if (__pyx_t_5) {
 
-          /* "aesara/scan/scan_perform.pyx":435
+          /* "aesara/scan/scan_perform.pyx":440
  *             for k in mit_mot_out_slices[j]:
  *                 if mitmots_preallocated[mitmot_out_idx]:
  *                     inp_idx = mitmot_inp_offset + mit_mot_out_to_tap_idx[mitmot_out_idx]             # <<<<<<<<<<<<<<
@@ -5779,7 +5797,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           __pyx_t_17 = __pyx_v_mitmot_out_idx;
           __pyx_v_inp_idx = (__pyx_v_mitmot_inp_offset + (*((unsigned int const  *) ( /* dim=0 */ (__pyx_v_mit_mot_out_to_tap_idx.data + __pyx_t_17 * __pyx_v_mit_mot_out_to_tap_idx.strides[0]) ))));
 
-          /* "aesara/scan/scan_perform.pyx":436
+          /* "aesara/scan/scan_perform.pyx":441
  *                 if mitmots_preallocated[mitmot_out_idx]:
  *                     inp_idx = mitmot_inp_offset + mit_mot_out_to_tap_idx[mitmot_out_idx]
  *                     inner_inp_idx = n_seqs + inp_idx             # <<<<<<<<<<<<<<
@@ -5788,7 +5806,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           __pyx_v_inner_inp_idx = (__pyx_v_n_seqs + __pyx_v_inp_idx);
 
-          /* "aesara/scan/scan_perform.pyx":440
+          /* "aesara/scan/scan_perform.pyx":445
  *                     # Verify whether the input points to the same data as
  *                     # it did before the execution of the inner function.
  *                     old_var = old_mitmot_input_storage[inp_idx]             # <<<<<<<<<<<<<<
@@ -5800,19 +5818,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           __Pyx_XDECREF_SET(__pyx_v_old_var, __pyx_t_3);
           __pyx_t_3 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":441
+          /* "aesara/scan/scan_perform.pyx":446
  *                     # it did before the execution of the inner function.
  *                     old_var = old_mitmot_input_storage[inp_idx]
  *                     new_var = inner_input_storage[inner_inp_idx][0]             # <<<<<<<<<<<<<<
  * 
  *                     # If the corresponding input storage has been replaced,
  */
-          __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_inner_inp_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 441, __pyx_L1_error)
+          __pyx_t_3 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_inner_inp_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 446, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_3);
           __Pyx_XDECREF_SET(__pyx_v_new_var, __pyx_t_3);
           __pyx_t_3 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":446
+          /* "aesara/scan/scan_perform.pyx":451
  *                     # recover the value as usual. Otherwise, the input was
  *                     # modified inplace and nothing needs to be done.
  *                     if old_var is not new_var or old_mitmot_input_data[inp_idx] != new_var.data:             # <<<<<<<<<<<<<<
@@ -5826,27 +5844,27 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
             __pyx_t_5 = __pyx_t_14;
             goto __pyx_L96_bool_binop_done;
           }
-          __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_new_var, __pyx_n_s_data); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 446, __pyx_L1_error)
+          __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_new_var, __pyx_n_s_data); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 451, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_3);
-          __pyx_t_1 = PyObject_RichCompare(PyList_GET_ITEM(__pyx_v_old_mitmot_input_data, __pyx_v_inp_idx), __pyx_t_3, Py_NE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 446, __pyx_L1_error)
+          __pyx_t_1 = PyObject_RichCompare(PyList_GET_ITEM(__pyx_v_old_mitmot_input_data, __pyx_v_inp_idx), __pyx_t_3, Py_NE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 451, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-          __pyx_t_14 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_14 < 0)) __PYX_ERR(0, 446, __pyx_L1_error)
+          __pyx_t_14 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_14 < 0)) __PYX_ERR(0, 451, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
           __pyx_t_5 = __pyx_t_14;
           __pyx_L96_bool_binop_done:;
           if (__pyx_t_5) {
 
-            /* "aesara/scan/scan_perform.pyx":448
+            /* "aesara/scan/scan_perform.pyx":453
  *                     if old_var is not new_var or old_mitmot_input_data[inp_idx] != new_var.data:
  *                         outer_outputs_j_0[<unsigned int>(k + pos_j)] = \
  *                             inner_input_storage[inner_inp_idx][0]             # <<<<<<<<<<<<<<
  *                 else:
  *                     # This output tap has not been preallocated, recover
  */
-            __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_inner_inp_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 448, __pyx_L1_error)
+            __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_input_storage, __pyx_v_inner_inp_idx), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 453, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_1);
 
-            /* "aesara/scan/scan_perform.pyx":447
+            /* "aesara/scan/scan_perform.pyx":452
  *                     # modified inplace and nothing needs to be done.
  *                     if old_var is not new_var or old_mitmot_input_data[inp_idx] != new_var.data:
  *                         outer_outputs_j_0[<unsigned int>(k + pos_j)] = \             # <<<<<<<<<<<<<<
@@ -5854,10 +5872,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *                 else:
  */
             __pyx_t_13 = ((unsigned int)(__pyx_v_k + __pyx_v_pos_j));
-            if (unlikely(__Pyx_SetItemInt(__pyx_v_outer_outputs_j_0, __pyx_t_13, __pyx_t_1, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 447, __pyx_L1_error)
+            if (unlikely(__Pyx_SetItemInt(__pyx_v_outer_outputs_j_0, __pyx_t_13, __pyx_t_1, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 452, __pyx_L1_error)
             __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-            /* "aesara/scan/scan_perform.pyx":446
+            /* "aesara/scan/scan_perform.pyx":451
  *                     # recover the value as usual. Otherwise, the input was
  *                     # modified inplace and nothing needs to be done.
  *                     if old_var is not new_var or old_mitmot_input_data[inp_idx] != new_var.data:             # <<<<<<<<<<<<<<
@@ -5866,7 +5884,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
           }
 
-          /* "aesara/scan/scan_perform.pyx":434
+          /* "aesara/scan/scan_perform.pyx":439
  * 
  *             for k in mit_mot_out_slices[j]:
  *                 if mitmots_preallocated[mitmot_out_idx]:             # <<<<<<<<<<<<<<
@@ -5876,7 +5894,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           goto __pyx_L94;
         }
 
-        /* "aesara/scan/scan_perform.pyx":453
+        /* "aesara/scan/scan_perform.pyx":458
  *                     # its value as usual
  *                     outer_outputs_j_0[<unsigned int>(k + pos_j)] = \
  *                             inner_output_storage[offset_out][0]             # <<<<<<<<<<<<<<
@@ -5884,10 +5902,10 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *                 offset_out += 1
  */
         /*else*/ {
-          __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_offset_out), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 453, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_offset_out), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 458, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
 
-          /* "aesara/scan/scan_perform.pyx":452
+          /* "aesara/scan/scan_perform.pyx":457
  *                     # This output tap has not been preallocated, recover
  *                     # its value as usual
  *                     outer_outputs_j_0[<unsigned int>(k + pos_j)] = \             # <<<<<<<<<<<<<<
@@ -5895,12 +5913,12 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  * 
  */
           __pyx_t_13 = ((unsigned int)(__pyx_v_k + __pyx_v_pos_j));
-          if (unlikely(__Pyx_SetItemInt(__pyx_v_outer_outputs_j_0, __pyx_t_13, __pyx_t_1, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 452, __pyx_L1_error)
+          if (unlikely(__Pyx_SetItemInt(__pyx_v_outer_outputs_j_0, __pyx_t_13, __pyx_t_1, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 457, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         }
         __pyx_L94:;
 
-        /* "aesara/scan/scan_perform.pyx":455
+        /* "aesara/scan/scan_perform.pyx":460
  *                             inner_output_storage[offset_out][0]
  * 
  *                 offset_out += 1             # <<<<<<<<<<<<<<
@@ -5909,7 +5927,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         __pyx_v_offset_out = (__pyx_v_offset_out + 1);
 
-        /* "aesara/scan/scan_perform.pyx":456
+        /* "aesara/scan/scan_perform.pyx":461
  * 
  *                 offset_out += 1
  *                 mitmot_out_idx += 1             # <<<<<<<<<<<<<<
@@ -5918,7 +5936,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         __pyx_v_mitmot_out_idx = (__pyx_v_mitmot_out_idx + 1);
 
-        /* "aesara/scan/scan_perform.pyx":433
+        /* "aesara/scan/scan_perform.pyx":438
  *             outer_outputs_j_0 = outer_outputs[j][0]
  * 
  *             for k in mit_mot_out_slices[j]:             # <<<<<<<<<<<<<<
@@ -5928,7 +5946,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       }
       __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":458
+      /* "aesara/scan/scan_perform.pyx":463
  *                 mitmot_out_idx += 1
  * 
  *             mitmot_inp_offset += tap_array_len[j]             # <<<<<<<<<<<<<<
@@ -5939,7 +5957,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_v_mitmot_inp_offset = (__pyx_v_mitmot_inp_offset + (*((unsigned int const  *) ( /* dim=0 */ (__pyx_v_tap_array_len.data + __pyx_t_17 * __pyx_v_tap_array_len.strides[0]) ))));
     }
 
-    /* "aesara/scan/scan_perform.pyx":461
+    /* "aesara/scan/scan_perform.pyx":466
  * 
  *         # 5.4 Copy over the values for mit_sot/sit_sot outputs
  *         begin = n_mit_mot             # <<<<<<<<<<<<<<
@@ -5948,7 +5966,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_begin = __pyx_v_n_mit_mot;
 
-    /* "aesara/scan/scan_perform.pyx":462
+    /* "aesara/scan/scan_perform.pyx":467
  *         # 5.4 Copy over the values for mit_sot/sit_sot outputs
  *         begin = n_mit_mot
  *         end   = n_outs             # <<<<<<<<<<<<<<
@@ -5957,7 +5975,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_end = __pyx_v_n_outs;
 
-    /* "aesara/scan/scan_perform.pyx":463
+    /* "aesara/scan/scan_perform.pyx":468
  *         begin = n_mit_mot
  *         end   = n_outs
  *         offset_out -= n_mit_mot             # <<<<<<<<<<<<<<
@@ -5966,7 +5984,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_offset_out = (__pyx_v_offset_out - __pyx_v_n_mit_mot);
 
-    /* "aesara/scan/scan_perform.pyx":465
+    /* "aesara/scan/scan_perform.pyx":470
  *         offset_out -= n_mit_mot
  * 
  *         for j in range(begin, end):             # <<<<<<<<<<<<<<
@@ -5978,7 +5996,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = __pyx_v_begin; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_j = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":467
+      /* "aesara/scan/scan_perform.pyx":472
  *         for j in range(begin, end):
  * 
  *             jout = j + offset_out             # <<<<<<<<<<<<<<
@@ -5987,7 +6005,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       __pyx_v_jout = (__pyx_v_j + __pyx_v_offset_out);
 
-      /* "aesara/scan/scan_perform.pyx":468
+      /* "aesara/scan/scan_perform.pyx":473
  * 
  *             jout = j + offset_out
  *             outer_outputs_j = outer_outputs[j]             # <<<<<<<<<<<<<<
@@ -5999,7 +6017,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __Pyx_XDECREF_SET(__pyx_v_outer_outputs_j, __pyx_t_16);
       __pyx_t_16 = 0;
 
-      /* "aesara/scan/scan_perform.pyx":471
+      /* "aesara/scan/scan_perform.pyx":476
  * 
  *             # Copy the output value to `outer_outputs`, if necessary
  *             if store_steps[j] == 1 or vector_outs[j] == 1:             # <<<<<<<<<<<<<<
@@ -6019,24 +6037,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_L101_bool_binop_done:;
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":472
+        /* "aesara/scan/scan_perform.pyx":477
  *             # Copy the output value to `outer_outputs`, if necessary
  *             if store_steps[j] == 1 or vector_outs[j] == 1:
  *                 outer_outputs_j[0][pos[j]] = inner_output_storage[jout][0]             # <<<<<<<<<<<<<<
  *             else:
  *                 # Check whether the initialization of the output storage map
  */
-        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 472, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 477, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
-        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_outer_outputs_j, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 472, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_outer_outputs_j, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 477, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __pyx_t_17 = __pyx_v_j;
         __pyx_t_13 = (*((unsigned int *) ( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_17 * __pyx_v_pos.strides[0]) )));
-        if (unlikely(__Pyx_SetItemInt(__pyx_t_1, __pyx_t_13, __pyx_t_16, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 472, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_t_1, __pyx_t_13, __pyx_t_16, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 477, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":471
+        /* "aesara/scan/scan_perform.pyx":476
  * 
  *             # Copy the output value to `outer_outputs`, if necessary
  *             if store_steps[j] == 1 or vector_outs[j] == 1:             # <<<<<<<<<<<<<<
@@ -6046,7 +6064,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L100;
       }
 
-      /* "aesara/scan/scan_perform.pyx":476
+      /* "aesara/scan/scan_perform.pyx":481
  *                 # Check whether the initialization of the output storage map
  *                 # for this output has been reused.
  *                 old_var = old_output_storage[jout]             # <<<<<<<<<<<<<<
@@ -6059,7 +6077,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __Pyx_XDECREF_SET(__pyx_v_old_var, __pyx_t_16);
         __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":477
+        /* "aesara/scan/scan_perform.pyx":482
  *                 # for this output has been reused.
  *                 old_var = old_output_storage[jout]
  *                 old_data = old_output_data[jout]             # <<<<<<<<<<<<<<
@@ -6071,19 +6089,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __Pyx_XDECREF_SET(__pyx_v_old_data, __pyx_t_16);
         __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":478
+        /* "aesara/scan/scan_perform.pyx":483
  *                 old_var = old_output_storage[jout]
  *                 old_data = old_output_data[jout]
  *                 new_var = inner_output_storage[jout][0]             # <<<<<<<<<<<<<<
  * 
  *                 if old_var is not new_var or old_data is None:
  */
-        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 478, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 483, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
         __Pyx_XDECREF_SET(__pyx_v_new_var, __pyx_t_16);
         __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":480
+        /* "aesara/scan/scan_perform.pyx":485
  *                 new_var = inner_output_storage[jout][0]
  * 
  *                 if old_var is not new_var or old_data is None:             # <<<<<<<<<<<<<<
@@ -6103,21 +6121,21 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_L104_bool_binop_done:;
         if (__pyx_t_5) {
 
-          /* "aesara/scan/scan_perform.pyx":481
+          /* "aesara/scan/scan_perform.pyx":486
  * 
  *                 if old_var is not new_var or old_data is None:
  *                     outer_outputs_j[0][pos[j]] = new_var             # <<<<<<<<<<<<<<
  * 
  *         # 5.5 Copy over the values for nit_sot outputs
  */
-          __pyx_t_16 = __Pyx_GetItemInt(__pyx_v_outer_outputs_j, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 481, __pyx_L1_error)
+          __pyx_t_16 = __Pyx_GetItemInt(__pyx_v_outer_outputs_j, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 486, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_16);
           __pyx_t_17 = __pyx_v_j;
           __pyx_t_13 = (*((unsigned int *) ( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_17 * __pyx_v_pos.strides[0]) )));
-          if (unlikely(__Pyx_SetItemInt(__pyx_t_16, __pyx_t_13, __pyx_v_new_var, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 481, __pyx_L1_error)
+          if (unlikely(__Pyx_SetItemInt(__pyx_t_16, __pyx_t_13, __pyx_v_new_var, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 486, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":480
+          /* "aesara/scan/scan_perform.pyx":485
  *                 new_var = inner_output_storage[jout][0]
  * 
  *                 if old_var is not new_var or old_data is None:             # <<<<<<<<<<<<<<
@@ -6129,7 +6147,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_L100:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":484
+    /* "aesara/scan/scan_perform.pyx":489
  * 
  *         # 5.5 Copy over the values for nit_sot outputs
  *         begin  = end             # <<<<<<<<<<<<<<
@@ -6138,7 +6156,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_begin = __pyx_v_end;
 
-    /* "aesara/scan/scan_perform.pyx":485
+    /* "aesara/scan/scan_perform.pyx":490
  *         # 5.5 Copy over the values for nit_sot outputs
  *         begin  = end
  *         end   += n_nit_sot             # <<<<<<<<<<<<<<
@@ -6147,7 +6165,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_end = (__pyx_v_end + __pyx_v_n_nit_sot);
 
-    /* "aesara/scan/scan_perform.pyx":486
+    /* "aesara/scan/scan_perform.pyx":491
  *         begin  = end
  *         end   += n_nit_sot
  *         for j in range(begin,end):             # <<<<<<<<<<<<<<
@@ -6159,7 +6177,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = __pyx_v_begin; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_j = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":488
+      /* "aesara/scan/scan_perform.pyx":493
  *         for j in range(begin,end):
  * 
  *             jout = j + offset_out             # <<<<<<<<<<<<<<
@@ -6168,7 +6186,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       __pyx_v_jout = (__pyx_v_j + __pyx_v_offset_out);
 
-      /* "aesara/scan/scan_perform.pyx":490
+      /* "aesara/scan/scan_perform.pyx":495
  *             jout = j + offset_out
  * 
  *             if i == 0:             # <<<<<<<<<<<<<<
@@ -6178,7 +6196,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_5 = ((__pyx_v_i == 0) != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":491
+        /* "aesara/scan/scan_perform.pyx":496
  * 
  *             if i == 0:
  *                 store_steps_j = store_steps[j]             # <<<<<<<<<<<<<<
@@ -6188,54 +6206,54 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_t_17 = __pyx_v_j;
         __pyx_v_store_steps_j = (*((unsigned int *) ( /* dim=0 */ (__pyx_v_store_steps.data + __pyx_t_17 * __pyx_v_store_steps.strides[0]) )));
 
-        /* "aesara/scan/scan_perform.pyx":492
+        /* "aesara/scan/scan_perform.pyx":497
  *             if i == 0:
  *                 store_steps_j = store_steps[j]
  *                 inner_output_storage_jout_0 = inner_output_storage[jout][0]             # <<<<<<<<<<<<<<
  *                 shape = (store_steps_j,) + inner_output_storage_jout_0.shape
  *                 dtype = inner_output_storage_jout_0.dtype
  */
-        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 492, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 497, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
         __Pyx_XDECREF_SET(__pyx_v_inner_output_storage_jout_0, __pyx_t_16);
         __pyx_t_16 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":493
+        /* "aesara/scan/scan_perform.pyx":498
  *                 store_steps_j = store_steps[j]
  *                 inner_output_storage_jout_0 = inner_output_storage[jout][0]
  *                 shape = (store_steps_j,) + inner_output_storage_jout_0.shape             # <<<<<<<<<<<<<<
  *                 dtype = inner_output_storage_jout_0.dtype
  *                 outer_outputs_j = outer_outputs[j]
  */
-        __pyx_t_16 = __Pyx_PyInt_From_unsigned_int(__pyx_v_store_steps_j); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 493, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_PyInt_From_unsigned_int(__pyx_v_store_steps_j); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 498, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
-        __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 493, __pyx_L1_error)
+        __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 498, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_GIVEREF(__pyx_t_16);
         PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_16);
         __pyx_t_16 = 0;
-        __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_v_inner_output_storage_jout_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 493, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_v_inner_output_storage_jout_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 498, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
-        __pyx_t_3 = PyNumber_Add(__pyx_t_1, __pyx_t_16); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 493, __pyx_L1_error)
+        __pyx_t_3 = PyNumber_Add(__pyx_t_1, __pyx_t_16); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 498, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         __Pyx_XDECREF_SET(__pyx_v_shape, __pyx_t_3);
         __pyx_t_3 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":494
+        /* "aesara/scan/scan_perform.pyx":499
  *                 inner_output_storage_jout_0 = inner_output_storage[jout][0]
  *                 shape = (store_steps_j,) + inner_output_storage_jout_0.shape
  *                 dtype = inner_output_storage_jout_0.dtype             # <<<<<<<<<<<<<<
  *                 outer_outputs_j = outer_outputs[j]
  *                 outer_outputs_j_0 = outer_outputs_j[0]
  */
-        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_inner_output_storage_jout_0, __pyx_n_s_dtype); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 494, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_inner_output_storage_jout_0, __pyx_n_s_dtype); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 499, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_XDECREF_SET(__pyx_v_dtype, __pyx_t_3);
         __pyx_t_3 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":495
+        /* "aesara/scan/scan_perform.pyx":500
  *                 shape = (store_steps_j,) + inner_output_storage_jout_0.shape
  *                 dtype = inner_output_storage_jout_0.dtype
  *                 outer_outputs_j = outer_outputs[j]             # <<<<<<<<<<<<<<
@@ -6247,19 +6265,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __Pyx_XDECREF_SET(__pyx_v_outer_outputs_j, __pyx_t_3);
         __pyx_t_3 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":496
+        /* "aesara/scan/scan_perform.pyx":501
  *                 dtype = inner_output_storage_jout_0.dtype
  *                 outer_outputs_j = outer_outputs[j]
  *                 outer_outputs_j_0 = outer_outputs_j[0]             # <<<<<<<<<<<<<<
  * 
  *                 if (
  */
-        __pyx_t_3 = __Pyx_GetItemInt(__pyx_v_outer_outputs_j, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 496, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_GetItemInt(__pyx_v_outer_outputs_j, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 501, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_XDECREF_SET(__pyx_v_outer_outputs_j_0, __pyx_t_3);
         __pyx_t_3 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":499
+        /* "aesara/scan/scan_perform.pyx":504
  * 
  *                 if (
  *                         outer_outputs_j_0 is None or             # <<<<<<<<<<<<<<
@@ -6274,24 +6292,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           goto __pyx_L110_bool_binop_done;
         }
 
-        /* "aesara/scan/scan_perform.pyx":500
+        /* "aesara/scan/scan_perform.pyx":505
  *                 if (
  *                         outer_outputs_j_0 is None or
  *                         outer_outputs_j_0.shape[0] < store_steps_j or             # <<<<<<<<<<<<<<
  *                         outer_outputs_j_0.shape[1:] != shape[1:] or
  *                         outer_outputs_j_0.dtype != dtype
  */
-        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_j_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 500, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_j_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 505, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_16 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 500, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 505, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-        __pyx_t_3 = __Pyx_PyInt_From_unsigned_int(__pyx_v_store_steps_j); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 500, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyInt_From_unsigned_int(__pyx_v_store_steps_j); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 505, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_1 = PyObject_RichCompare(__pyx_t_16, __pyx_t_3, Py_LT); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 500, __pyx_L1_error)
+        __pyx_t_1 = PyObject_RichCompare(__pyx_t_16, __pyx_t_3, Py_LT); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 505, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-        __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 500, __pyx_L1_error)
+        __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 505, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         if (!__pyx_t_15) {
         } else {
@@ -6299,24 +6317,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           goto __pyx_L110_bool_binop_done;
         }
 
-        /* "aesara/scan/scan_perform.pyx":501
+        /* "aesara/scan/scan_perform.pyx":506
  *                         outer_outputs_j_0 is None or
  *                         outer_outputs_j_0.shape[0] < store_steps_j or
  *                         outer_outputs_j_0.shape[1:] != shape[1:] or             # <<<<<<<<<<<<<<
  *                         outer_outputs_j_0.dtype != dtype
  *                     ):
  */
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_j_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 501, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_j_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 506, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_t_1, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 501, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_t_1, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 506, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_shape, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 501, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_shape, 1, 0, NULL, NULL, &__pyx_slice_, 1, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 506, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_16 = PyObject_RichCompare(__pyx_t_3, __pyx_t_1, Py_NE); __Pyx_XGOTREF(__pyx_t_16); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 501, __pyx_L1_error)
+        __pyx_t_16 = PyObject_RichCompare(__pyx_t_3, __pyx_t_1, Py_NE); __Pyx_XGOTREF(__pyx_t_16); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 506, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_16); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 501, __pyx_L1_error)
+        __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_16); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 506, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
         if (!__pyx_t_15) {
         } else {
@@ -6324,23 +6342,23 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           goto __pyx_L110_bool_binop_done;
         }
 
-        /* "aesara/scan/scan_perform.pyx":502
+        /* "aesara/scan/scan_perform.pyx":507
  *                         outer_outputs_j_0.shape[0] < store_steps_j or
  *                         outer_outputs_j_0.shape[1:] != shape[1:] or
  *                         outer_outputs_j_0.dtype != dtype             # <<<<<<<<<<<<<<
  *                     ):
  *                     new_outer_outputs_j_0 = numpy.empty(shape, dtype=outer_output_dtypes[j])
  */
-        __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_j_0, __pyx_n_s_dtype); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 502, __pyx_L1_error)
+        __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_j_0, __pyx_n_s_dtype); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 507, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_16);
-        __pyx_t_1 = PyObject_RichCompare(__pyx_t_16, __pyx_v_dtype, Py_NE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 502, __pyx_L1_error)
+        __pyx_t_1 = PyObject_RichCompare(__pyx_t_16, __pyx_v_dtype, Py_NE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 507, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-        __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 502, __pyx_L1_error)
+        __pyx_t_15 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 507, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __pyx_t_5 = __pyx_t_15;
         __pyx_L110_bool_binop_done:;
 
-        /* "aesara/scan/scan_perform.pyx":498
+        /* "aesara/scan/scan_perform.pyx":503
  *                 outer_outputs_j_0 = outer_outputs_j[0]
  * 
  *                 if (             # <<<<<<<<<<<<<<
@@ -6349,27 +6367,27 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         if (__pyx_t_5) {
 
-          /* "aesara/scan/scan_perform.pyx":504
+          /* "aesara/scan/scan_perform.pyx":509
  *                         outer_outputs_j_0.dtype != dtype
  *                     ):
  *                     new_outer_outputs_j_0 = numpy.empty(shape, dtype=outer_output_dtypes[j])             # <<<<<<<<<<<<<<
  *                 elif outer_outputs_j_0.shape[0] != store_steps_j:
  *                     new_outer_outputs_j_0 = outer_outputs_j_0[:store_steps_j]
  */
-          __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_numpy); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 504, __pyx_L1_error)
+          __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_numpy); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 509, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
-          __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_empty); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 504, __pyx_L1_error)
+          __pyx_t_16 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_empty); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 509, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_16);
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 504, __pyx_L1_error)
+          __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 509, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __Pyx_INCREF(__pyx_v_shape);
           __Pyx_GIVEREF(__pyx_v_shape);
           PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_v_shape);
-          __pyx_t_3 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 504, __pyx_L1_error)
+          __pyx_t_3 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 509, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_3);
-          if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, PyTuple_GET_ITEM(__pyx_v_outer_output_dtypes, __pyx_v_j)) < 0) __PYX_ERR(0, 504, __pyx_L1_error)
-          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_16, __pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 504, __pyx_L1_error)
+          if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, PyTuple_GET_ITEM(__pyx_v_outer_output_dtypes, __pyx_v_j)) < 0) __PYX_ERR(0, 509, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_16, __pyx_t_1, __pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 509, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_2);
           __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
@@ -6377,7 +6395,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           __Pyx_XDECREF_SET(__pyx_v_new_outer_outputs_j_0, __pyx_t_2);
           __pyx_t_2 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":498
+          /* "aesara/scan/scan_perform.pyx":503
  *                 outer_outputs_j_0 = outer_outputs_j[0]
  * 
  *                 if (             # <<<<<<<<<<<<<<
@@ -6387,40 +6405,40 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           goto __pyx_L109;
         }
 
-        /* "aesara/scan/scan_perform.pyx":505
+        /* "aesara/scan/scan_perform.pyx":510
  *                     ):
  *                     new_outer_outputs_j_0 = numpy.empty(shape, dtype=outer_output_dtypes[j])
  *                 elif outer_outputs_j_0.shape[0] != store_steps_j:             # <<<<<<<<<<<<<<
  *                     new_outer_outputs_j_0 = outer_outputs_j_0[:store_steps_j]
  *                 else:
  */
-        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_j_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 505, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_j_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 510, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_2, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 505, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_2, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 510, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        __pyx_t_2 = __Pyx_PyInt_From_unsigned_int(__pyx_v_store_steps_j); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 505, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyInt_From_unsigned_int(__pyx_v_store_steps_j); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 510, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_1 = PyObject_RichCompare(__pyx_t_3, __pyx_t_2, Py_NE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 505, __pyx_L1_error)
+        __pyx_t_1 = PyObject_RichCompare(__pyx_t_3, __pyx_t_2, Py_NE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 510, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-        __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 505, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_5 < 0)) __PYX_ERR(0, 510, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         if (__pyx_t_5) {
 
-          /* "aesara/scan/scan_perform.pyx":506
+          /* "aesara/scan/scan_perform.pyx":511
  *                     new_outer_outputs_j_0 = numpy.empty(shape, dtype=outer_output_dtypes[j])
  *                 elif outer_outputs_j_0.shape[0] != store_steps_j:
  *                     new_outer_outputs_j_0 = outer_outputs_j_0[:store_steps_j]             # <<<<<<<<<<<<<<
  *                 else:
  *                     new_outer_outputs_j_0 = outer_outputs_j_0
  */
-          __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_j_0, 0, __pyx_v_store_steps_j, NULL, NULL, NULL, 0, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 506, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_j_0, 0, __pyx_v_store_steps_j, NULL, NULL, NULL, 0, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 511, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __Pyx_XDECREF_SET(__pyx_v_new_outer_outputs_j_0, __pyx_t_1);
           __pyx_t_1 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":505
+          /* "aesara/scan/scan_perform.pyx":510
  *                     ):
  *                     new_outer_outputs_j_0 = numpy.empty(shape, dtype=outer_output_dtypes[j])
  *                 elif outer_outputs_j_0.shape[0] != store_steps_j:             # <<<<<<<<<<<<<<
@@ -6430,7 +6448,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
           goto __pyx_L109;
         }
 
-        /* "aesara/scan/scan_perform.pyx":508
+        /* "aesara/scan/scan_perform.pyx":513
  *                     new_outer_outputs_j_0 = outer_outputs_j_0[:store_steps_j]
  *                 else:
  *                     new_outer_outputs_j_0 = outer_outputs_j_0             # <<<<<<<<<<<<<<
@@ -6443,7 +6461,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         }
         __pyx_L109:;
 
-        /* "aesara/scan/scan_perform.pyx":510
+        /* "aesara/scan/scan_perform.pyx":515
  *                     new_outer_outputs_j_0 = outer_outputs_j_0
  * 
  *                 new_outer_outputs_j_0[pos[j]] = inner_output_storage_jout_0             # <<<<<<<<<<<<<<
@@ -6452,18 +6470,18 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
         __pyx_t_17 = __pyx_v_j;
         __pyx_t_13 = (*((unsigned int *) ( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_17 * __pyx_v_pos.strides[0]) )));
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_new_outer_outputs_j_0, __pyx_t_13, __pyx_v_inner_output_storage_jout_0, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 510, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_new_outer_outputs_j_0, __pyx_t_13, __pyx_v_inner_output_storage_jout_0, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 515, __pyx_L1_error)
 
-        /* "aesara/scan/scan_perform.pyx":512
+        /* "aesara/scan/scan_perform.pyx":517
  *                 new_outer_outputs_j_0[pos[j]] = inner_output_storage_jout_0
  * 
  *                 outer_outputs_j[0] = new_outer_outputs_j_0             # <<<<<<<<<<<<<<
  *             elif store_steps[j] == 1 or vector_outs[j] == 1:
  *                 outer_outputs[j][0][pos[j]] = inner_output_storage[jout][0]
  */
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_outer_outputs_j, 0, __pyx_v_new_outer_outputs_j_0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 512, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_outer_outputs_j, 0, __pyx_v_new_outer_outputs_j_0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 517, __pyx_L1_error)
 
-        /* "aesara/scan/scan_perform.pyx":490
+        /* "aesara/scan/scan_perform.pyx":495
  *             jout = j + offset_out
  * 
  *             if i == 0:             # <<<<<<<<<<<<<<
@@ -6473,7 +6491,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L108;
       }
 
-      /* "aesara/scan/scan_perform.pyx":513
+      /* "aesara/scan/scan_perform.pyx":518
  * 
  *                 outer_outputs_j[0] = new_outer_outputs_j_0
  *             elif store_steps[j] == 1 or vector_outs[j] == 1:             # <<<<<<<<<<<<<<
@@ -6493,24 +6511,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_L114_bool_binop_done:;
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":514
+        /* "aesara/scan/scan_perform.pyx":519
  *                 outer_outputs_j[0] = new_outer_outputs_j_0
  *             elif store_steps[j] == 1 or vector_outs[j] == 1:
  *                 outer_outputs[j][0][pos[j]] = inner_output_storage[jout][0]             # <<<<<<<<<<<<<<
  *             else:
  *                 # Check whether the initialization of the output storage map
  */
-        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 514, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 519, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 514, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 519, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
         __pyx_t_17 = __pyx_v_j;
         __pyx_t_13 = (*((unsigned int *) ( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_17 * __pyx_v_pos.strides[0]) )));
-        if (unlikely(__Pyx_SetItemInt(__pyx_t_2, __pyx_t_13, __pyx_t_1, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 514, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_t_2, __pyx_t_13, __pyx_t_1, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 519, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":513
+        /* "aesara/scan/scan_perform.pyx":518
  * 
  *                 outer_outputs_j[0] = new_outer_outputs_j_0
  *             elif store_steps[j] == 1 or vector_outs[j] == 1:             # <<<<<<<<<<<<<<
@@ -6520,7 +6538,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L108;
       }
 
-      /* "aesara/scan/scan_perform.pyx":518
+      /* "aesara/scan/scan_perform.pyx":523
  *                 # Check whether the initialization of the output storage map
  *                 # for this output has been reused.
  *                 old_var = old_output_storage[jout]             # <<<<<<<<<<<<<<
@@ -6533,7 +6551,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __Pyx_XDECREF_SET(__pyx_v_old_var, __pyx_t_1);
         __pyx_t_1 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":519
+        /* "aesara/scan/scan_perform.pyx":524
  *                 # for this output has been reused.
  *                 old_var = old_output_storage[jout]
  *                 old_data = old_output_data[jout]             # <<<<<<<<<<<<<<
@@ -6545,19 +6563,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __Pyx_XDECREF_SET(__pyx_v_old_data, __pyx_t_1);
         __pyx_t_1 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":520
+        /* "aesara/scan/scan_perform.pyx":525
  *                 old_var = old_output_storage[jout]
  *                 old_data = old_output_data[jout]
  *                 new_var = inner_output_storage[jout][0]             # <<<<<<<<<<<<<<
  * 
  *                 if old_var is not new_var or old_data is None:
  */
-        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 520, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 525, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_XDECREF_SET(__pyx_v_new_var, __pyx_t_1);
         __pyx_t_1 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":522
+        /* "aesara/scan/scan_perform.pyx":527
  *                 new_var = inner_output_storage[jout][0]
  * 
  *                 if old_var is not new_var or old_data is None:             # <<<<<<<<<<<<<<
@@ -6577,21 +6595,21 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         __pyx_L117_bool_binop_done:;
         if (__pyx_t_5) {
 
-          /* "aesara/scan/scan_perform.pyx":523
+          /* "aesara/scan/scan_perform.pyx":528
  * 
  *                 if old_var is not new_var or old_data is None:
  *                     outer_outputs[j][0][pos[j]] = new_var             # <<<<<<<<<<<<<<
  * 
  *         # 5.6 Copy over the values for outputs corresponding to shared
  */
-          __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 523, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 528, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __pyx_t_17 = __pyx_v_j;
           __pyx_t_13 = (*((unsigned int *) ( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_17 * __pyx_v_pos.strides[0]) )));
-          if (unlikely(__Pyx_SetItemInt(__pyx_t_1, __pyx_t_13, __pyx_v_new_var, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 523, __pyx_L1_error)
+          if (unlikely(__Pyx_SetItemInt(__pyx_t_1, __pyx_t_13, __pyx_v_new_var, unsigned int, 0, __Pyx_PyInt_From_unsigned_int, 0, 0, 0) < 0)) __PYX_ERR(0, 528, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-          /* "aesara/scan/scan_perform.pyx":522
+          /* "aesara/scan/scan_perform.pyx":527
  *                 new_var = inner_output_storage[jout][0]
  * 
  *                 if old_var is not new_var or old_data is None:             # <<<<<<<<<<<<<<
@@ -6603,7 +6621,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_L108:;
     }
 
-    /* "aesara/scan/scan_perform.pyx":527
+    /* "aesara/scan/scan_perform.pyx":532
  *         # 5.6 Copy over the values for outputs corresponding to shared
  *         # variables
  *         begin  = end             # <<<<<<<<<<<<<<
@@ -6612,7 +6630,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_begin = __pyx_v_end;
 
-    /* "aesara/scan/scan_perform.pyx":528
+    /* "aesara/scan/scan_perform.pyx":533
  *         # variables
  *         begin  = end
  *         end   += n_shared_outs             # <<<<<<<<<<<<<<
@@ -6621,7 +6639,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
     __pyx_v_end = (__pyx_v_end + __pyx_v_n_shared_outs);
 
-    /* "aesara/scan/scan_perform.pyx":529
+    /* "aesara/scan/scan_perform.pyx":534
  *         begin  = end
  *         end   += n_shared_outs
  *         for j in range(begin,end):             # <<<<<<<<<<<<<<
@@ -6633,7 +6651,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = __pyx_v_begin; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_j = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":530
+      /* "aesara/scan/scan_perform.pyx":535
  *         end   += n_shared_outs
  *         for j in range(begin,end):
  *             jout = j +offset_out             # <<<<<<<<<<<<<<
@@ -6642,20 +6660,20 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       __pyx_v_jout = (__pyx_v_j + __pyx_v_offset_out);
 
-      /* "aesara/scan/scan_perform.pyx":531
+      /* "aesara/scan/scan_perform.pyx":536
  *         for j in range(begin,end):
  *             jout = j +offset_out
  *             outer_outputs[j][0] = inner_output_storage[jout][0]             # <<<<<<<<<<<<<<
  * 
  *         for idx in range(lenpos):
  */
-      __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 531, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_GetItemInt(PyList_GET_ITEM(__pyx_v_inner_output_storage, __pyx_v_jout), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 536, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, __pyx_t_1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 531, __pyx_L1_error)
+      if (unlikely(__Pyx_SetItemInt(PyList_GET_ITEM(__pyx_v_outer_outputs, __pyx_v_j), 0, __pyx_t_1, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 536, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     }
 
-    /* "aesara/scan/scan_perform.pyx":533
+    /* "aesara/scan/scan_perform.pyx":538
  *             outer_outputs[j][0] = inner_output_storage[jout][0]
  * 
  *         for idx in range(lenpos):             # <<<<<<<<<<<<<<
@@ -6667,7 +6685,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_idx = __pyx_t_7;
 
-      /* "aesara/scan/scan_perform.pyx":534
+      /* "aesara/scan/scan_perform.pyx":539
  * 
  *         for idx in range(lenpos):
  *             pos[idx] = pymod(pos[idx] + 1, store_steps[idx])             # <<<<<<<<<<<<<<
@@ -6680,7 +6698,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       *((unsigned int *) ( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_18 * __pyx_v_pos.strides[0]) )) = __pyx_f_6aesara_4scan_12scan_perform_pymod(((*((unsigned int *) ( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_17 * __pyx_v_pos.strides[0]) ))) + 1), (*((unsigned int *) ( /* dim=0 */ (__pyx_v_store_steps.data + __pyx_t_12 * __pyx_v_store_steps.strides[0]) ))));
     }
 
-    /* "aesara/scan/scan_perform.pyx":536
+    /* "aesara/scan/scan_perform.pyx":541
  *             pos[idx] = pymod(pos[idx] + 1, store_steps[idx])
  * 
  *         i = i + 1             # <<<<<<<<<<<<<<
@@ -6690,7 +6708,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_v_i = (__pyx_v_i + 1);
   }
 
-  /* "aesara/scan/scan_perform.pyx":539
+  /* "aesara/scan/scan_perform.pyx":544
  * 
  *     # 6. Check if you need to re-order output buffers
  *     begin = n_mit_mot             # <<<<<<<<<<<<<<
@@ -6699,7 +6717,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_begin = __pyx_v_n_mit_mot;
 
-  /* "aesara/scan/scan_perform.pyx":540
+  /* "aesara/scan/scan_perform.pyx":545
  *     # 6. Check if you need to re-order output buffers
  *     begin = n_mit_mot
  *     end   = n_outs + n_nit_sot             # <<<<<<<<<<<<<<
@@ -6708,7 +6726,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
   __pyx_v_end = (__pyx_v_n_outs + __pyx_v_n_nit_sot);
 
-  /* "aesara/scan/scan_perform.pyx":541
+  /* "aesara/scan/scan_perform.pyx":546
  *     begin = n_mit_mot
  *     end   = n_outs + n_nit_sot
  *     for idx in range(begin, end):             # <<<<<<<<<<<<<<
@@ -6720,7 +6738,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   for (__pyx_t_7 = __pyx_v_begin; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
     __pyx_v_idx = __pyx_t_7;
 
-    /* "aesara/scan/scan_perform.pyx":542
+    /* "aesara/scan/scan_perform.pyx":547
  *     end   = n_outs + n_nit_sot
  *     for idx in range(begin, end):
  *         outer_outputs_idx = outer_outputs[idx]             # <<<<<<<<<<<<<<
@@ -6732,19 +6750,19 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __Pyx_XDECREF_SET(__pyx_v_outer_outputs_idx, __pyx_t_1);
     __pyx_t_1 = 0;
 
-    /* "aesara/scan/scan_perform.pyx":543
+    /* "aesara/scan/scan_perform.pyx":548
  *     for idx in range(begin, end):
  *         outer_outputs_idx = outer_outputs[idx]
  *         outer_outputs_idx_0 = outer_outputs_idx[0]             # <<<<<<<<<<<<<<
  * 
  *         store_steps_idx = store_steps[idx]
  */
-    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_outer_outputs_idx, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 543, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_outer_outputs_idx, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 548, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_XDECREF_SET(__pyx_v_outer_outputs_idx_0, __pyx_t_1);
     __pyx_t_1 = 0;
 
-    /* "aesara/scan/scan_perform.pyx":545
+    /* "aesara/scan/scan_perform.pyx":550
  *         outer_outputs_idx_0 = outer_outputs_idx[0]
  * 
  *         store_steps_idx = store_steps[idx]             # <<<<<<<<<<<<<<
@@ -6754,7 +6772,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_12 = __pyx_v_idx;
     __pyx_v_store_steps_idx = (*((unsigned int *) ( /* dim=0 */ (__pyx_v_store_steps.data + __pyx_t_12 * __pyx_v_store_steps.strides[0]) )));
 
-    /* "aesara/scan/scan_perform.pyx":546
+    /* "aesara/scan/scan_perform.pyx":551
  * 
  *         store_steps_idx = store_steps[idx]
  *         mintaps_idx = mintaps[idx]             # <<<<<<<<<<<<<<
@@ -6764,7 +6782,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_12 = __pyx_v_idx;
     __pyx_v_mintaps_idx = (*((int const  *) ( /* dim=0 */ (__pyx_v_mintaps.data + __pyx_t_12 * __pyx_v_mintaps.strides[0]) )));
 
-    /* "aesara/scan/scan_perform.pyx":548
+    /* "aesara/scan/scan_perform.pyx":553
  *         mintaps_idx = mintaps[idx]
  * 
  *         pdx = pos[idx]             # <<<<<<<<<<<<<<
@@ -6774,7 +6792,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_12 = __pyx_v_idx;
     __pyx_v_pdx = (*((unsigned int *) ( /* dim=0 */ (__pyx_v_pos.data + __pyx_t_12 * __pyx_v_pos.strides[0]) )));
 
-    /* "aesara/scan/scan_perform.pyx":550
+    /* "aesara/scan/scan_perform.pyx":555
  *         pdx = pos[idx]
  * 
  *         if (store_steps_idx < i - mintaps_idx and pdx < store_steps_idx ):             # <<<<<<<<<<<<<<
@@ -6792,7 +6810,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_L126_bool_binop_done:;
     if (__pyx_t_5) {
 
-      /* "aesara/scan/scan_perform.pyx":551
+      /* "aesara/scan/scan_perform.pyx":556
  * 
  *         if (store_steps_idx < i - mintaps_idx and pdx < store_steps_idx ):
  *             if pdx >= store_steps_idx // 2 :             # <<<<<<<<<<<<<<
@@ -6802,16 +6820,16 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_5 = ((__pyx_v_pdx >= (__pyx_v_store_steps_idx / 2)) != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":558
+        /* "aesara/scan/scan_perform.pyx":563
  *                 # This way, there will be no information overwritten
  *                 # before it is read (as it used to happen).
  *                 tmp = outer_outputs_idx_0[:pdx].copy()             # <<<<<<<<<<<<<<
  *                 outer_outputs_idx_0[:store_steps_idx - pdx] = outer_outputs_idx_0[pdx:]
  *                 outer_outputs_idx_0[store_steps_idx - pdx:] = tmp
  */
-        __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_idx_0, 0, __pyx_v_pdx, NULL, NULL, NULL, 0, 1, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 558, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_idx_0, 0, __pyx_v_pdx, NULL, NULL, NULL, 0, 1, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 563, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_copy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 558, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_copy); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 563, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
         __pyx_t_2 = NULL;
@@ -6826,34 +6844,34 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         }
         __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2) : __Pyx_PyObject_CallNoArg(__pyx_t_3);
         __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-        if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 558, __pyx_L1_error)
+        if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 563, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         __Pyx_XDECREF_SET(__pyx_v_tmp, __pyx_t_1);
         __pyx_t_1 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":559
+        /* "aesara/scan/scan_perform.pyx":564
  *                 # before it is read (as it used to happen).
  *                 tmp = outer_outputs_idx_0[:pdx].copy()
  *                 outer_outputs_idx_0[:store_steps_idx - pdx] = outer_outputs_idx_0[pdx:]             # <<<<<<<<<<<<<<
  *                 outer_outputs_idx_0[store_steps_idx - pdx:] = tmp
  *             else:
  */
-        __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_idx_0, __pyx_v_pdx, 0, NULL, NULL, NULL, 1, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 559, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_idx_0, __pyx_v_pdx, 0, NULL, NULL, NULL, 1, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 564, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_t_1, 0, (__pyx_v_store_steps_idx - __pyx_v_pdx), NULL, NULL, NULL, 0, 1, 0) < 0) __PYX_ERR(0, 559, __pyx_L1_error)
+        if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_t_1, 0, (__pyx_v_store_steps_idx - __pyx_v_pdx), NULL, NULL, NULL, 0, 1, 0) < 0) __PYX_ERR(0, 564, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":560
+        /* "aesara/scan/scan_perform.pyx":565
  *                 tmp = outer_outputs_idx_0[:pdx].copy()
  *                 outer_outputs_idx_0[:store_steps_idx - pdx] = outer_outputs_idx_0[pdx:]
  *                 outer_outputs_idx_0[store_steps_idx - pdx:] = tmp             # <<<<<<<<<<<<<<
  *             else:
  *                 tmp = outer_outputs_idx_0[pdx:].copy()
  */
-        if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_v_tmp, (__pyx_v_store_steps_idx - __pyx_v_pdx), 0, NULL, NULL, NULL, 1, 0, 0) < 0) __PYX_ERR(0, 560, __pyx_L1_error)
+        if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_v_tmp, (__pyx_v_store_steps_idx - __pyx_v_pdx), 0, NULL, NULL, NULL, 1, 0, 0) < 0) __PYX_ERR(0, 565, __pyx_L1_error)
 
-        /* "aesara/scan/scan_perform.pyx":551
+        /* "aesara/scan/scan_perform.pyx":556
  * 
  *         if (store_steps_idx < i - mintaps_idx and pdx < store_steps_idx ):
  *             if pdx >= store_steps_idx // 2 :             # <<<<<<<<<<<<<<
@@ -6863,7 +6881,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         goto __pyx_L128;
       }
 
-      /* "aesara/scan/scan_perform.pyx":562
+      /* "aesara/scan/scan_perform.pyx":567
  *                 outer_outputs_idx_0[store_steps_idx - pdx:] = tmp
  *             else:
  *                 tmp = outer_outputs_idx_0[pdx:].copy()             # <<<<<<<<<<<<<<
@@ -6871,9 +6889,9 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  *                 outer_outputs_idx_0[:store_steps_idx - pdx] = tmp
  */
       /*else*/ {
-        __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_idx_0, __pyx_v_pdx, 0, NULL, NULL, NULL, 1, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 562, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_idx_0, __pyx_v_pdx, 0, NULL, NULL, NULL, 1, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 567, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_copy); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 562, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_copy); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 567, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         __pyx_t_3 = NULL;
@@ -6888,36 +6906,36 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
         }
         __pyx_t_1 = (__pyx_t_3) ? __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_3) : __Pyx_PyObject_CallNoArg(__pyx_t_2);
         __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
-        if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 562, __pyx_L1_error)
+        if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 567, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
         __Pyx_XDECREF_SET(__pyx_v_tmp, __pyx_t_1);
         __pyx_t_1 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":563
+        /* "aesara/scan/scan_perform.pyx":568
  *             else:
  *                 tmp = outer_outputs_idx_0[pdx:].copy()
  *                 outer_outputs_idx_0[store_steps_idx - pdx:] = outer_outputs_idx_0[:pdx]             # <<<<<<<<<<<<<<
  *                 outer_outputs_idx_0[:store_steps_idx - pdx] = tmp
  * 
  */
-        __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_idx_0, 0, __pyx_v_pdx, NULL, NULL, NULL, 0, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 563, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_idx_0, 0, __pyx_v_pdx, NULL, NULL, NULL, 0, 1, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 568, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_t_1, (__pyx_v_store_steps_idx - __pyx_v_pdx), 0, NULL, NULL, NULL, 1, 0, 0) < 0) __PYX_ERR(0, 563, __pyx_L1_error)
+        if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_t_1, (__pyx_v_store_steps_idx - __pyx_v_pdx), 0, NULL, NULL, NULL, 1, 0, 0) < 0) __PYX_ERR(0, 568, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":564
+        /* "aesara/scan/scan_perform.pyx":569
  *                 tmp = outer_outputs_idx_0[pdx:].copy()
  *                 outer_outputs_idx_0[store_steps_idx - pdx:] = outer_outputs_idx_0[:pdx]
  *                 outer_outputs_idx_0[:store_steps_idx - pdx] = tmp             # <<<<<<<<<<<<<<
  * 
  *         # This would normally happen only when doing truncated
  */
-        if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_v_tmp, 0, (__pyx_v_store_steps_idx - __pyx_v_pdx), NULL, NULL, NULL, 0, 1, 0) < 0) __PYX_ERR(0, 564, __pyx_L1_error)
+        if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_v_tmp, 0, (__pyx_v_store_steps_idx - __pyx_v_pdx), NULL, NULL, NULL, 0, 1, 0) < 0) __PYX_ERR(0, 569, __pyx_L1_error)
       }
       __pyx_L128:;
 
-      /* "aesara/scan/scan_perform.pyx":550
+      /* "aesara/scan/scan_perform.pyx":555
  *         pdx = pos[idx]
  * 
  *         if (store_steps_idx < i - mintaps_idx and pdx < store_steps_idx ):             # <<<<<<<<<<<<<<
@@ -6927,7 +6945,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       goto __pyx_L125;
     }
 
-    /* "aesara/scan/scan_perform.pyx":570
+    /* "aesara/scan/scan_perform.pyx":575
  *         # expected to return 0 for all entries for which the gradient is
  *         # not actually computed
  *         elif store_steps_idx > i - mintaps_idx:             # <<<<<<<<<<<<<<
@@ -6937,16 +6955,16 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_t_5 = ((__pyx_v_store_steps_idx > (__pyx_v_i - __pyx_v_mintaps_idx)) != 0);
     if (__pyx_t_5) {
 
-      /* "aesara/scan/scan_perform.pyx":571
+      /* "aesara/scan/scan_perform.pyx":576
  *         # not actually computed
  *         elif store_steps_idx > i - mintaps_idx:
  *             outer_outputs_idx_0[i - mintaps_idx:] = 0             # <<<<<<<<<<<<<<
  * 
  *             # This is a fix for a bug introduced by while. If you say
  */
-      if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_int_0, (__pyx_v_i - __pyx_v_mintaps_idx), 0, NULL, NULL, NULL, 1, 0, 0) < 0) __PYX_ERR(0, 571, __pyx_L1_error)
+      if (__Pyx_PyObject_SetSlice(__pyx_v_outer_outputs_idx_0, __pyx_int_0, (__pyx_v_i - __pyx_v_mintaps_idx), 0, NULL, NULL, NULL, 1, 0, 0) < 0) __PYX_ERR(0, 576, __pyx_L1_error)
 
-      /* "aesara/scan/scan_perform.pyx":580
+      /* "aesara/scan/scan_perform.pyx":585
  *             # if optimization gets applied compared to when optimization
  *             # do not get applied
  *             if i < n_steps:             # <<<<<<<<<<<<<<
@@ -6956,35 +6974,35 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
       __pyx_t_5 = ((__pyx_v_i < __pyx_v_n_steps) != 0);
       if (__pyx_t_5) {
 
-        /* "aesara/scan/scan_perform.pyx":587
+        /* "aesara/scan/scan_perform.pyx":592
  *                 # code faster, so this workaround is better then removing
  *                 # the directive.
  *                 sh0 = outer_outputs_idx_0.shape[0]             # <<<<<<<<<<<<<<
  *                 outer_outputs_idx[0] = outer_outputs_idx_0[:sh0-(n_steps - i)]
  * 
  */
-        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_idx_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 587, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_outer_outputs_idx_0, __pyx_n_s_shape); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 592, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_1, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 587, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_1, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 592, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-        __pyx_t_13 = __Pyx_PyInt_As_unsigned_int(__pyx_t_2); if (unlikely((__pyx_t_13 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 587, __pyx_L1_error)
+        __pyx_t_13 = __Pyx_PyInt_As_unsigned_int(__pyx_t_2); if (unlikely((__pyx_t_13 == (unsigned int)-1) && PyErr_Occurred())) __PYX_ERR(0, 592, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
         __pyx_v_sh0 = __pyx_t_13;
 
-        /* "aesara/scan/scan_perform.pyx":588
+        /* "aesara/scan/scan_perform.pyx":593
  *                 # the directive.
  *                 sh0 = outer_outputs_idx_0.shape[0]
  *                 outer_outputs_idx[0] = outer_outputs_idx_0[:sh0-(n_steps - i)]             # <<<<<<<<<<<<<<
  * 
  *     # We never reuse the input or output storage of the
  */
-        __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_idx_0, 0, (__pyx_v_sh0 - (__pyx_v_n_steps - __pyx_v_i)), NULL, NULL, NULL, 0, 1, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 588, __pyx_L1_error)
+        __pyx_t_2 = __Pyx_PyObject_GetSlice(__pyx_v_outer_outputs_idx_0, 0, (__pyx_v_sh0 - (__pyx_v_n_steps - __pyx_v_i)), NULL, NULL, NULL, 0, 1, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 593, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        if (unlikely(__Pyx_SetItemInt(__pyx_v_outer_outputs_idx, 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 588, __pyx_L1_error)
+        if (unlikely(__Pyx_SetItemInt(__pyx_v_outer_outputs_idx, 0, __pyx_t_2, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 593, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-        /* "aesara/scan/scan_perform.pyx":580
+        /* "aesara/scan/scan_perform.pyx":585
  *             # if optimization gets applied compared to when optimization
  *             # do not get applied
  *             if i < n_steps:             # <<<<<<<<<<<<<<
@@ -6993,7 +7011,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
  */
       }
 
-      /* "aesara/scan/scan_perform.pyx":570
+      /* "aesara/scan/scan_perform.pyx":575
  *         # expected to return 0 for all entries for which the gradient is
  *         # not actually computed
  *         elif store_steps_idx > i - mintaps_idx:             # <<<<<<<<<<<<<<
@@ -7004,7 +7022,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
     __pyx_L125:;
   }
 
-  /* "aesara/scan/scan_perform.pyx":592
+  /* "aesara/scan/scan_perform.pyx":597
  *     # We never reuse the input or output storage of the
  *     # inner function so we clear it.
  *     for s in inner_input_storage:             # <<<<<<<<<<<<<<
@@ -7015,24 +7033,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   for (;;) {
     if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_2)) break;
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-    __pyx_t_1 = PyList_GET_ITEM(__pyx_t_2, __pyx_t_9); __Pyx_INCREF(__pyx_t_1); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 592, __pyx_L1_error)
+    __pyx_t_1 = PyList_GET_ITEM(__pyx_t_2, __pyx_t_9); __Pyx_INCREF(__pyx_t_1); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 597, __pyx_L1_error)
     #else
-    __pyx_t_1 = PySequence_ITEM(__pyx_t_2, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 592, __pyx_L1_error)
+    __pyx_t_1 = PySequence_ITEM(__pyx_t_2, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 597, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_s, __pyx_t_1);
     __pyx_t_1 = 0;
 
-    /* "aesara/scan/scan_perform.pyx":593
+    /* "aesara/scan/scan_perform.pyx":598
  *     # inner function so we clear it.
  *     for s in inner_input_storage:
  *         s[0] = None             # <<<<<<<<<<<<<<
  *     for s in inner_output_storage:
  *         s[0] = None
  */
-    if (unlikely(__Pyx_SetItemInt(__pyx_v_s, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 593, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(__pyx_v_s, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 598, __pyx_L1_error)
 
-    /* "aesara/scan/scan_perform.pyx":592
+    /* "aesara/scan/scan_perform.pyx":597
  *     # We never reuse the input or output storage of the
  *     # inner function so we clear it.
  *     for s in inner_input_storage:             # <<<<<<<<<<<<<<
@@ -7042,7 +7060,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   }
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":594
+  /* "aesara/scan/scan_perform.pyx":599
  *     for s in inner_input_storage:
  *         s[0] = None
  *     for s in inner_output_storage:             # <<<<<<<<<<<<<<
@@ -7053,24 +7071,24 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   for (;;) {
     if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_2)) break;
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-    __pyx_t_1 = PyList_GET_ITEM(__pyx_t_2, __pyx_t_9); __Pyx_INCREF(__pyx_t_1); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 594, __pyx_L1_error)
+    __pyx_t_1 = PyList_GET_ITEM(__pyx_t_2, __pyx_t_9); __Pyx_INCREF(__pyx_t_1); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 599, __pyx_L1_error)
     #else
-    __pyx_t_1 = PySequence_ITEM(__pyx_t_2, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 594, __pyx_L1_error)
+    __pyx_t_1 = PySequence_ITEM(__pyx_t_2, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 599, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     #endif
     __Pyx_XDECREF_SET(__pyx_v_s, __pyx_t_1);
     __pyx_t_1 = 0;
 
-    /* "aesara/scan/scan_perform.pyx":595
+    /* "aesara/scan/scan_perform.pyx":600
  *         s[0] = None
  *     for s in inner_output_storage:
  *         s[0] = None             # <<<<<<<<<<<<<<
  * 
  *     return t_fn, i
  */
-    if (unlikely(__Pyx_SetItemInt(__pyx_v_s, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 595, __pyx_L1_error)
+    if (unlikely(__Pyx_SetItemInt(__pyx_v_s, 0, Py_None, long, 1, __Pyx_PyInt_From_long, 0, 0, 0) < 0)) __PYX_ERR(0, 600, __pyx_L1_error)
 
-    /* "aesara/scan/scan_perform.pyx":594
+    /* "aesara/scan/scan_perform.pyx":599
  *     for s in inner_input_storage:
  *         s[0] = None
  *     for s in inner_output_storage:             # <<<<<<<<<<<<<<
@@ -7080,17 +7098,17 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   }
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "aesara/scan/scan_perform.pyx":597
+  /* "aesara/scan/scan_perform.pyx":602
  *         s[0] = None
  * 
  *     return t_fn, i             # <<<<<<<<<<<<<<
  */
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_2 = __Pyx_PyInt_From_time_t(__pyx_v_t_fn); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 597, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyInt_From_time_t(__pyx_v_t_fn); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 602, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_1 = __Pyx_PyInt_From_unsigned_int(__pyx_v_i); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 597, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_unsigned_int(__pyx_v_i); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 602, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 597, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 602, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_2);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_2);
@@ -7125,6 +7143,7 @@ static PyObject *__pyx_pf_6aesara_4scan_12scan_perform_2perform(CYTHON_UNUSED Py
   __pyx_L0:;
   __Pyx_XDECREF(__pyx_v_outer_outputs_idx);
   __Pyx_XDECREF(__pyx_v_outer_outputs_idx_0);
+  __Pyx_XDECREF(__pyx_v_outer_inputs_offset_idx);
   __Pyx_XDECREF(__pyx_v_other_args);
   __Pyx_XDECREF(__pyx_v_old_mitmot_input_storage);
   __Pyx_XDECREF(__pyx_v_old_mitmot_input_data);
@@ -22095,6 +22114,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_old_var, __pyx_k_old_var, sizeof(__pyx_k_old_var), 0, 0, 1, 1},
   {&__pyx_n_s_other_args, __pyx_k_other_args, sizeof(__pyx_k_other_args), 0, 0, 1, 1},
   {&__pyx_n_s_outer_inputs, __pyx_k_outer_inputs, sizeof(__pyx_k_outer_inputs), 0, 0, 1, 1},
+  {&__pyx_n_s_outer_inputs_offset_idx, __pyx_k_outer_inputs_offset_idx, sizeof(__pyx_k_outer_inputs_offset_idx), 0, 0, 1, 1},
   {&__pyx_n_s_outer_output_dtypes, __pyx_k_outer_output_dtypes, sizeof(__pyx_k_outer_output_dtypes), 0, 0, 1, 1},
   {&__pyx_n_s_outer_output_ndims, __pyx_k_outer_output_ndims, sizeof(__pyx_k_outer_output_ndims), 0, 0, 1, 1},
   {&__pyx_n_s_outer_outputs, __pyx_k_outer_outputs, sizeof(__pyx_k_outer_outputs), 0, 0, 1, 1},
@@ -22180,50 +22200,50 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__Pyx_InitCachedConstants", 0);
 
-  /* "aesara/scan/scan_perform.pyx":258
+  /* "aesara/scan/scan_perform.pyx":260
  * 
  *         if ( outer_outputs_idx_0 is not None and
- *               outer_outputs_idx_0.shape[1:] == outer_inputs[<unsigned int>(1+ n_seqs + idx)].shape[1:]             # <<<<<<<<<<<<<<
+ *               outer_outputs_idx_0.shape[1:] == outer_inputs_offset_idx.shape[1:]             # <<<<<<<<<<<<<<
  *               and outer_outputs_idx_0.shape[0] >= store_steps[idx] ):
  *             # Put in the values of the initial state
  */
-  __pyx_slice_ = PySlice_New(__pyx_int_1, Py_None, Py_None); if (unlikely(!__pyx_slice_)) __PYX_ERR(0, 258, __pyx_L1_error)
+  __pyx_slice_ = PySlice_New(__pyx_int_1, Py_None, Py_None); if (unlikely(!__pyx_slice_)) __PYX_ERR(0, 260, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_slice_);
   __Pyx_GIVEREF(__pyx_slice_);
 
-  /* "aesara/scan/scan_perform.pyx":266
- *                 outer_outputs_idx_0[:l] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)][:l]
+  /* "aesara/scan/scan_perform.pyx":271
+ *                 outer_outputs_idx_0[:l] = outer_inputs_offset_idx[:l]
  *             else:
- *                 outer_outputs_idx_0[:] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)]             # <<<<<<<<<<<<<<
+ *                 outer_outputs_idx_0[:] = outer_inputs_offset_idx             # <<<<<<<<<<<<<<
  *         else:
- *             outer_outputs_idx[0] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)].copy()
+ *             outer_outputs_idx[0] = outer_inputs_offset_idx.copy()
  */
-  __pyx_slice__2 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__2)) __PYX_ERR(0, 266, __pyx_L1_error)
+  __pyx_slice__2 = PySlice_New(Py_None, Py_None, Py_None); if (unlikely(!__pyx_slice__2)) __PYX_ERR(0, 271, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_slice__2);
   __Pyx_GIVEREF(__pyx_slice__2);
 
-  /* "aesara/scan/scan_perform.pyx":273
+  /* "aesara/scan/scan_perform.pyx":278
  *         for idx in range(n_outs, n_outs + n_nit_sot):
  *             if outs_is_tensor[idx]:
  *                 outer_outputs[idx][0] = numpy.empty((0,) * outer_output_ndims[idx], dtype=outer_output_dtypes[idx])             # <<<<<<<<<<<<<<
  *             else:
  *                 outer_outputs[idx][0] = None
  */
-  __pyx_tuple__3 = PyTuple_New(1); if (unlikely(!__pyx_tuple__3)) __PYX_ERR(0, 273, __pyx_L1_error)
+  __pyx_tuple__3 = PyTuple_New(1); if (unlikely(!__pyx_tuple__3)) __PYX_ERR(0, 278, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__3);
   __Pyx_INCREF(__pyx_int_0);
   __Pyx_GIVEREF(__pyx_int_0);
   PyTuple_SET_ITEM(__pyx_tuple__3, 0, __pyx_int_0);
   __Pyx_GIVEREF(__pyx_tuple__3);
 
-  /* "aesara/scan/scan_perform.pyx":276
+  /* "aesara/scan/scan_perform.pyx":281
  *             else:
  *                 outer_outputs[idx][0] = None
  *         return 0.0, 0             # <<<<<<<<<<<<<<
  * 
  *     for idx in range(lenpos):
  */
-  __pyx_tuple__4 = PyTuple_Pack(2, __pyx_float_0_0, __pyx_int_0); if (unlikely(!__pyx_tuple__4)) __PYX_ERR(0, 276, __pyx_L1_error)
+  __pyx_tuple__4 = PyTuple_Pack(2, __pyx_float_0_0, __pyx_int_0); if (unlikely(!__pyx_tuple__4)) __PYX_ERR(0, 281, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__4);
   __Pyx_GIVEREF(__pyx_tuple__4);
 
@@ -22434,7 +22454,7 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
  * 
  * 
  * def get_version():             # <<<<<<<<<<<<<<
- *     return 0.325
+ *     return 0.326
  * 
  */
   __pyx_codeobj__24 = (PyObject*)__Pyx_PyCode_New(0, 0, 0, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_scan_perform_pyx, __pyx_n_s_get_version, 64, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__24)) __PYX_ERR(0, 64, __pyx_L1_error)
@@ -22446,10 +22466,10 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
  *     const unsigned int n_shared_outs,
  *     const unsigned int n_mit_mot_outs,
  */
-  __pyx_tuple__25 = PyTuple_Pack(86, __pyx_n_s_n_shared_outs, __pyx_n_s_n_mit_mot_outs, __pyx_n_s_n_seqs, __pyx_n_s_n_mit_mot, __pyx_n_s_n_mit_sot, __pyx_n_s_n_sit_sot, __pyx_n_s_n_nit_sot, __pyx_n_s_as_while, __pyx_n_s_mintaps, __pyx_n_s_pos, __pyx_n_s_store_steps, __pyx_n_s_tap_array, __pyx_n_s_tap_array_len, __pyx_n_s_vector_seqs, __pyx_n_s_vector_outs, __pyx_n_s_mit_mot_out_slices, __pyx_n_s_mitmots_preallocated, __pyx_n_s_mit_mot_out_to_tap_idx, __pyx_n_s_outs_is_tensor, __pyx_n_s_inner_input_storage, __pyx_n_s_inner_output_storage, __pyx_n_s_destroy_map, __pyx_n_s_outer_inputs, __pyx_n_s_outer_outputs, __pyx_n_s_outer_output_dtypes, __pyx_n_s_outer_output_ndims, __pyx_n_s_fn, __pyx_n_s_t_fn, __pyx_n_s_t0_fn, __pyx_n_s_dt_fn, __pyx_n_s_n_steps, __pyx_n_s_n_outs, __pyx_n_s_seqs_arg_offset, __pyx_n_s_shared_arg_offset, __pyx_n_s_nit_sot_arg_offset, __pyx_n_s_offset_out, __pyx_n_s_lenpos, __pyx_n_s_l, __pyx_n_s_offset, __pyx_n_s_tap, __pyx_n_s_idx, __pyx_n_s_a_offset, __pyx_n_s_o_offset, __pyx_n_s_idx_2, __pyx_n_s_i, __pyx_n_s_j, __pyx_n_s_k, __pyx_n_s_kdx, __pyx_n_s_tdx, __pyx_n_s_pdx, __pyx_n_s_jout, __pyx_n_s_begin, __pyx_n_s_end, __pyx_n_s_cond, __pyx_n_s_len_output_storage, __pyx_n_s_mitmot_inp_offset, __pyx_n_s_mitmot_out_idx, __pyx_n_s_inp_idx, __pyx_n_s_inner_inp_idx, __pyx_n_s_store_steps_j, __pyx_n_s_store_steps_idx, __pyx_n_s_mintaps_idx, __pyx_n_s_sh0, __pyx_n_s_pos_j, __pyx_n_s_pos_idx, __pyx_n_s_outer_outputs_idx, __pyx_n_s_outer_outputs_idx_0, __pyx_n_s_other_args, __pyx_n_s_nb_mitmot_in, __pyx_n_s_old_mitmot_input_storage, __pyx_n_s_old_mitmot_input_data, __pyx_n_s_old_output_storage, __pyx_n_s_old_output_data, __pyx_n_s_var, __pyx_n_s_exc, __pyx_n_s_outer_outputs_j_0, __pyx_n_s_old_var, __pyx_n_s_new_var, __pyx_n_s_outer_outputs_j, __pyx_n_s_old_data, __pyx_n_s_inner_output_storage_jout_0, __pyx_n_s_shape, __pyx_n_s_dtype, __pyx_n_s_new_outer_outputs_j_0, __pyx_n_s_tmp, __pyx_n_s_s); if (unlikely(!__pyx_tuple__25)) __PYX_ERR(0, 76, __pyx_L1_error)
+  __pyx_tuple__25 = PyTuple_Pack(87, __pyx_n_s_n_shared_outs, __pyx_n_s_n_mit_mot_outs, __pyx_n_s_n_seqs, __pyx_n_s_n_mit_mot, __pyx_n_s_n_mit_sot, __pyx_n_s_n_sit_sot, __pyx_n_s_n_nit_sot, __pyx_n_s_as_while, __pyx_n_s_mintaps, __pyx_n_s_pos, __pyx_n_s_store_steps, __pyx_n_s_tap_array, __pyx_n_s_tap_array_len, __pyx_n_s_vector_seqs, __pyx_n_s_vector_outs, __pyx_n_s_mit_mot_out_slices, __pyx_n_s_mitmots_preallocated, __pyx_n_s_mit_mot_out_to_tap_idx, __pyx_n_s_outs_is_tensor, __pyx_n_s_inner_input_storage, __pyx_n_s_inner_output_storage, __pyx_n_s_destroy_map, __pyx_n_s_outer_inputs, __pyx_n_s_outer_outputs, __pyx_n_s_outer_output_dtypes, __pyx_n_s_outer_output_ndims, __pyx_n_s_fn, __pyx_n_s_t_fn, __pyx_n_s_t0_fn, __pyx_n_s_dt_fn, __pyx_n_s_n_steps, __pyx_n_s_n_outs, __pyx_n_s_seqs_arg_offset, __pyx_n_s_shared_arg_offset, __pyx_n_s_nit_sot_arg_offset, __pyx_n_s_offset_out, __pyx_n_s_lenpos, __pyx_n_s_l, __pyx_n_s_offset, __pyx_n_s_tap, __pyx_n_s_idx, __pyx_n_s_a_offset, __pyx_n_s_o_offset, __pyx_n_s_idx_2, __pyx_n_s_i, __pyx_n_s_j, __pyx_n_s_k, __pyx_n_s_kdx, __pyx_n_s_tdx, __pyx_n_s_pdx, __pyx_n_s_jout, __pyx_n_s_begin, __pyx_n_s_end, __pyx_n_s_cond, __pyx_n_s_len_output_storage, __pyx_n_s_mitmot_inp_offset, __pyx_n_s_mitmot_out_idx, __pyx_n_s_inp_idx, __pyx_n_s_inner_inp_idx, __pyx_n_s_store_steps_j, __pyx_n_s_store_steps_idx, __pyx_n_s_mintaps_idx, __pyx_n_s_sh0, __pyx_n_s_pos_j, __pyx_n_s_pos_idx, __pyx_n_s_outer_outputs_idx, __pyx_n_s_outer_outputs_idx_0, __pyx_n_s_outer_inputs_offset_idx, __pyx_n_s_other_args, __pyx_n_s_nb_mitmot_in, __pyx_n_s_old_mitmot_input_storage, __pyx_n_s_old_mitmot_input_data, __pyx_n_s_old_output_storage, __pyx_n_s_old_output_data, __pyx_n_s_var, __pyx_n_s_exc, __pyx_n_s_outer_outputs_j_0, __pyx_n_s_old_var, __pyx_n_s_new_var, __pyx_n_s_outer_outputs_j, __pyx_n_s_old_data, __pyx_n_s_inner_output_storage_jout_0, __pyx_n_s_shape, __pyx_n_s_dtype, __pyx_n_s_new_outer_outputs_j_0, __pyx_n_s_tmp, __pyx_n_s_s); if (unlikely(!__pyx_tuple__25)) __PYX_ERR(0, 76, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__25);
   __Pyx_GIVEREF(__pyx_tuple__25);
-  __pyx_codeobj__26 = (PyObject*)__Pyx_PyCode_New(27, 0, 86, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__25, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_scan_perform_pyx, __pyx_n_s_perform, 76, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__26)) __PYX_ERR(0, 76, __pyx_L1_error)
+  __pyx_codeobj__26 = (PyObject*)__Pyx_PyCode_New(27, 0, 87, 0, CO_OPTIMIZED|CO_NEWLOCALS, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__25, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_scan_perform_pyx, __pyx_n_s_perform, 76, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__26)) __PYX_ERR(0, 76, __pyx_L1_error)
 
   /* "View.MemoryView":286
  *         return self.name
@@ -22525,7 +22545,7 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedConstants(void) {
 static CYTHON_SMALL_CODE int __Pyx_InitGlobals(void) {
   if (__Pyx_InitStrings(__pyx_string_tab) < 0) __PYX_ERR(0, 1, __pyx_L1_error);
   __pyx_float_0_0 = PyFloat_FromDouble(0.0); if (unlikely(!__pyx_float_0_0)) __PYX_ERR(0, 1, __pyx_L1_error)
-  __pyx_float_0_325 = PyFloat_FromDouble(0.325); if (unlikely(!__pyx_float_0_325)) __PYX_ERR(0, 1, __pyx_L1_error)
+  __pyx_float_0_326 = PyFloat_FromDouble(0.326); if (unlikely(!__pyx_float_0_326)) __PYX_ERR(0, 1, __pyx_L1_error)
   __pyx_int_0 = PyInt_FromLong(0); if (unlikely(!__pyx_int_0)) __PYX_ERR(0, 1, __pyx_L1_error)
   __pyx_int_1 = PyInt_FromLong(1); if (unlikely(!__pyx_int_1)) __PYX_ERR(0, 1, __pyx_L1_error)
   __pyx_int_184977713 = PyInt_FromLong(184977713L); if (unlikely(!__pyx_int_184977713)) __PYX_ERR(0, 1, __pyx_L1_error)
@@ -22974,7 +22994,7 @@ if (!__Pyx_RefNanny) {
  * 
  * 
  * def get_version():             # <<<<<<<<<<<<<<
- *     return 0.325
+ *     return 0.326
  * 
  */
   __pyx_t_2 = PyCFunction_NewEx(&__pyx_mdef_6aesara_4scan_12scan_perform_1get_version, NULL, __pyx_n_s_aesara_scan_scan_perform); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 64, __pyx_L1_error)

--- a/aesara/scan/scan_perform.pyx
+++ b/aesara/scan/scan_perform.pyx
@@ -62,7 +62,7 @@ numpy.import_array()
 
 
 def get_version():
-    return 0.325
+    return 0.326
 
 
 @cython.cdivision(True)
@@ -253,19 +253,24 @@ def perform(
             continue
 
         outer_outputs_idx_0 = outer_outputs_idx[0]
+        outer_inputs_offset_idx = outer_inputs[<unsigned int>(seqs_arg_offset + idx)]
+
 
         if ( outer_outputs_idx_0 is not None and
-              outer_outputs_idx_0.shape[1:] == outer_inputs[<unsigned int>(1+ n_seqs + idx)].shape[1:]
+              outer_outputs_idx_0.shape[1:] == outer_inputs_offset_idx.shape[1:]
               and outer_outputs_idx_0.shape[0] >= store_steps[idx] ):
             # Put in the values of the initial state
-            outer_outputs_idx[0] = outer_outputs_idx_0[:store_steps[idx]]
+
+            outer_outputs_idx_0 = outer_outputs_idx_0[:store_steps[idx]]
+            outer_outputs_idx[0] = outer_outputs_idx_0
+
             if idx > n_mit_mot:
                 l = - mintaps[idx]
-                outer_outputs_idx_0[:l] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)][:l]
+                outer_outputs_idx_0[:l] = outer_inputs_offset_idx[:l]
             else:
-                outer_outputs_idx_0[:] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)]
+                outer_outputs_idx_0[:] = outer_inputs_offset_idx
         else:
-            outer_outputs_idx[0] = outer_inputs[<unsigned int>(seqs_arg_offset + idx)].copy()
+            outer_outputs_idx[0] = outer_inputs_offset_idx.copy()
 
     if n_steps == 0:
         for idx in range(n_outs, n_outs + n_nit_sot):

--- a/aesara/scan/scan_perform_ext.py
+++ b/aesara/scan/scan_perform_ext.py
@@ -23,7 +23,7 @@ if not config.cxx:
 
 _logger = logging.getLogger("aesara.scan.scan_perform")
 
-version = 0.325  # must match constant returned in function get_version()
+version = 0.326  # must match constant returned in function get_version()
 
 need_reload = False
 scan_perform: Optional[ModuleType] = None


### PR DESCRIPTION
This PR fixes an issue in `Scan`'s Cython implementation where an attempt is made to overwrite an output storage array with one of a different shape.


This issue was seen in https://github.com/aesara-devs/aehmc/pull/64 [here](https://github.com/aesara-devs/aehmc/runs/7074712615?check_suite_focus=true#step:6:159), when an outer-output array wasn't sliced before attempting an in-place update with a smaller outer-input array (during outer-output initialization).