### PR TITLE
Update pypi.yml to also build wheel

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -27,9 +27,10 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.8"
-      - name: Build the sdist
+      - name: Build the sdist and the wheel
         run: |
-          python setup.py sdist
+          pip install wheel
+          python setup.py sdist bdist_wheel
       - name: Check the sdist installs and imports
         run: |
           mkdir -p test-sdist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,10 +5,7 @@ global-include *.cuh
 global-include *.cpp
 global-include *.h
 global-include *.sh
-global-include *.pkl
-recursive-include doc
+recursive-include doc *
 include bin/aesara-cache
-prune .jenkins
-prune .travis
 include versioneer.py
 include aesara/_version.py


### PR DESCRIPTION
Hello Y'all,

PR solves https://github.com/aesara-devs/aesara/issues/1047. TLDR: pypi can't figure the dependencies of aesara if the wheel isn't uploaded.

During the github action that publishes to pypi make sure to not only build a sdist but also a wheel. This is similar to what happens when executing `make pypi`.  Twine (inside pypa/gh-action-pypi-publish@master) will automatically upload the wheel first such that [pypi can extract the dependencies better](https://github.com/pypa/pypi-legacy/issues/622#issuecomment-305829257) and the pypi json api doesn't return `requires_dist = null`

Thank you for this awesome tool!   🙇‍♂️
