### PR TITLE
Handle duplicate indices in Numba implementation of `AdvancedIncSubtensor1`

### DIFF
--- a/aesara/link/numba/dispatch/extra_ops.py
+++ b/aesara/link/numba/dispatch/extra_ops.py
@@ -54,7 +54,7 @@ def numba_funcify_CumOp(op, node, **kwargs):
         x_axis_first = x.transpose(reaxis_first)
         res = np.empty(x_axis_first.shape, dtype=out_dtype)
 
-        for m in numba.prange(x.shape[axis]):
+        for m in range(x.shape[axis]):
             if m == 0:
                 np_func(identity, x_axis_first[m], res[m])
             else:

--- a/aesara/tensor/subtensor.py
+++ b/aesara/tensor/subtensor.py
@@ -2127,7 +2127,11 @@ class AdvancedIncSubtensor1(COp):
             self.destroy_map = {0: [0]}
 
     def clone_inplace(self):
-        return self.__class__(inplace=True, set_instead_of_inc=self.set_instead_of_inc)
+        return self.__class__(
+            inplace=True,
+            set_instead_of_inc=self.set_instead_of_inc,
+            boundscheck=self.boundscheck,
+        )
 
     def __str__(self):
         if self.inplace:

--- a/aesara/tensor/subtensor.py
+++ b/aesara/tensor/subtensor.py
@@ -2115,13 +2115,14 @@ class AdvancedIncSubtensor1(COp):
 
     """
 
-    __props__ = ("inplace", "set_instead_of_inc")
+    __props__ = ("inplace", "set_instead_of_inc", "boundscheck")
     check_input = False
     params_type = ParamsType(inplace=aes.bool, set_instead_of_inc=aes.bool)
 
-    def __init__(self, inplace=False, set_instead_of_inc=False):
+    def __init__(self, inplace=False, set_instead_of_inc=False, boundscheck=True):
         self.inplace = bool(inplace)
         self.set_instead_of_inc = bool(set_instead_of_inc)
+        self.boundscheck = boundscheck
         if inplace:
             self.destroy_map = {0: [0]}
 
@@ -2137,6 +2138,10 @@ class AdvancedIncSubtensor1(COp):
             msg += ",set"
         else:
             msg += ",inc"
+        if self.boundscheck:
+            msg += ",check"
+        else:
+            msg += ",no_check"
 
         return self.__class__.__name__ + "{%s}" % msg
 

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -1517,9 +1517,7 @@ def test_perform_params():
         out = [out]
 
     out_fg = FunctionGraph([x], out)
-
-    with pytest.warns(UserWarning, match=".*object mode.*"):
-        compare_numba_and_py(out_fg, [get_test_value(i) for i in out_fg.inputs])
+    compare_numba_and_py(out_fg, [get_test_value(i) for i in out_fg.inputs])
 
 
 def test_perform_type_convert():
@@ -1538,9 +1536,7 @@ def test_perform_type_convert():
         out = [out]
 
     out_fg = FunctionGraph([x], out)
-
-    with pytest.warns(UserWarning, match=".*object mode.*"):
-        compare_numba_and_py(out_fg, [get_test_value(i) for i in out_fg.inputs])
+    compare_numba_and_py(out_fg, [get_test_value(i) for i in out_fg.inputs])
 
 
 @pytest.mark.parametrize(

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -586,12 +586,13 @@ def test_AdvancedIncSubtensor1(inplace, set_instead_of_inc, x, y, indices, error
         inplace=inplace, set_instead_of_inc=set_instead_of_inc
     )(x_at, y, indices)
     assert isinstance(out_at.owner.op, at_subtensor.AdvancedIncSubtensor1)
-    out_fg = FunctionGraph([x_at], [out_at])
 
     if error is not None:
         with pytest.raises(error):
-            compare_numba_and_py(out_fg, [x.data])
+            func = function([x_at], [out_at], mode="NUMBA", accept_inplace=True)
+            func(x.data)
     else:
+        out_fg = FunctionGraph([x_at], [out_at])
         compare_numba_and_py(out_fg, [x.data])
 
     # Test with non-constant indices
@@ -605,7 +606,8 @@ def test_AdvancedIncSubtensor1(inplace, set_instead_of_inc, x, y, indices, error
 
     if error is not None:
         with pytest.raises(error):
-            compare_numba_and_py(out_fg, [x.data, indices])
+            func = function([x_at, idxs], [out_at], mode="NUMBA", accept_inplace=True)
+            func(x.data, indices)
     else:
         compare_numba_and_py(out_fg, [x.data, indices])
 


### PR DESCRIPTION
Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [ ] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [x] There are tests covering the changes introduced in the PR.

First, this PR removes the incorrect numba implementation of `AdvancedIncSubtensor`, so this will now just fall back to objectmode, and be slow and correct. (We should also provide a numba impl for this, but that will be a separate PR).

But we do add a new implementation for `AdvancedIncSubtensor1` (the much more common case). Here, we also take advantage of the fact that sometimes we know the indices beforehand, so we can simplify bounds checks, and generate cleaner and faster assembly code.

Also a one line fix for cumop accidentally made its way into the PR, but this is simple enough that maybe we can just keep it here? (it has its own commit).
The problem was that the `numba.prange` loop had data races.

fixes https://github.com/aesara-devs/aesara/issues/603