### PR TITLE
Allow `size` to broadcast `CategoricalRV` `p` argument

### DIFF
--- a/aesara/tensor/random/basic.py
+++ b/aesara/tensor/random/basic.py
@@ -1121,20 +1121,17 @@ class CategoricalRV(RandomVariable):
     @classmethod
     def rng_fn(cls, rng, p, size):
         if size is None:
-            size = ()
-
-        size = tuple(np.atleast_1d(size))
-        ind_shape = p.shape[:-1]
-
-        if len(ind_shape) > 0:
-            if len(size) > 0 and size[-len(ind_shape) :] != ind_shape:
-                raise ValueError("Parameters shape and size do not match.")
-
-            samples_shape = size[: -len(ind_shape)] + ind_shape
+            size = p.shape[:-1]
         else:
-            samples_shape = size
+            # Check that `size` does not define a shape that would be broadcasted
+            # to `p.shape[:-1]` in the call to `vsearchsorted` below.
+            if len(size) < (p.ndim - 1):
+                raise ValueError("`size` is incompatible with the shape of `p`")
+            for s, ps in zip(reversed(size), reversed(p.shape[:-1])):
+                if s == 1 and ps != 1:
+                    raise ValueError("`size` is incompatible with the shape of `p`")
 
-        unif_samples = rng.uniform(size=samples_shape)
+        unif_samples = rng.uniform(size=size)
         samples = vsearchsorted(p.cumsum(axis=-1), unif_samples)
 
         return samples

--- a/tests/link/test_numba.py
+++ b/tests/link/test_numba.py
@@ -3221,13 +3221,28 @@ def test_unaligned_RandomVariable(rv_op, dist_args, base_size, cdf_name, params_
                 set_test_value(
                     at.dmatrix(),
                     np.array(
+                        [[100000, 1, 1]],
+                        dtype=np.float64,
+                    ),
+                ),
+            ],
+            (5, 4, 3),
+            contextlib.suppress(),
+        ),
+        pytest.param(
+            [
+                set_test_value(
+                    at.dmatrix(),
+                    np.array(
                         [[100000, 1, 1], [1, 100000, 1], [1, 1, 100000]],
                         dtype=np.float64,
                     ),
                 ),
             ],
             (10, 4),
-            pytest.raises(ValueError, match="Parameters shape.*"),
+            pytest.raises(
+                ValueError, match="objects cannot be broadcast to a single shape"
+            ),
         ),
     ],
 )


### PR DESCRIPTION
Follow up to https://github.com/aesara-devs/aesara/pull/1056