### PR TITLE
Fix handling of `numpy.dtype` input in `TensorType`

### DIFF
--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -92,7 +92,7 @@ class TensorType(CType[np.ndarray], HasDataType, HasShape):
             )
             shape = broadcastable
 
-        if dtype == "floatX":
+        if str(dtype) == "floatX":
             self.dtype = config.floatX
         else:
             if np.obj2sctype(dtype) is None:

--- a/tests/tensor/test_type.py
+++ b/tests/tensor/test_type.py
@@ -10,9 +10,18 @@ from aesara.tensor.shape import SpecifyShape
 from aesara.tensor.type import TensorType
 
 
-def test_numpy_dtype():
-    test_type = TensorType(np.int32, [])
-    assert test_type.dtype == "int32"
+@pytest.mark.parametrize(
+    "dtype, exp_dtype",
+    [
+        (np.int32, "int32"),
+        (np.dtype(np.int32), "int32"),
+        ("int32", "int32"),
+        ("floatX", config.floatX),
+    ],
+)
+def test_numpy_dtype(dtype, exp_dtype):
+    test_type = TensorType(dtype, [])
+    assert test_type.dtype == exp_dtype
 
 
 def test_in_same_class():


### PR DESCRIPTION
This PR fixes a bug caused by string comparisons of `numpy.dtype` instances with `"floatX"`.