### PR TITLE
Fix type inference in Elemwise when inputs have 0 shape

### DIFF
--- a/tests/tensor/test_elemwise.py
+++ b/tests/tensor/test_elemwise.py
@@ -856,8 +856,8 @@ class TestElemwise(unittest_tools.InferShapeTester):
         assert all(isinstance(v.type, TensorType) for v in out_shape)
 
     def test_static_shape_unary(self):
-        x = tensor("float64", shape=(None, 1, 5))
-        exp(x).type.shape == (None, 1, 5)
+        x = tensor("float64", shape=(None, 0, 1, 5))
+        exp(x).type.shape == (None, 0, 1, 5)
 
     def test_static_shape_binary(self):
         x = tensor("float64", shape=(None, 5))
@@ -875,6 +875,19 @@ class TestElemwise(unittest_tools.InferShapeTester):
         x = tensor("float64", shape=(None, 1))
         y = tensor("float64", shape=(1, 1))
         assert (x + y).type.shape == (None, 1)
+
+        x = tensor("float64", shape=(0, 0, 0))
+        y = tensor("float64", shape=(0, 1, None))
+        assert (x + y).type.shape == (0, 0, 0)
+
+    def test_invalid_static_shape(self):
+        x = tensor("float64", shape=(2,))
+        y = tensor("float64", shape=(3,))
+        with pytest.raises(
+            ValueError,
+            match=re.escape("Incompatible Elemwise input shapes [(2,), (3,)]"),
+        ):
+            x + y
 
 
 def test_not_implemented_elemwise_grad():


### PR DESCRIPTION
This bug was introduced in #821 because I forgot to account for static shapes of 0

Revealed in https://github.com/pymc-devs/pymc/pull/6140