### PR TITLE
Prevent `Print` from being constant folded

### DIFF
--- a/aesara/printing.py
+++ b/aesara/printing.py
@@ -802,6 +802,9 @@ class Print(Op):
     def c_code_cache_version(self):
         return (1,)
 
+    def do_constant_folding(self, fgraph, node):
+        return False
+
 
 class PrinterState(Scratchpad):
     def __init__(self, props=None, **more_props):


### PR DESCRIPTION
This PR prevents the `Print` `Op` from being constant folded and, as a result, unintentionally removed from graphs compiled in modes like `FAST_RUN`.