### PR TITLE
Replace `distutils` with `setuptools`

### DIFF
--- a/aesara/configdefaults.py
+++ b/aesara/configdefaults.py
@@ -1,4 +1,3 @@
-import distutils.spawn
 import errno
 import logging
 import os
@@ -9,6 +8,7 @@ import sys
 import textwrap
 
 import numpy as np
+from setuptools._distutils.spawn import find_executable
 
 import aesara
 import aesara.configparser
@@ -437,7 +437,7 @@ def add_compile_configvars():
 
     # Try to find the full compiler path from the name
     if param != "":
-        newp = distutils.spawn.find_executable(param)
+        newp = find_executable(param)
         if newp is not None:
             param = newp
         del newp

--- a/aesara/link/c/cmodule.py
+++ b/aesara/link/c/cmodule.py
@@ -21,7 +21,7 @@ import warnings
 from io import BytesIO, StringIO
 from typing import Callable, Dict, List, Optional, Set, Tuple, cast
 
-import numpy.distutils
+import numpy as np
 from setuptools._distutils.sysconfig import (
     get_config_h_filename,
     get_config_var,
@@ -1670,7 +1670,7 @@ def get_gcc_shared_library_arg():
 
 
 def std_include_dirs():
-    numpy_inc_dirs = numpy.distutils.misc_util.get_numpy_include_dirs()
+    numpy_inc_dirs = [np.get_include()]
     py_inc = get_python_inc()
     py_plat_spec_inc = get_python_inc(plat_specific=True)
     python_inc_dirs = (
@@ -2705,27 +2705,9 @@ def default_blas_ldflags():
     str
 
     """
-    import numpy.distutils  # noqa
-
     warn_record = []
     try:
-        # We do this import only here, as in some setup, if we
-        # just import aesara and exit, with the import at global
-        # scope, we get this error at exit: "Exception TypeError:
-        # "'NoneType' object is not callable" in <bound method
-        # Popen.__del__ of <subprocess.Popen object at 0x21359d0>>
-        # ignored"
-
-        # This happen with Python 2.7.3 |EPD 7.3-1 and numpy 1.8.1
-        # isort: off
-        import numpy.distutils.system_info  # noqa
-
-        # We need to catch warnings as in some cases NumPy print
-        # stuff that we don't want the user to see.
-        # I'm not able to remove all printed stuff
-        with warnings.catch_warnings(record=True):
-            numpy.distutils.system_info.system_info.verbosity = 0
-            blas_info = numpy.distutils.system_info.get_info("blas_opt")
+        blas_info = np.__config__.get_info("blas_opt")
 
         # If we are in a EPD installation, mkl is available
         if "EPD" in sys.version:

--- a/aesara/link/c/exceptions.py
+++ b/aesara/link/c/exceptions.py
@@ -1,4 +1,4 @@
-from distutils.errors import CompileError as BaseCompileError
+from setuptools._distutils.errors import CompileError as BaseCompileError
 
 
 class MissingGXX(Exception):

--- a/aesara/tensor/blas.py
+++ b/aesara/tensor/blas.py
@@ -130,11 +130,10 @@ import os
 import time
 
 import numpy as np
-import numpy.distutils
 
 
 try:
-    import numpy.distutils.__config__  # noqa
+    import numpy.__config__  # noqa
 except ImportError:
     pass
 

--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -150,7 +150,7 @@ How do I configure/test my BLAS library
 There are many ways to configure BLAS for Aesara. This is done with the Aesara
 flags ``blas__ldflags`` (:ref:`libdoc_config`). The default is to use the BLAS
 installation information in NumPy, accessible via
-``numpy.distutils.__config__.show()``.  You can tell aesara to use a different
+``numpy.__config__.show()``.  You can tell aesara to use a different
 version of BLAS, in case you did not compile NumPy with a fast BLAS or if NumPy
 was compiled with a static library of BLAS (the latter is not supported in
 Aesara).

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ install_requires = [
     "miniKanren",
     "cons",
     "typing_extensions",
+    "setuptools>=45.0.0",
 ]
 
 


### PR DESCRIPTION
This PR replaces `distutils` imports with the equivalent `setuptools` imports, in anticipation of [`distutils`'s deprecation](https://peps.python.org/pep-0632/).