### PR TITLE
Enable type checking for some `aesara.tensor` modules

### DIFF
--- a/aesara/graph/type.py
+++ b/aesara/graph/type.py
@@ -1,13 +1,14 @@
 from abc import abstractmethod
-from typing import Any, Generic, Optional, Text, Tuple, TypeVar, Union
-
-from typing_extensions import TypeAlias
+from typing import Any, Generic, Optional, Text, Tuple
+from typing import Type as TypingType
+from typing import TypeVar, Union
 
 from aesara.graph import utils
 from aesara.graph.basic import Constant, Variable
 from aesara.graph.utils import MetaObject
 
 
+SelfType = TypeVar("SelfType", bound="Type")
 D = TypeVar("D")
 
 
@@ -25,15 +26,19 @@ class Type(MetaObject, Generic[D]):
 
     """
 
-    variable_type: TypeAlias = Variable
-    """
-    The `Type` that will be created by a call to `Type.make_variable`.
-    """
+    @property
+    def variable_type(self) -> TypingType[Variable]:
+        """
+        The `Type` that will be created by a call to `Type.make_variable`.
+        """
+        return Variable
 
-    constant_type: TypeAlias = Constant
-    """
-    The `Type` that will be created by a call to `Type.make_constant`.
-    """
+    @property
+    def constant_type(self) -> TypingType[Constant]:
+        """
+        The `Type` that will be created by a call to `Type.make_constant`.
+        """
+        return Constant
 
     def in_same_class(self, otype: "Type") -> Optional[bool]:
         """Determine if another `Type` represents a subset from the same "class" of types represented by `self`.
@@ -131,7 +136,7 @@ class Type(MetaObject, Generic[D]):
 
     def filter_variable(
         self, other: Union[Variable, D], allow_convert: bool = True
-    ) -> variable_type:
+    ) -> Variable:
         r"""Convert a `other` into a `Variable` with a `Type` that's compatible with `self`.
 
         If the involved `Type`\s are not compatible, a `TypeError` will be raised.
@@ -188,7 +193,7 @@ class Type(MetaObject, Generic[D]):
         except (TypeError, ValueError):
             return False
 
-    def make_variable(self, name: Optional[Text] = None) -> variable_type:
+    def make_variable(self, name: Optional[Text] = None) -> Variable:
         """Return a new `Variable` instance of this `Type`.
 
         Parameters
@@ -199,7 +204,7 @@ class Type(MetaObject, Generic[D]):
         """
         return self.variable_type(self, None, name=name)
 
-    def make_constant(self, value: D, name: Optional[Text] = None) -> constant_type:
+    def make_constant(self, value: D, name: Optional[Text] = None) -> Constant:
         """Return a new `Constant` instance of this `Type`.
 
         Parameters
@@ -212,11 +217,11 @@ class Type(MetaObject, Generic[D]):
         """
         return self.constant_type(type=self, data=value, name=name)
 
-    def clone(self, *args, **kwargs) -> "Type":
+    def clone(self: SelfType) -> SelfType:
         """Clone a copy of this type with the given arguments/keyword values, if any."""
-        return type(self)(*args, **kwargs)
+        return type(self)()
 
-    def __call__(self, name: Optional[Text] = None) -> variable_type:
+    def __call__(self, name: Optional[Text] = None) -> Variable:
         """Return a new `Variable` instance of Type `self`.
 
         Parameters

--- a/aesara/link/c/type.py
+++ b/aesara/link/c/type.py
@@ -145,6 +145,10 @@ class CDataType(CType[D]):
         The version to use in Aesara cache system.
     """
 
+    @property
+    def constant_type(self):
+        return CDataTypeConstant
+
     __props__ = (
         "ctype",
         "freefunc",
@@ -301,9 +305,6 @@ class CDataTypeConstant(Constant[T]):
         # There is no way to put the data in the signature, so we
         # don't even try
         return (self.type,)
-
-
-CDataType.constant_type = CDataTypeConstant
 
 
 class EnumType(CType, dict):

--- a/aesara/scalar/basic.py
+++ b/aesara/scalar/basic.py
@@ -285,6 +285,14 @@ class ScalarType(CType, HasDataType, HasShape):
     ndim = 0
     shape = ()
 
+    @property
+    def variable_type(self):
+        return ScalarVariable
+
+    @property
+    def constant_type(self):
+        return ScalarVariable
+
     def __init__(self, dtype):
         if isinstance(dtype, str) and dtype == "floatX":
             dtype = config.floatX
@@ -838,16 +846,9 @@ class ScalarVariable(_scalar_py_operators, Variable):
     pass
 
 
-ScalarType.variable_type = ScalarVariable
-
-
 class ScalarConstant(ScalarVariable, Constant):
     def __init__(self, *args, **kwargs):
         Constant.__init__(self, *args, **kwargs)
-
-
-# Register ScalarConstant as the type of Constant corresponding to ScalarType
-ScalarType.constant_type = ScalarConstant
 
 
 def constant(x, name=None, dtype=None) -> ScalarConstant:

--- a/aesara/sparse/__init__.py
+++ b/aesara/sparse/__init__.py
@@ -1,47 +1,36 @@
 from warnings import warn
 
-
-try:
-    import scipy
-
-    enable_sparse = True
-except ImportError:
-    enable_sparse = False
-    warn("SciPy can't be imported.  Sparse matrix support is disabled.")
-
+from aesara.sparse import opt, sharedvar
+from aesara.sparse.basic import *
+from aesara.sparse.sharedvar import sparse_constructor as shared
 from aesara.sparse.type import SparseTensorType, _is_sparse
 
 
-if enable_sparse:
-    from aesara.sparse import opt, sharedvar
-    from aesara.sparse.basic import *
-    from aesara.sparse.sharedvar import sparse_constructor as shared
+def sparse_grad(var):
+    """This function return a new variable whose gradient will be
+    stored in a sparse format instead of dense.
 
-    def sparse_grad(var):
-        """This function return a new variable whose gradient will be
-        stored in a sparse format instead of dense.
+    Currently only variable created by AdvancedSubtensor1 is supported.
+    i.e. a_tensor_var[an_int_vector].
 
-        Currently only variable created by AdvancedSubtensor1 is supported.
-        i.e. a_tensor_var[an_int_vector].
+    .. versionadded:: 0.6rc4
+    """
+    from aesara.tensor.subtensor import AdvancedSubtensor, AdvancedSubtensor1
 
-        .. versionadded:: 0.6rc4
-        """
-        from aesara.tensor.subtensor import AdvancedSubtensor, AdvancedSubtensor1
+    if var.owner is None or not isinstance(
+        var.owner.op, (AdvancedSubtensor, AdvancedSubtensor1)
+    ):
+        raise TypeError(
+            "Sparse gradient is only implemented for AdvancedSubtensor and AdvancedSubtensor1"
+        )
 
-        if var.owner is None or not isinstance(
-            var.owner.op, (AdvancedSubtensor, AdvancedSubtensor1)
-        ):
-            raise TypeError(
-                "Sparse gradient is only implemented for AdvancedSubtensor and AdvancedSubtensor1"
-            )
+    x = var.owner.inputs[0]
+    indices = var.owner.inputs[1:]
 
-        x = var.owner.inputs[0]
-        indices = var.owner.inputs[1:]
+    if len(indices) > 1:
+        raise TypeError(
+            "Sparse gradient is only implemented for single advanced indexing"
+        )
 
-        if len(indices) > 1:
-            raise TypeError(
-                "Sparse gradient is only implemented for single advanced indexing"
-            )
-
-        ret = AdvancedSubtensor1(sparse_grad=True)(x, indices[0])
-        return ret
+    ret = AdvancedSubtensor1(sparse_grad=True)(x, indices[0])
+    return ret

--- a/aesara/sparse/basic.py
+++ b/aesara/sparse/basic.py
@@ -508,10 +508,6 @@ class SparseConstant(TensorConstant, _sparse_py_operators):
         return str(self)
 
 
-SparseTensorType.variable_type = SparseVariable
-SparseTensorType.constant_type = SparseConstant
-
-
 # for more dtypes, call SparseTensorType(format, dtype)
 def matrix(format, name=None, dtype=None):
     if dtype is None:

--- a/aesara/sparse/type.py
+++ b/aesara/sparse/type.py
@@ -68,9 +68,13 @@ class SparseTensorType(TensorType, HasDataType):
     }
     ndim = 2
 
-    # Will be set to SparseVariable SparseConstant later.
-    variable_type = None
-    Constant = None
+    @property
+    def variable_type(self):
+        return aesara.sparse.SparseVariable
+
+    @property
+    def constant_type(self):
+        return aesara.sparse.SparseConstant
 
     def __init__(self, format, dtype, shape=None, broadcastable=None, name=None):
         if shape is None:

--- a/aesara/tensor/var.py
+++ b/aesara/tensor/var.py
@@ -1,9 +1,7 @@
-import copy
 import traceback as tb
 import warnings
 from collections.abc import Iterable
-from numbers import Number
-from typing import Optional, TypeVar
+from typing import TYPE_CHECKING, Optional, TypeVar
 
 import numpy as np
 
@@ -12,10 +10,14 @@ from aesara.configdefaults import config
 from aesara.graph.basic import Constant, OptionalApplyType, Variable
 from aesara.graph.utils import MetaType
 from aesara.scalar import ComplexError, IntegerDivisionError
-from aesara.tensor import _get_vector_length, as_tensor_variable
+from aesara.tensor import TensorLike, _get_vector_length, as_tensor_variable
 from aesara.tensor.exceptions import AdvancedIndexingError
 from aesara.tensor.type import TensorType
 from aesara.tensor.utils import hash_from_ndarray
+
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
 
 
 _TensorTypeType = TypeVar("_TensorTypeType", bound=TensorType)
@@ -826,8 +828,8 @@ class TensorVariable(
         self,
         type: _TensorTypeType,
         owner: OptionalApplyType,
-        index=None,
-        name=None,
+        index: Optional[int] = None,
+        name: Optional[str] = None,
     ):
         super().__init__(type, owner, index=index, name=name)
         if config.warn_float64 != "ignore" and type.dtype == "float64":
@@ -871,9 +873,6 @@ def _get_vector_length_TensorVariable(op_or_var, var):
     if var.type.shape[0] is None:
         raise ValueError(f"Length of {var} cannot be determined")
     return var.type.shape[0]
-
-
-TensorType.variable_type = TensorVariable
 
 
 class TensorConstantSignature(tuple):
@@ -976,7 +975,7 @@ class TensorConstantSignature(tuple):
     no_nan = property(_get_no_nan)
 
 
-def get_unique_value(x: TensorVariable) -> Optional[Number]:
+def get_unique_value(x: TensorLike) -> Optional[np.generic, np.ndarray]:
     """Return the unique value of a tensor, if there is one"""
     if isinstance(x, Constant):
         data = x.data
@@ -993,7 +992,9 @@ def get_unique_value(x: TensorVariable) -> Optional[Number]:
 class TensorConstant(TensorVariable, Constant[_TensorTypeType]):
     """Subclass to add the tensor operators to the basic `Constant` class."""
 
-    def __init__(self, type: _TensorTypeType, data, name=None):
+    def __init__(
+        self, type: _TensorTypeType, data: "ArrayLike", name: Optional[str] = None
+    ):
         data_shape = np.shape(data)
 
         if len(data_shape) != type.ndim or any(
@@ -1022,8 +1023,8 @@ class TensorConstant(TensorVariable, Constant[_TensorTypeType]):
         if self.name is not None:
             name = self.name
         else:
-            name = "TensorConstant"
-        return "%s{%s}" % (name, val)
+            name = type(self).__name__
+        return f"{name}{val}"
 
     def signature(self):
         return TensorConstantSignature((self.type, self.data))
@@ -1041,17 +1042,6 @@ class TensorConstant(TensorVariable, Constant[_TensorTypeType]):
     def __copy__(self):
         # We need to do this to remove the cached attribute
         return type(self)(self.type, self.data, self.name)
-
-    def __deepcopy__(self, memo):
-        # We need to do this to remove the cached attribute
-        return type(self)(
-            copy.deepcopy(self.type, memo),
-            copy.deepcopy(self.data, memo),
-            copy.deepcopy(self.name, memo),
-        )
-
-
-TensorType.constant_type = TensorConstant
 
 
 class DenseVariableMeta(MetaType):

--- a/setup.cfg
+++ b/setup.cfg
@@ -132,10 +132,6 @@ check_untyped_defs = False
 ignore_errors = True
 check_untyped_defs = False
 
-[mypy-aesara.tensor.type]
-ignore_errors = True
-check_untyped_defs = False
-
 [mypy-aesara.tensor.var]
 ignore_errors = True
 check_untyped_defs = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -132,10 +132,6 @@ check_untyped_defs = False
 ignore_errors = True
 check_untyped_defs = False
 
-[mypy-aesara.tensor.var]
-ignore_errors = True
-check_untyped_defs = False
-
 [mypy-aesara.tensor.basic]
 ignore_errors = True
 check_untyped_defs = False


### PR DESCRIPTION
This PR enables type checking for a few of the `aesara.tensor` modules.

There are still some inherent class/interface design issues that prevent type checking from working without manual intervention.  One of the biggest issues has to do with our use  of `Type.variable_type` and `Type.constant_type`.  These "late binding" class-level `type` attributes determine the return type of `Type.__call__`, but we aren't able to use those attribute values during static type checking, so something else needs to be done.  The current approach has subclasses (e.g. `TensorType`) re-declare/define their `__call__` methods, but this is less than ideal.


Also, there's still a weird issue with the parameterized `Apply` type in `Variable`.  The current approach kind of works for the base class `Variable`, but, in subclasses like `TensorVariable`, the generic type parameter (e.g. `OptionalApplyType`) is expanded to its variants (e.g. `None` or `Apply`) and fails when the `super().__init__` constructor is type checked, since it expects the generic type parameter&mdash;for some reason.