### PR TITLE
Add Owens-T Function `Op`

### DIFF
--- a/aesara/scalar/math.py
+++ b/aesara/scalar/math.py
@@ -250,6 +250,35 @@ class Erfcinv(UnaryScalarOp):
 erfcinv = Erfcinv(upgrade_to_float_no_complex, name="erfcinv")
 
 
+class Owens_t(BinaryScalarOp):
+    nfunc_spec = ("scipy.special.owens_t", 2, 1)
+
+    @staticmethod
+    def st_impl(h, a):
+        return scipy.special.owens_t(h, a)
+
+    def impl(self, h, a):
+        return Owens_t.st_impl(h, a)
+
+    def grad(self, inputs, grads):
+        (h, a) = inputs
+        (gz,) = grads
+        return [
+            gz
+            * (-1)
+            * exp(-(h**2) / 2)
+            * erf(a * h / np.sqrt(2))
+            / (2 * np.sqrt(2 * np.pi)),
+            gz * exp(-0.5 * (a**2 + 1) * h**2) / (2 * np.pi * (a**2 + 1)),
+        ]
+
+    def c_code(self, *args, **kwargs):
+        raise NotImplementedError()
+
+
+owens_t = Owens_t(upgrade_to_float, name="owens_t")
+
+
 class Gamma(UnaryScalarOp):
     nfunc_spec = ("scipy.special.gamma", 1, 1)
 

--- a/aesara/tensor/inplace.py
+++ b/aesara/tensor/inplace.py
@@ -234,6 +234,11 @@ def erfcx_inplace(a):
 
 
 @scalar_elemwise
+def owens_t_inplace(h, a):
+    """owens t function"""
+
+
+@scalar_elemwise
 def gamma_inplace(a):
     """gamma function"""
 

--- a/aesara/tensor/math.py
+++ b/aesara/tensor/math.py
@@ -1340,6 +1340,11 @@ def erfcinv(a):
 
 
 @scalar_elemwise
+def owens_t(h, a):
+    """owens t function"""
+
+
+@scalar_elemwise
 def gamma(a):
     """gamma function"""
 
@@ -3062,6 +3067,7 @@ __all__ = [
     "erfcx",
     "erfinv",
     "erfcinv",
+    "owens_t",
     "gamma",
     "gammaln",
     "psi",

--- a/tests/tensor/test_math_scipy.py
+++ b/tests/tensor/test_math_scipy.py
@@ -53,6 +53,7 @@ expected_erf = scipy.special.erf
 expected_erfc = scipy.special.erfc
 expected_erfinv = scipy.special.erfinv
 expected_erfcinv = scipy.special.erfcinv
+expected_owenst = scipy.special.owens_t
 expected_gamma = scipy.special.gamma
 expected_gammaln = scipy.special.gammaln
 expected_psi = scipy.special.psi
@@ -144,6 +145,55 @@ TestErfcinvBroadcast = makeBroadcastTester(
     grad=_grad_broadcast_unary_0_2_no_complex,
     eps=2e-10,
     mode=mode_no_scipy,
+)
+
+rng = np.random.default_rng(seed=utt.fetch_seed())
+_good_broadcast_binary_owenst = dict(
+    normal=(
+        random_ranged(-5, 5, (2, 3), rng=rng),
+        random_ranged(-5, 5, (2, 3), rng=rng),
+    ),
+    empty=(np.asarray([], dtype=config.floatX), np.asarray([], dtype=config.floatX)),
+    int=(
+        integers_ranged(-5, 5, (2, 3), rng=rng),
+        integers_ranged(-5, 5, (2, 3), rng=rng),
+    ),
+    uint8=(
+        integers_ranged(1, 6, (2, 3), rng=rng).astype("uint8"),
+        integers_ranged(1, 6, (2, 3), rng=rng).astype("uint8"),
+    ),
+    uint16=(
+        integers_ranged(1, 10, (2, 3), rng=rng).astype("uint16"),
+        integers_ranged(1, 10, (2, 3), rng=rng).astype("uint16"),
+    ),
+    uint64=(
+        integers_ranged(1, 10, (2, 3), rng=rng).astype("uint64"),
+        integers_ranged(1, 10, (2, 3), rng=rng).astype("uint64"),
+    ),
+)
+
+_grad_broadcast_binary_owenst = dict(
+    normal=(
+        random_ranged(-5, 5, (2, 3), rng=rng),
+        random_ranged(-5, 5, (2, 3), rng=rng),
+    )
+)
+
+TestOwensTBroadcast = makeBroadcastTester(
+    op=at.owens_t,
+    expected=expected_owenst,
+    good=_good_broadcast_binary_owenst,
+    grad=_grad_broadcast_binary_owenst,
+    eps=2e-10,
+    mode=mode_no_scipy,
+)
+TestOwensTInplaceBroadcast = makeBroadcastTester(
+    op=inplace.owens_t_inplace,
+    expected=expected_owenst,
+    good=_good_broadcast_binary_owenst,
+    eps=2e-10,
+    mode=mode_no_scipy,
+    inplace=True,
 )
 
 rng = np.random.default_rng(seed=utt.fetch_seed())


### PR DESCRIPTION
This draft PR adds `scipy.special's` `owens_t`-function, needed primarily in the computation of a skewed Gaussian's CDF [1]. The gradient is taken from wolfram alpha ([2] and [3]).

As I've never contributed to aesara before I'm open for any feedback. 

[1] https://en.wikipedia.org/wiki/Skew_normal_distribution
[2] https://www.wolframalpha.com/input?i=d%2Fdh+OwenT%5Bh%2C+a%5D
[3] https://www.wolframalpha.com/input?i=d%2Fda+OwenT%5Bh%2C+a%5D

Here are a few important guidelines and requirements to check before your PR can be merged:

- [x] There is an informative high-level description of the changes.
- [x] The description and/or commit message(s) references the relevant GitHub issue(s).
- [x] [pre-commit](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
- [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] The commits correspond to [relevant logical changes](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are no commits that fix changes introduced by other commits in the same branch/BR.
- [x] There are tests covering the changes introduced in the PR.