### PR TITLE
Fix broadcasting conditions in `broadcast_shape_iter`

### DIFF
--- a/aesara/tensor/extra_ops.py
+++ b/aesara/tensor/extra_ops.py
@@ -1548,15 +1548,26 @@ def broadcast_shape_iter(
                 )
 
                 if len(nonconst_nb_shapes) > 0:
+                    # All the potential non-broadcast shapes need to either
+                    # be broadcastable or equal to the one non-broadcastable
+                    # constant `const_nt_shape_var`.
                     assert_dim = Assert("Could not broadcast dimensions")
                     assert_cond = reduce(
                         aes.and_,
-                        (aes.eq(nbv, const_nt_shape_var) for nbv in nonconst_nb_shapes),
+                        (
+                            aes.or_(
+                                aes.eq(nbv, one_at), aes.eq(nbv, const_nt_shape_var)
+                            )
+                            for nbv in nonconst_nb_shapes
+                        ),
                     )
                     bcast_dim = assert_dim(const_nt_shape_var, assert_cond)
                 else:
                     bcast_dim = const_nt_shape_var
             else:
+                # There are no constant, non-broadcastable shapes in this
+                # dimension.
+
                 all_dims_equal = all(
                     # TODO FIXME: This is a largely deficient, and expensive, means
                     # of comparing graphs (and especially shapes)

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -1198,6 +1198,31 @@ def test_broadcast_shape_symbolic(s1_vals, s2_vals, exp_res):
     assert tuple(res.eval(eval_point)) == exp_res
 
 
+def test_broadcast_shape_symbolic_one_symbolic():
+    """Test case for a constant non-broadcast shape and a symbolic shape."""
+    one_at = at.as_tensor(1, dtype=np.int64)
+    three_at = at.as_tensor(3, dtype=np.int64)
+    int_div = one_at / one_at
+
+    assert int_div.owner.op == at.true_div
+
+    index_shapes = [
+        (one_at, one_at, three_at),
+        (one_at, int_div, one_at),
+        (one_at, one_at, int_div),
+    ]
+
+    res_shape = broadcast_shape(*index_shapes, arrays_are_shapes=True)
+
+    from aesara.graph.rewriting.utils import rewrite_graph
+
+    res_shape = rewrite_graph(res_shape)
+
+    assert res_shape[0].data == 1
+    assert res_shape[1].data == 1
+    assert res_shape[2].data == 3
+
+
 class TestBroadcastTo(utt.InferShapeTester):
     def setup_method(self):
         super().setup_method()

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -2463,90 +2463,83 @@ def test_basic_shape():
     assert get_test_value(res) == (2,)
 
 
-@config.change_flags(compute_test_value="raise")
-def test_indexed_result_shape():
-    _test_idx = np.ix_(np.array([True, True]), np.array([True]), np.array([True, True]))
+def idx_as_tensor(x):
+    if isinstance(x, (slice, type(None))):
+        return x
+    else:
+        return at.as_tensor(x)
 
-    test_shape = (5, 6, 7, 8)
-    test_array = np.arange(np.prod(test_shape)).reshape(test_shape)
 
-    def idx_as_tensor(x):
-        if isinstance(x, (slice, type(None))):
-            return x
-        else:
-            return at.as_tensor(x)
-
-    def bcast_shape_tuple(x):
-        if not hasattr(x, "shape"):
-            return x
-        return tuple(
-            s if not bcast else 1 for s, bcast in zip(tuple(x.shape), x.broadcastable)
-        )
-
-    def compare_index_shapes(test_array, test_idx):
-        res = indexed_result_shape(
-            at.as_tensor(test_array).shape, [idx_as_tensor(i) for i in test_idx]
-        )
-        exp_res = test_array[test_idx].shape
-        assert np.array_equal(tuple(get_test_value(r) for r in res), exp_res)
-
-        # Test shape-only version
-        res = indexed_result_shape(
-            at.as_tensor(test_array).shape,
-            [bcast_shape_tuple(idx_as_tensor(i)) for i in test_idx],
-            indices_are_shapes=True,
-        )
-        exp_res = test_array[test_idx].shape
-        assert np.array_equal(tuple(get_test_value(r) for r in res), exp_res)
-
-    # Simple basic indices
-    test_idx = (slice(None, None),)
-    compare_index_shapes(test_array, test_idx)
-
-    # Advanced indices
-    test_idx = (2,)
-    compare_index_shapes(test_array, test_idx)
-
-    test_idx = _test_idx[:1]
-    compare_index_shapes(test_array, test_idx)
-
-    test_idx = _test_idx[:2]
-    compare_index_shapes(test_array, test_idx)
-
-    # A Mix of advanced and basic indices
-    test_idx = _test_idx[:2] + (slice(None, None),)
-    compare_index_shapes(test_array, test_idx)
-
-    test_idx = (slice(None, None),) + _test_idx[1:]
-    compare_index_shapes(test_array, test_idx)
-
-    test_idx = (slice(None, None), None) + _test_idx[1:2]
-    compare_index_shapes(test_array, test_idx)
-
-    test_idx = (np.array(1), slice(None, None), None)
-    compare_index_shapes(test_array, test_idx)
-
-    test_idx = (slice(None, None), None, np.array(1))
-    compare_index_shapes(test_array, test_idx)
-
-    test_idx = _test_idx[:1] + (slice(None, None),) + _test_idx[1:2]
-    compare_index_shapes(test_array, test_idx)
-
-    test_idx = (
-        _test_idx[:1] + (slice(None, None),) + _test_idx[1:2] + (slice(None, None),)
+def bcast_shape_tuple(x):
+    if not hasattr(x, "shape"):
+        return x
+    return tuple(
+        s if not bcast else 1 for s, bcast in zip(tuple(x.shape), x.broadcastable)
     )
-    compare_index_shapes(test_array, test_idx)
 
-    test_idx = _test_idx[:1] + (None,) + _test_idx[1:2]
-    compare_index_shapes(test_array, test_idx)
 
-    test_shape = (5, 4)
-    test_array = np.arange(np.prod(test_shape)).reshape(test_shape)
-    test_idx = ([1, 3, 2], slice(1, 3))
-    compare_index_shapes(test_array, test_idx)
+test_idx = np.ix_(np.array([True, True]), np.array([True]), np.array([True, True]))
 
-    test_idx = (slice(1, 3), [1, 3, 2])
-    compare_index_shapes(test_array, test_idx)
+
+@pytest.mark.parametrize(
+    "test_array, test_idx",
+    [
+        (np.arange(np.prod((5, 6, 7, 8))).reshape((5, 6, 7, 8)), (slice(None, None),)),
+        (np.arange(np.prod((5, 6, 7, 8))).reshape((5, 6, 7, 8)), (2,)),
+        (np.arange(np.prod((5, 6, 7, 8))).reshape((5, 6, 7, 8)), test_idx[:1]),
+        (np.arange(np.prod((5, 6, 7, 8))).reshape((5, 6, 7, 8)), test_idx[:2]),
+        (
+            np.arange(np.prod((5, 6, 7, 8))).reshape((5, 6, 7, 8)),
+            test_idx[:2] + (slice(None, None),),
+        ),
+        (
+            np.arange(np.prod((5, 6, 7, 8))).reshape((5, 6, 7, 8)),
+            (slice(None, None),) + test_idx[:1],
+        ),
+        (
+            np.arange(np.prod((5, 6, 7, 8))).reshape((5, 6, 7, 8)),
+            (slice(None, None), None) + test_idx[1:2],
+        ),
+        (
+            np.arange(np.prod((5, 6, 7, 8))).reshape((5, 6, 7, 8)),
+            (np.array(1), slice(None, None), None),
+        ),
+        (
+            np.arange(np.prod((5, 6, 7, 8))).reshape((5, 6, 7, 8)),
+            (slice(None, None), None, np.array(1)),
+        ),
+        (
+            np.arange(np.prod((5, 6, 7, 8))).reshape((5, 6, 7, 8)),
+            test_idx[:1] + (slice(None, None),) + test_idx[1:2],
+        ),
+        (
+            np.arange(np.prod((5, 6, 7, 8))).reshape((5, 6, 7, 8)),
+            test_idx[:1] + (slice(None, None),) + test_idx[1:2] + (slice(None, None),),
+        ),
+        (
+            np.arange(np.prod((5, 6, 7, 8))).reshape((5, 6, 7, 8)),
+            test_idx[:1] + (None,) + test_idx[1:2],
+        ),
+        (np.arange(np.prod((5, 4))).reshape((5, 4)), ([1, 3, 2], slice(1, 3))),
+        (np.arange(np.prod((5, 4))).reshape((5, 4)), (slice(1, 3), [1, 3, 2])),
+    ],
+)
+@config.change_flags(compute_test_value="raise")
+def test_indexed_result_shape(test_array, test_idx):
+    res = indexed_result_shape(
+        at.as_tensor(test_array).shape, [idx_as_tensor(i) for i in test_idx]
+    )
+    exp_res = test_array[test_idx].shape
+    assert np.array_equal(tuple(get_test_value(r) for r in res), exp_res)
+
+    # Test shape-only version
+    res = indexed_result_shape(
+        at.as_tensor(test_array).shape,
+        [bcast_shape_tuple(idx_as_tensor(i)) for i in test_idx],
+        indices_are_shapes=True,
+    )
+    exp_res = test_array[test_idx].shape
+    assert np.array_equal(tuple(get_test_value(r) for r in res), exp_res)
 
 
 def test_symbolic_slice():


### PR DESCRIPTION
This PR fixes faulty broadcast conditions in some of the `Assert`s produced by `broadcast_shape_iter`.