### PR TITLE
Fix incorrect setuptools minimum version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ install_requires = [
     "miniKanren",
     "cons",
     "typing_extensions",
-    "setuptools>=45.0.0",
+    "setuptools>=48.0.0",
 ]
 
 


### PR DESCRIPTION
With setuptools < 48.0.0, Aesara causes the following exception:

```
/opt/hostedtoolcache/Python/3.7.13/x64/lib/python3.7/site-packages/aesara/configdefaults.py:11: in <module>
    from setuptools._distutils.spawn import find_executable
E   ModuleNotFoundError: No module named 'setuptools._distutils'
```

For full details, see https://github.com/pymc-devs/pymc/issues/6013. In particular, my reasoning for determining 48.0.0 is explained in https://github.com/pymc-devs/pymc/issues/6013#issuecomment-1196435732.

**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [X] There is an informative high-level description of the changes.
+ [X] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [X] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [X] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.
