### PR TITLE
Use folded shape in output of `Alloc`

### DIFF
--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -1,4 +1,5 @@
 import copy
+import re
 
 import numpy as np
 import pytest
@@ -277,7 +278,10 @@ class TestLocalCanonicalizeAlloc:
         assert a.owner and isinstance(a.owner.op, Alloc)
 
         # `local_useless_alloc` should replace the `Alloc` with an `Assert`
-        with pytest.raises(AssertionError):
+        with pytest.raises(
+            TypeError,
+            match=re.escape("Cannot convert Type TensorType(float64, (3, 7))"),
+        ):
             f = function([], a, mode=rewrite_mode)
 
         x = at.as_tensor(self.rng.standard_normal((6, 7)))

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -792,6 +792,10 @@ class TestAlloc:
         res = aesara.function([], full_at, mode=self.mode)()
         assert np.array_equal(res, np.full((2, 3), 3, dtype="int64"))
 
+    def test_static_shape(self):
+        out = at.alloc(0, at.constant(50), iscalar())
+        assert out.type.shape == (50, None)
+
 
 def test_infer_broadcastable():
     with pytest.raises(TypeError, match="^Shapes must be scalar integers.*"):


### PR DESCRIPTION
Follow up to #821 

```python
import aesara.tensor as at

at.zeros((50,)).type.shape  # (50,)
```

This however leads to a weird failing Scan test that still has to be figured out.