### PR TITLE
Fix typing error in numba MakeVector impl

### DIFF
--- a/aesara/link/numba/dispatch/tensor_basic.py
+++ b/aesara/link/numba/dispatch/tensor_basic.py
@@ -171,7 +171,7 @@ def numba_funcify_Eye(op, **kwargs):
 def numba_funcify_MakeVector(op, node, **kwargs):
     dtype = np.dtype(op.dtype)
 
-    global_env = {"np": np, "to_scalar": numba_basic.to_scalar}
+    global_env = {"np": np, "to_scalar": numba_basic.to_scalar, "dtype": dtype}
 
     unique_names = unique_name_generator(
         ["np", "to_scalar"],
@@ -185,7 +185,7 @@ def numba_funcify_MakeVector(op, node, **kwargs):
 
     makevector_def_src = f"""
 def makevector({", ".join(input_names)}):
-    return np.array({create_list_string(input_names)}, dtype=np.{dtype})
+    return np.array({create_list_string(input_names)}, dtype=dtype)
     """
 
     makevector_fn = compile_function_src(

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -998,6 +998,10 @@ def test_scalar_Elemwise_Clip():
             (set_test_value(at.iscalar(), np.array(1, dtype=np.int32)),),
             "float64",
         ),
+        (
+            (set_test_value(at.scalar(dtype=bool), True),),
+            bool,
+        ),
     ],
 )
 def test_MakeVector(vals, dtype):


### PR DESCRIPTION
Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [ ] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [x] There are tests covering the changes introduced in the PR.

In numba `np.array([], dtype=np.bool)` doesn't typecheck, but `np.array([], dtype=bool)` does:

```python
import numba
import numpy as np

@numba.njit
def foo():
    return np.array([True], dtype=np.bool)  # doesn't work
    # return np.array([True], dtype=bool)  # works
```

This leads to compilation errors for graphs like this:
```python
import aesara
import aesara.tensor as at

x = at.scalar(dtype=bool)
make_vector = aesara.tensor.basic.MakeVector(dtype=bool)
y = make_vector(x)
func = aesara.function([x], y, mode="NUMBA")
func(True)
```

We can fix this by passing the dtype as an object into the jited function, instead of relying on string formatting.