### PR TITLE
Fix a numpy deprecation related to dtype

### DIFF
--- a/aesara/misc/safe_asarray.py
+++ b/aesara/misc/safe_asarray.py
@@ -31,6 +31,11 @@ def _asarray(a, dtype, order=None):
     """
     if str(dtype) == "floatX":
         dtype = config.floatX
+    try:
+        if not isinstance(dtype, type) and not isinstance(dtype.dtype, np.dtype):
+            dtype = dtype.dtype
+    except AttributeError:
+        pass
     dtype = np.dtype(dtype)  # Convert into dtype object.
     rval = np.asarray(a, dtype=dtype, order=order)
     # Note that dtype comparison must be done by comparing their `num`

--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -719,6 +719,11 @@ def cast(x, dtype: Union[str, np.dtype]) -> TensorVariable:
 
     if isinstance(dtype, str) and dtype == "floatX":
         dtype = config.floatX
+    try:
+        if not isinstance(dtype, type) and not isinstance(dtype.dtype, np.dtype):
+            dtype = dtype.dtype
+    except AttributeError:
+        pass
 
     dtype_name = np.dtype(dtype).name
 


### PR DESCRIPTION
Deprecated in numpy 1.21.0.
This fixes 369 deprecation warnings in PyMC's test suite.

See https://numpy.org/doc/stable/release/1.21.0-notes.html#the-dtype-attribute-must-return-a-dtype


**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [x] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
