### PR TITLE
Use context managers with `open`

### DIFF
--- a/aesara/compile/compiledir.py
+++ b/aesara/compile/compiledir.py
@@ -33,14 +33,13 @@ def cleanup():
     """
     compiledir = config.compiledir
     for directory in os.listdir(compiledir):
-        file = None
         try:
-            try:
-                filename = os.path.join(compiledir, directory, "key.pkl")
-                file = open(filename, "rb")
-                # print file
+            filename = os.path.join(compiledir, directory, "key.pkl")
+            # print file
+            with open(filename, "rb") as file:
                 try:
                     keydata = pickle.load(file)
+
                     for key in list(keydata.keys):
                         have_npy_abi_version = False
                         have_c_compiler = False
@@ -86,14 +85,11 @@ def cleanup():
                         "the clean-up, please remove manually "
                         "the directory containing it."
                     )
-            except OSError:
-                _logger.error(
-                    f"Could not clean up this directory: '{directory}'. To complete "
-                    "the clean-up, please remove it manually."
-                )
-        finally:
-            if file is not None:
-                file.close()
+        except OSError:
+            _logger.error(
+                f"Could not clean up this directory: '{directory}'. To complete "
+                "the clean-up, please remove it manually."
+            )
 
 
 def print_title(title, overline="", underline=""):

--- a/aesara/configdefaults.py
+++ b/aesara/configdefaults.py
@@ -1300,7 +1300,8 @@ def _filter_compiledir(path):
     init_file = os.path.join(path, "__init__.py")
     if not os.path.exists(init_file):
         try:
-            open(init_file, "w").close()
+            with open(init_file, "w"):
+                pass
         except OSError as e:
             if os.path.exists(init_file):
                 pass  # has already been created

--- a/aesara/link/c/cmodule.py
+++ b/aesara/link/c/cmodule.py
@@ -1008,8 +1008,8 @@ class ModuleCache:
                 entry = key_data.get_entry()
                 try:
                     # Test to see that the file is [present and] readable.
-                    open(entry).close()
-                    gone = False
+                    with open(entry):
+                        gone = False
                 except OSError:
                     gone = True
 
@@ -1505,8 +1505,8 @@ class ModuleCache:
             if filename.startswith("tmp"):
                 try:
                     fname = os.path.join(self.dirname, filename, "key.pkl")
-                    open(fname).close()
-                    has_key = True
+                    with open(fname):
+                        has_key = True
                 except OSError:
                     has_key = False
                 if not has_key:
@@ -1599,7 +1599,8 @@ def _rmtree(
         if os.path.exists(parent):
             try:
                 _logger.info(f'placing "delete.me" in {parent}')
-                open(os.path.join(parent, "delete.me"), "w").close()
+                with open(os.path.join(parent, "delete.me"), "w"):
+                    pass
             except Exception as ee:
                 _logger.warning(
                     f"Failed to remove or mark cache directory {parent} for removal {ee}"
@@ -2641,7 +2642,8 @@ class GCC_compiler(Compiler):
 
         if py_module:
             # touch the __init__ file
-            open(os.path.join(location, "__init__.py"), "w").close()
+            with open(os.path.join(location, "__init__.py"), "w"):
+                pass
             assert os.path.isfile(lib_filename)
             return dlimport(lib_filename)
 

--- a/aesara/link/c/cutils.py
+++ b/aesara/link/c/cutils.py
@@ -96,7 +96,8 @@ try:
             assert e.errno == errno.EEXIST
             assert os.path.exists(location), location
     if not os.path.exists(os.path.join(location, "__init__.py")):
-        open(os.path.join(location, "__init__.py"), "w").close()
+        with open(os.path.join(location, "__init__.py"), "w"):
+            pass
 
     try:
         from cutils_ext.cutils_ext import *  # noqa

--- a/aesara/link/c/lazylinker_c.py
+++ b/aesara/link/c/lazylinker_c.py
@@ -59,7 +59,8 @@ try:
     init_file = os.path.join(location, "__init__.py")
     if not os.path.exists(init_file):
         try:
-            open(init_file, "w").close()
+            with open(init_file, "w"):
+                pass
         except OSError as e:
             if os.path.exists(init_file):
                 pass  # has already been created
@@ -126,10 +127,12 @@ except ImportError:
                     "code generation."
                 )
                 raise ImportError("The file lazylinker_c.c is not available.")
-            code = open(cfile).read()
+
+            with open(cfile) as f:
+                code = f.read()
+
             loc = os.path.join(config.compiledir, dirname)
             if not os.path.exists(loc):
-
                 try:
                     os.mkdir(loc)
                 except OSError as e:
@@ -140,14 +143,17 @@ except ImportError:
             GCC_compiler.compile_str(dirname, code, location=loc, preargs=args)
             # Save version into the __init__.py file.
             init_py = os.path.join(loc, "__init__.py")
+
             with open(init_py, "w") as f:
                 f.write(f"_version = {version}\n")
+
             # If we just compiled the module for the first time, then it was
             # imported at the same time: we need to make sure we do not
             # reload the now outdated __init__.pyc below.
             init_pyc = os.path.join(loc, "__init__.pyc")
             if os.path.isfile(init_pyc):
                 os.remove(init_pyc)
+
             try_import()
             try_reload()
             from lazylinker_ext import lazylinker_ext as lazy_c

--- a/aesara/misc/pkl_utils.py
+++ b/aesara/misc/pkl_utils.py
@@ -42,21 +42,19 @@ Pickler = pickle.Pickler
 
 
 class StripPickler(Pickler):
-    """
-    Subclass of Pickler that strips unnecessary attributes from Aesara objects.
+    """Subclass of `Pickler` that strips unnecessary attributes from Aesara objects.
 
-    .. versionadded:: 0.8
-
-    Example of use::
+    Example
+    -------
 
         fn_args = dict(inputs=inputs,
                        outputs=outputs,
                        updates=updates)
         dest_pkl = 'my_test.pkl'
-        f = open(dest_pkl, 'wb')
-        strip_pickler = StripPickler(f, protocol=-1)
-        strip_pickler.dump(fn_args)
-        f.close()
+        with open(dest_pkl, 'wb') as f:
+            strip_pickler = StripPickler(f, protocol=-1)
+            strip_pickler.dump(fn_args)
+
     """
 
     def __init__(self, file, protocol=0, extra_tag_to_remove=None):

--- a/doc/tutorial/loading_and_saving.rst
+++ b/doc/tutorial/loading_and_saving.rst
@@ -118,7 +118,8 @@ For instance, you can define functions along the lines of:
 
     def __setstate__(self, d):
         self.__dict__.update(d)
-        self.training_set = cPickle.load(open(self.training_set_file, 'rb'))
+        with open(self.training_set_file, 'rb') as f:
+            self.training_set = cPickle.load(f)
 
 
 Robust Serialization

--- a/tests/misc/test_pkl_utils.py
+++ b/tests/misc/test_pkl_utils.py
@@ -66,6 +66,6 @@ class TestStripPickler:
         with open("test.pkl", "wb") as f:
             m = matrix()
             dest_pkl = "my_test.pkl"
-            f = open(dest_pkl, "wb")
-            strip_pickler = StripPickler(f, protocol=-1)
-            strip_pickler.dump(m)
+            with open(dest_pkl, "wb") as f:
+                strip_pickler = StripPickler(f, protocol=-1)
+                strip_pickler.dump(m)


### PR DESCRIPTION
This PR changes invocations of `open` to ones that use a `with` context managers.  Hopefully, this will help avoid unclosed file handles, especially the ones observed in https://github.com/sympy/sympy/pull/23745#discussion_r917398141.