### PR TITLE
add deps to match `install_requires` in `setup.py`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,7 @@ pre-commit
 isort
 packaging
 typing_extensions
+etuples
+logical-unification
+miniKanren
+cons


### PR DESCRIPTION
Add the modules etuples, logical-unification, miniKanren, cons to requirement.txt. They are already included in setup.py under install_requires. 

I'm working with self hosted pip repo. Currently when I add pymc to the repo these dependencies of aesara don't automatically get added to the repo. I hope this resolves it.


**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [ ] There is an informative high-level description of the changes.
+ [ ] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [ ] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [ ] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ ] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
