### PR TITLE
Add deprecation warning for `rng_mrg`

### DIFF
--- a/aesara/sandbox/rng_mrg.py
+++ b/aesara/sandbox/rng_mrg.py
@@ -37,6 +37,14 @@ from aesara.tensor.shape import reshape
 from aesara.tensor.type import TensorType, iscalar, ivector, lmatrix
 
 
+warnings.warn(
+    "The module `aesara.sandbox.rng_mrg` is deprecated. "
+    "Use the module `aesara.tensor.random` for random variables instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+
 def matVecModM(A, s, m):
     # TODO : need description for method, parameter and return
     assert A.dtype == "int64"


### PR DESCRIPTION
The deprecation warning is only about `rng_mrg`. However I find not reference to `DotModulo` and the other functions defined in `aesara.sandbox.rng_mrg.py` anywhere else in the library and we should probably get rid of them as well.

Closes #324.