### PR TITLE
Make `ChoiceRV` behave like NumPy's `choice`

### DIFF
--- a/aesara/tensor/random/basic.py
+++ b/aesara/tensor/random/basic.py
@@ -1792,7 +1792,7 @@ class ChoiceRV(RandomVariable):
             a = aesara.tensor.arange(a)
 
         if p is None:
-            p = aesara.tensor.type_other.NoneConst.clone()
+            p = aesara.tensor.type_other.NoneConst
 
         if isinstance(replace, bool):
             replace = aesara.tensor.constant(np.array(replace))

--- a/tests/tensor/random/test_basic.py
+++ b/tests/tensor/random/test_basic.py
@@ -1321,17 +1321,28 @@ def test_choice_samples():
     with pytest.raises(NotImplementedError):
         choice._supp_shape_from_params(np.asarray(5))
 
+    compare_sample_values(choice, np.asarray(5))
     compare_sample_values(choice, np.asarray([5]))
     compare_sample_values(choice, np.array([1.0, 5.0], dtype=config.floatX))
     compare_sample_values(choice, np.asarray([5]), 3)
 
-    with pytest.raises(ValueError):
-        compare_sample_values(choice, np.array([[1, 2], [3, 4]]))
+    compare_sample_values(choice, np.array([[1, 2], [3, 4]]))
+    compare_sample_values(choice, np.array([[1, 2], [3, 4]]), p=[0.4, 0.6])
 
     compare_sample_values(choice, [1, 2, 3], 1)
+
     compare_sample_values(
         choice, [1, 2, 3], 1, p=at.as_tensor([1 / 3.0, 1 / 3.0, 1 / 3.0])
     )
+
+    # p must be 1-dimensional.
+    # TODO: The exception is raised at runtime but could be raised at compile
+    # time in some situations using static shape analysis.
+    with pytest.raises(ValueError):
+        rng = np.random.default_rng()
+        rng_at = shared(rng, borrow=True)
+        choice(a=[1, 2], p=at.as_tensor([[0.1, 0.9], [0.3, 0.7]]), rng=rng_at).eval()
+
     compare_sample_values(choice, [1, 2, 3], (10, 2), replace=True)
     compare_sample_values(choice, at.as_tensor_variable([1, 2, 3]), 2, replace=True)
 


### PR DESCRIPTION
`ChoiceRV` currently does not behave like its NumPy equivalent when its `a` parameters is an `int` or an array with more than one dimension. We implement the necessary changes so that it does. Closes #1146 

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [x] There are tests covering the changes introduced in the PR.