### PR TITLE
Add tensor conversion to Numpy-like helper functions

### DIFF
--- a/aesara/tensor/basic.py
+++ b/aesara/tensor/basic.py
@@ -2484,30 +2484,33 @@ def roll(x, shift, axis=None):
         Output tensor, with the same shape as ``x``.
 
     """
+    _x = as_tensor_variable(x)
     if axis is None:
-        if x.ndim > 1:
-            y = x.flatten()
-            return roll(y, shift, axis=0).reshape(x.shape)
+        if _x.ndim > 1:
+            y = _x.flatten()
+            return roll(y, shift, axis=0).reshape(_x.shape)
         else:
             axis = 0
 
     if axis < 0:
-        axis += x.ndim
+        axis += _x.ndim
 
     # Shift may be larger than the size of the axis. If so, since the
     # roll operation is cyclic, we can take the shift modulo the size
     # of the axis
-    shift = shift % x.shape[axis]
+    shift = shift % _x.shape[axis]
 
     # A slice of all elements in a dimension ':'
     allslice = slice(None)
     # List of slices describing the front half [:, :, shift:, :]
     front_slice = slice(-shift, None)
-    front_list = [allslice] * axis + [front_slice] + [allslice] * (x.ndim - axis - 1)
+    front_list = [allslice] * axis + [front_slice] + [allslice] * (_x.ndim - axis - 1)
     # List of slices describing the back half [:, :, :shift, :]
     end_slice = slice(0, -shift)
-    end_list = [allslice] * axis + [end_slice] + [allslice] * (x.ndim - axis - 1)
-    return join(axis, x.__getitem__(tuple(front_list)), x.__getitem__(tuple(end_list)))
+    end_list = [allslice] * axis + [end_slice] + [allslice] * (_x.ndim - axis - 1)
+    return join(
+        axis, _x.__getitem__(tuple(front_list)), _x.__getitem__(tuple(end_list))
+    )
 
 
 def stack(*tensors, **kwargs):

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -1449,6 +1449,15 @@ class TestJoinAndSplit:
 
             assert (out == want).all()
 
+            # Pass a list to make sure `a` is converted to a
+            # TensorVariable by roll
+            a = [1, 2, 3, 4, 5, 6]
+            b = roll(a, get_shift(2))
+            want = np.array([5, 6, 1, 2, 3, 4])
+            out = aesara.function([], b)()
+
+            assert (out == want).all()
+
     def test_stack_vector(self):
         a = self.shared(np.array([1, 2, 3], dtype=self.floatX))
         b = as_tensor_variable(np.array([7, 8, 9], dtype=self.floatX))


### PR DESCRIPTION
Fixing [Issue 876](https://github.com/aesara-devs/aesara/issues/876) by adding tensor conversion to Numpy-like helper functions. Tests added by passing a list to these functions.

I fixed the bug fix + added a test for `at.roll`. Can it be reviewed and then, if ok, I can fix the other functions as well?

**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [x] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
