### PR TITLE
Light housekeeping in JAX dispatcher

### DIFF
--- a/aesara/link/jax/dispatch/basic.py
+++ b/aesara/link/jax/dispatch/basic.py
@@ -18,19 +18,6 @@ if config.floatX == "float64":
 else:
     jax.config.update("jax_enable_x64", False)
 
-# XXX: Enabling this will break some shape-based functionality, and severely
-# limit the types of graphs that can be converted.
-# See https://github.com/google/jax/blob/4d556837cc9003492f674c012689efc3d68fdf5f/design_notes/omnistaging.md
-# Older versions < 0.2.0 do not have this flag so we don't need to set it.
-try:
-    jax.config.disable_omnistaging()
-except AttributeError:
-    pass
-except Exception as e:
-    # The version might be >= 0.2.12, which means that omnistaging can't be
-    # disabled
-    warnings.warn(f"JAX omnistaging couldn't be disabled: {e}")
-
 
 @singledispatch
 def jax_typify(data, dtype=None, **kwargs):

--- a/tests/link/jax/test_basic.py
+++ b/tests/link/jax/test_basic.py
@@ -205,7 +205,6 @@ def test_jax_checkandraise():
     p.tag.test_value = 0
 
     res = assert_op(p, p < 1.0)
-    res_fg = FunctionGraph([p], [res])
 
-    with pytest.raises(NotImplementedError):
-        compare_jax_and_py(res_fg, [1.0])
+    with pytest.warns(UserWarning):
+        function((p,), res, mode=jax_mode)


### PR DESCRIPTION
Following the discussion in https://github.com/aesara-devs/aesara/discussions/1184#discussioncomment-3648343 and #1001 I am removing the omnistaging warning and warning users when transpiling a `CheckAndRaise` Op instead of raising an exception. Closes #1001 #629