### PR TITLE
Add docstring for the `GammaRV` Op

### DIFF
--- a/aesara/tensor/random/basic.py
+++ b/aesara/tensor/random/basic.py
@@ -160,6 +160,19 @@ lognormal = LogNormalRV()
 
 
 class GammaRV(ScipyRandomVariable):
+    r"""A gamma continuous random variable.
+
+    The probability density function for `gamma` in terms of `shape = alpha` and `rate = beta` is:
+
+    .. math::
+
+        f(x, \alpha, \beta) = \frac{\beta^\alpha}{\Gamma(\alpha)}x^{\alpha-1}e^{-\beta x}
+
+    for :math:`x \geq 0`, :math:`\alpha > 0` and :math:`\beta > 0`. `gamma`
+    takes ``shape`` as a shape parameter for :math:`\alpha` and ``rate`` as a
+    rate parameter for :math:`\beta`.
+
+    """
     name = "gamma"
     ndim_supp = 0
     ndims_params = [0, 0]
@@ -167,6 +180,22 @@ class GammaRV(ScipyRandomVariable):
     _print_name = ("Gamma", "\\operatorname{Gamma}")
 
     def __call__(self, shape, rate, size=None, **kwargs):
+        """Return gamma-distributed random variables.
+
+        Parameters
+        ----------
+        shape
+            The shape of the gamma distribution. Must be positive.
+        rate
+            The rate of the gamma distribution. Must be positive.
+        size
+            Sample shape. If the given size is, e.g. `(m, n, k)` then `m * n * k`
+            independent, identically distributed random variables are
+            returned. Default is `None` in which case a single random variable
+            is returned.
+
+        """
+
         return super().__call__(shape, 1.0 / rate, size=size, **kwargs)
 
     @classmethod

--- a/doc/library/tensor/random/basic.rst
+++ b/doc/library/tensor/random/basic.rst
@@ -43,3 +43,11 @@ Reference
     :class:`Op` that draws random numbers from a :class:`numpy.random.RandomState` object.
     This :class:`Op` is parameterized to draw numbers from many possible
     distributions.
+
+Distributions
+==============
+
+Aesara can produce :class:`RandomVariable`\s that draw samples from many different statistical distributions, using the following :class:`Op`\s.
+
+.. autoclass:: aesara.tensor.random.basic.GammaRV
+   :members: __call__


### PR DESCRIPTION
In this PR I add a docstring for the `GammaRV` Op.

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [NA] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [NA] There are tests covering the changes introduced in the PR.