### PR TITLE
Update `CheckAndRaise` to handle `ScalarType` inputs

### DIFF
--- a/aesara/scalar/basic.py
+++ b/aesara/scalar/basic.py
@@ -729,6 +729,12 @@ class _scalar_py_operators:
     dtype = property(lambda self: self.type.dtype)
     """The dtype of this scalar."""
 
+    @property
+    def shape(self):
+        from aesara.tensor.basic import as_tensor_variable
+
+        return as_tensor_variable([], ndim=1, dtype=np.int64)
+
     # UNARY
     def __abs__(self):
         return abs(self)

--- a/tests/scalar/test_basic.py
+++ b/tests/scalar/test_basic.py
@@ -488,3 +488,17 @@ def test_mean(mode):
     z = mean()
     z_fn = aesara.function([], z, mode=mode)
     assert z_fn() == 0
+
+
+def test_shape():
+    a = float32("a")
+    assert isinstance(a.type, ScalarType)
+    assert a.shape.type.ndim == 1
+    assert a.shape.type.shape == (0,)
+    assert a.shape.type.dtype == "int64"
+
+    b = constant(2, name="b")
+    assert isinstance(b.type, ScalarType)
+    assert b.shape.type.ndim == 1
+    assert b.shape.type.shape == (0,)
+    assert b.shape.type.dtype == "int64"


### PR DESCRIPTION
Closes #1180.

This should also improve the situation for broadcasting-related `CheckAndRaise` usage.  For example, under these changes the following no longer includes some of the unnecessary `TensorFromScalar` conversions within the `Assert`s:
```python
import aesara
import aesara.tensor as at


X = at.matrix("X")
Y = at.matrix("Y")

X_bcast, Y_bcast = at.broadcast_arrays(X, Y)

aesara.dprint(X_bcast)
# BroadcastTo [id A]
#  |X [id B]
#  |TensorFromScalar [id C]
#  | |Assert{msg=Could not broadcast dimensions} [id D]
#  |   |Abs [id E]
#  |   | |maximum [id F]
#  |   |   |Switch [id G]
#  |   |   | |EQ [id H]
#  |   |   | | |ScalarFromTensor [id I]
#  |   |   | | | |Subtensor{int64} [id J]
#  |   |   | | |   |Shape [id K]
#  |   |   | | |   | |X [id B]
#  |   |   | | |   |ScalarConstant{0} [id L]
#  |   |   | | |ScalarConstant{1} [id M]
#  |   |   | |neg [id N]
#  |   |   | | |ScalarConstant{1} [id O]
#  |   |   | |ScalarFromTensor [id P]
#  |   |   |   |Subtensor{int64} [id J]
#  |   |   |Switch [id Q]
#  |   |     |EQ [id R]
#  |   |     | |ScalarFromTensor [id S]
#  |   |     | | |Subtensor{int64} [id T]
#  |   |     | |   |Shape [id U]
#  |   |     | |   | |Y [id V]
#  |   |     | |   |ScalarConstant{0} [id W]
#  |   |     | |ScalarConstant{1} [id X]
#  |   |     |neg [id Y]
#  |   |     | |ScalarConstant{1} [id O]
#  |   |     |ScalarFromTensor [id Z]
#  |   |       |Subtensor{int64} [id T]
#  |   |AND [id BA]
#  |     |OR [id BB]
#  |     | |EQ [id BC]
#  |     | | |Switch [id G]
#  |     | | |neg [id BD]
#  |     | |   |ScalarConstant{1} [id O]
#  |     | |EQ [id BE]
#  |     |   |Switch [id G]
#  |     |   |Abs [id E]
#  |     |OR [id BF]
#  |       |EQ [id BG]
#  |       | |Switch [id Q]
#  |       | |neg [id BH]
#  |       |   |ScalarConstant{1} [id O]
#  |       |EQ [id BI]
#  |         |Switch [id Q]
#  |         |Abs [id E]
#  |TensorFromScalar [id BJ]
#    |Assert{msg=Could not broadcast dimensions} [id BK]
#      |Abs [id BL]
#      | |maximum [id BM]
#      |   |Switch [id BN]
#      |   | |EQ [id BO]
#      |   | | |ScalarFromTensor [id BP]
#      |   | | | |Subtensor{int64} [id BQ]
#      |   | | |   |Shape [id K]
#      |   | | |   |ScalarConstant{1} [id BR]
#      |   | | |ScalarConstant{1} [id BS]
#      |   | |neg [id BT]
#      |   | | |ScalarConstant{1} [id O]
#      |   | |ScalarFromTensor [id BU]
#      |   |   |Subtensor{int64} [id BQ]
#      |   |Switch [id BV]
#      |     |EQ [id BW]
#      |     | |ScalarFromTensor [id BX]
#      |     | | |Subtensor{int64} [id BY]
#      |     | |   |Shape [id U]
#      |     | |   |ScalarConstant{1} [id BZ]
#      |     | |ScalarConstant{1} [id CA]
#      |     |neg [id CB]
#      |     | |ScalarConstant{1} [id O]
#      |     |ScalarFromTensor [id CC]
#      |       |Subtensor{int64} [id BY]
#      |AND [id CD]
#        |OR [id CE]
#        | |EQ [id CF]
#        | | |Switch [id BN]
#        | | |neg [id CG]
#        | |   |ScalarConstant{1} [id O]
#        | |EQ [id CH]
#        |   |Switch [id BN]
#        |   |Abs [id BL]
#        |OR [id CI]
#          |EQ [id CJ]
#          | |Switch [id BV]
#          | |neg [id CK]
#          |   |ScalarConstant{1} [id O]
#          |EQ [id CL]
#            |Switch [id BV]
#            |Abs [id BL]
```