### PR TITLE
Add a rewrite that changes constant indices to unsigned integers

### DIFF
--- a/aesara/tensor/subtensor.py
+++ b/aesara/tensor/subtensor.py
@@ -41,6 +41,10 @@ from aesara.tensor.type import (
     iscalar,
     lscalar,
     tensor,
+    ubscalar,
+    uiscalar,
+    ulscalar,
+    uwscalar,
     wscalar,
     zscalar,
 )
@@ -50,12 +54,25 @@ from aesara.tensor.type_other import NoneConst, NoneTypeT, SliceType, make_slice
 _logger = logging.getLogger("aesara.tensor.subtensor")
 
 invalid_scal_types = (aes.float64, aes.float32, aes.float16)
-scal_types = (aes.int64, aes.int32, aes.int16, aes.int8)
+scal_types = (
+    aes.int64,
+    aes.int32,
+    aes.int16,
+    aes.int8,
+    aes.uint64,
+    aes.uint32,
+    aes.uint16,
+    aes.uint8,
+)
 tensor_types = (
     lscalar,
     iscalar,
     wscalar,
     bscalar,
+    ulscalar,
+    uiscalar,
+    uwscalar,
+    ubscalar,
 )
 invalid_tensor_types = (
     fscalar,
@@ -376,7 +393,7 @@ def slice_len(slc, n):
 def is_basic_idx(idx):
     """Determine if an index is of the NumPy basic type.
 
-    XXX: This only checks a single index, so an integers is *not* considered a
+    XXX: This only checks a single index, so an integer is *not* considered a
     basic index, because--depending on the other indices its used with--an
     integer can indicate advanced indexing.
 

--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -781,6 +781,10 @@ bscalar = TensorType("int8", ())
 wscalar = TensorType("int16", ())
 iscalar = TensorType("int32", ())
 lscalar = TensorType("int64", ())
+ubscalar = TensorType("uint8", ())
+uwscalar = TensorType("uint16", ())
+uiscalar = TensorType("uint32", ())
+ulscalar = TensorType("uint64", ())
 
 
 def scalar(name=None, dtype=None):

--- a/aesara/tensor/var.py
+++ b/aesara/tensor/var.py
@@ -515,13 +515,13 @@ class _tensor_py_operators:
                 isinstance(val, np.ndarray) and val.size == 0
             )
 
-        # Force input to be int64 datatype if input is an empty list or tuple
+        # Force input to be an int datatype if input is an empty list or tuple
         # Else leave it as is if it is a real number
         # Convert python literals to aesara constants
         args = tuple(
             [
                 at.subtensor.as_index_constant(
-                    np.array(inp, dtype=np.int64) if is_empty_array(inp) else inp
+                    np.array(inp, dtype=np.uint8) if is_empty_array(inp) else inp
                 )
                 for inp in args
             ]

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -618,7 +618,7 @@ def test_debugprint_compiled_fn():
     forall_inplace,cpu,scan_fn} [id A] (outer_out_sit_sot-0)
     >Elemwise{Composite{Switch(LT(i0, i1), i2, i0)}} [id I] (inner_out_sit_sot-0)
     > |TensorConstant{0} [id J]
-    > |Subtensor{int64, int64, int64} [id K]
+    > |Subtensor{int64, int64, uint8} [id K]
     > | |*2-<TensorType(float64, (20000, 2, 2))> [id L] -> [id H] (inner_in_non_seqs-0)
     > | |ScalarFromTensor [id M]
     > | | |*0-<TensorType(int64, ())> [id N] -> [id C] (inner_in_seqs-0)

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -2615,3 +2615,8 @@ def test_index_vars_to_types():
 
     res = index_vars_to_types(iscalar)
     assert isinstance(res, scal.ScalarType)
+
+    x = scal.constant(1, dtype=np.uint8)
+    assert isinstance(x.type, scal.ScalarType)
+    res = index_vars_to_types(x)
+    assert res == x.type

--- a/tests/tensor/test_var.py
+++ b/tests/tensor/test_var.py
@@ -26,7 +26,7 @@ from aesara.tensor.type import (
     scalar,
     tensor3,
 )
-from aesara.tensor.type_other import MakeSlice
+from aesara.tensor.type_other import MakeSlice, NoneConst
 from aesara.tensor.var import (
     DenseTensorConstant,
     DenseTensorVariable,
@@ -221,6 +221,7 @@ def test_print_constant():
     [
         (tensor3(), (np.newaxis, slice(None), np.newaxis), ("x", 0, "x", 1, 2)),
         (cscalar(), (np.newaxis,), ("x",)),
+        (cscalar(), (NoneConst,), ("x",)),
         (matrix(), (np.newaxis,), ("x", 0, 1)),
         (matrix(), (np.newaxis, np.newaxis), ("x", "x", 0, 1)),
         (matrix(), (np.newaxis, slice(None)), ("x", 0, 1)),


### PR DESCRIPTION
Closes #1147


- This implementation only changes the dtype sizes when they're also being converted to unsigned integers.
- Slice indices are not converted.

- [ ] Some comparisons with and without the rewrite enabled.