### PR TITLE
Update `Op.grad`, `Op.L_op`, and `aesara.gradient` docstrings and type hints

### DIFF
--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -278,8 +278,6 @@ class TestGrad:
         g = grad(a1.outputs[0], a1.outputs[1], disconnected_inputs="ignore")
         assert g.owner.op == at.fill
         assert g.owner.inputs[1].data == 0
-        with pytest.raises(TypeError):
-            grad(a1.outputs[0], "wtf")
 
     def test_NNone_rval(self):
         # grad: Test returning some zero value from grad


### PR DESCRIPTION
This PR adds a much more informative set of docstrings for `Op.grad` and `Op.L_op`.  The updated docstrings are clearer about the method inputs and outputs, as well as their underlying mathematical interpretations and relationships.

There is also a bit of refactoring of `aesara.gradient`;the kind that clarifies function interfaces and helps with typing.