### PR TITLE
Change R-operator to L-operator in `Lop` docstring

### DIFF
--- a/aesara/gradient.py
+++ b/aesara/gradient.py
@@ -377,10 +377,10 @@ def Lop(
     Parameters
     ----------
     f
-        The outputs of the computational graph to which the R-operator is
+        The outputs of the computational graph to which the L-operator is
         applied.
     wrt
-        Variables for which the R-operator of `f` is computed.
+        Variables for which the L-operator of `f` is computed.
     eval_points
         Points at which to evaluate each of the variables in `wrt`.
     consider_constant


### PR DESCRIPTION
This PR fixes some typos in the `Lop` docstring.