### PR TITLE
Remove defaults channel from conda env for docs

### DIFF
--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,7 +1,7 @@
 name: aesara-docs
 channels:
-  - defaults
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.7
   - gcc_linux-64

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,3 +3,7 @@ sphinx:
   configuration: doc/conf.py
 conda:
   environment: doc/environment.yml
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"


### PR DESCRIPTION
All the packages are available through conda-forge, and mixing different channels is just a recipe for trouble.

Motivation: for reasons which I don't understand, building the docs has been failing with a 404 error for the `defaults` Conda channel. But everything is available from the `conda-forge` channel, so having the `defaults` channel is pointless. Moreover, if anything does sneak in through the `defaults` channel, it may cause conflicts with the `conda-forge` packages. Thus it's best to just remove it.

**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [X] There is an informative high-level description of the changes.
+ [ ] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [X] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [X] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
