### PR TITLE
Fix storage allocation and access in `numba_funcify_Scan`

### DIFF
--- a/aesara/link/numba/dispatch/basic.py
+++ b/aesara/link/numba/dispatch/basic.py
@@ -393,10 +393,14 @@ def numba_funcify_FunctionGraph(
 def create_index_func(node, objmode=False):
     """Create a Python function that assembles and uses an index on an array."""
 
+    unique_names = unique_name_generator(
+        ["subtensor", "incsubtensor", "z"], suffix_sep="_"
+    )
+
     def convert_indices(indices, entry):
         if indices and isinstance(entry, Type):
             rval = indices.pop(0)
-            return rval.auto_name
+            return unique_names(rval)
         elif isinstance(entry, slice):
             return (
                 f"slice({convert_indices(indices, entry.start)}, "
@@ -412,10 +416,6 @@ def create_index_func(node, objmode=False):
         node.op, (IncSubtensor, AdvancedIncSubtensor1, AdvancedIncSubtensor)
     )
     index_start_idx = 1 + int(set_or_inc)
-
-    unique_names = unique_name_generator(
-        ["subtensor", "incsubtensor", "z"], suffix_sep="_"
-    )
 
     input_names = [unique_names(v, force_unique=True) for v in node.inputs]
     op_indices = list(node.inputs[index_start_idx:])

--- a/aesara/link/numba/dispatch/basic.py
+++ b/aesara/link/numba/dispatch/basic.py
@@ -3,6 +3,7 @@ import warnings
 from contextlib import contextmanager
 from functools import singledispatch
 from textwrap import dedent
+from typing import Union
 
 import numba
 import numba.np.unsafe.ndarray as numba_ndarray
@@ -96,11 +97,13 @@ def get_numba_type(
 
 
 def create_numba_signature(
-    node: Apply, force_scalar: bool = False, reduce_to_scalar: bool = False
+    node_or_fgraph: Union[FunctionGraph, Apply],
+    force_scalar: bool = False,
+    reduce_to_scalar: bool = False,
 ) -> numba.types.Type:
-    """Create a Numba type for the signature of an ``Apply`` node."""
+    """Create a Numba type for the signature of an `Apply` node or `FunctionGraph`."""
     input_types = []
-    for inp in node.inputs:
+    for inp in node_or_fgraph.inputs:
         input_types.append(
             get_numba_type(
                 inp.type, force_scalar=force_scalar, reduce_to_scalar=reduce_to_scalar
@@ -108,7 +111,7 @@ def create_numba_signature(
         )
 
     output_types = []
-    for out in node.outputs:
+    for out in node_or_fgraph.outputs:
         output_types.append(
             get_numba_type(
                 out.type, force_scalar=force_scalar, reduce_to_scalar=reduce_to_scalar

--- a/aesara/link/numba/dispatch/scan.py
+++ b/aesara/link/numba/dispatch/scan.py
@@ -54,7 +54,7 @@ def numba_funcify_Scan(op, node, **kwargs):
     p_outer_in_nit_sot = p_outer_in_shared + n_shared_outs
     p_outer_in_non_seqs = p_outer_in_nit_sot + n_nit_sot
 
-    input_names = [f"{n.auto_name}_{i}" for i, n in enumerate(node.inputs[1:])]
+    input_names = [f"outer_in_{i}" for i, n in enumerate(node.inputs[1:])]
     outer_in_seqs_names = input_names[:n_seqs]
     outer_in_mit_mot_names = input_names[p_in_mit_mot : p_in_mit_mot + n_mit_mot]
     outer_in_mit_sot_names = input_names[p_in_mit_sot : p_in_mit_sot + n_mit_sot]

--- a/aesara/link/numba/dispatch/tensor_basic.py
+++ b/aesara/link/numba/dispatch/tensor_basic.py
@@ -230,6 +230,6 @@ def numba_funcify_TensorFromScalar(op, **kwargs):
 def numba_funcify_ScalarFromTensor(op, **kwargs):
     @numba_basic.numba_njit(inline="always")
     def scalar_from_tensor(x):
-        return x.item()
+        return numba_basic.to_scalar(x)
 
     return scalar_from_tensor

--- a/aesara/link/utils.py
+++ b/aesara/link/utils.py
@@ -613,8 +613,8 @@ def compile_function_src(
 def get_name_for_object(x: Any) -> str:
     """Get the name for an arbitrary object."""
 
-    if isinstance(x, Variable):
-        name = re.sub("[^0-9a-zA-Z]+", "_", x.name) if x.name else ""
+    if isinstance(x, Variable) and x.name:
+        name = re.sub("[^0-9a-zA-Z]+", "_", x.name)
         name = (
             name
             if (
@@ -622,19 +622,22 @@ def get_name_for_object(x: Any) -> str:
                 and not iskeyword(name)
                 and name not in dir(builtins)
             )
-            else x.auto_name
+            else ""
         )
     else:
-        name = getattr(x, "__name__", "")
+        name = re.sub(r"(?<!^)(?=[A-Z])", "_", getattr(x, "__name__", "")).lower()
 
     if not name or (not name.isidentifier() or iskeyword(name)):
-        name = type(x).__name__
+        # Try to get snake-case out of the type name
+        name = re.sub(r"(?<!^)(?=[A-Z])", "_", type(x).__name__).lower()
+
+    assert name.isidentifier() and not iskeyword(name)
 
     return name
 
 
 def unique_name_generator(
-    external_names: Optional[List[str]] = None, suffix_sep: str = ""
+    external_names: Optional[List[str]] = None, suffix_sep: str = "_"
 ) -> Callable:
     """Create a function that generates unique names."""
 

--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ def pytest_sessionstart(session):
             "warn__ignore_bug_before=all,on_opt_error=raise,on_shape_error=raise,cmodule__warn_no_version=True",
         ]
     )
+    os.environ["NUMBA_BOUNDSCHECK"] = "1"
 
 
 def pytest_addoption(parser):

--- a/tests/link/jax/test_basic.py
+++ b/tests/link/jax/test_basic.py
@@ -89,23 +89,6 @@ def compare_jax_and_py(
     return jax_res
 
 
-def test_jax_FunctionGraph_names():
-    import inspect
-
-    from aesara.link.jax.dispatch import jax_funcify
-
-    x = scalar("1x")
-    y = scalar("_")
-    z = scalar()
-    q = scalar("def")
-
-    out_fg = FunctionGraph([x, y, z, q], [x, y, z, q], clone=False)
-    out_jx = jax_funcify(out_fg)
-    sig = inspect.signature(out_jx)
-    assert (x.auto_name, "_", z.auto_name, q.auto_name) == tuple(sig.parameters.keys())
-    assert (1, 2, 3, 4) == out_jx(1, 2, 3, 4)
-
-
 def test_jax_FunctionGraph_once():
     """Make sure that an output is only computed once when it's referenced multiple times."""
     from aesara.link.jax.dispatch import jax_funcify

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -98,7 +98,7 @@ def compare_shape_dtype(x, y):
     return x.shape == y.shape and x.dtype == y.dtype
 
 
-def eval_python_only(fn_inputs, fgraph, inputs):
+def eval_python_only(fn_inputs, fgraph, inputs, mode=numba_mode):
     """Evaluate the Numba implementation in pure Python for coverage purposes."""
 
     def py_tuple_setitem(t, i, v):
@@ -164,13 +164,15 @@ def eval_python_only(fn_inputs, fgraph, inputs):
         aesara_numba_fn = function(
             fn_inputs,
             fgraph.outputs,
-            mode=numba_mode,
+            mode=mode,
             accept_inplace=True,
         )
         _ = aesara_numba_fn(*inputs)
 
 
-def compare_numba_and_py(fgraph, inputs, assert_fn=None):
+def compare_numba_and_py(
+    fgraph, inputs, assert_fn=None, numba_mode=numba_mode, py_mode=py_mode
+):
     """Function to compare python graph output and Numba compiled output for testing equality
 
     In the tests below computational graphs are defined in Aesara. These graphs are then passed to
@@ -211,7 +213,7 @@ def compare_numba_and_py(fgraph, inputs, assert_fn=None):
     numba_res = aesara_numba_fn(*inputs)
 
     # Get some coverage
-    eval_python_only(fn_inputs, fgraph, inputs)
+    eval_python_only(fn_inputs, fgraph, inputs, mode=numba_mode)
 
     if len(fgraph.outputs) > 1:
         for j, p in zip(numba_res, py_res):

--- a/tests/link/test_link.py
+++ b/tests/link/test_link.py
@@ -220,7 +220,6 @@ class TestWrapLinker:
 
 
 def test_sort_schedule_fn():
-    import aesara
     from aesara.graph.sched import make_depends, sort_schedule_fn
 
     x = matrix("x")

--- a/tests/link/test_utils.py
+++ b/tests/link/test_utils.py
@@ -12,7 +12,7 @@ from aesara.link.utils import (
     get_name_for_object,
     unique_name_generator,
 )
-from aesara.scalar.basic import Add
+from aesara.scalar.basic import Add, float64
 from aesara.tensor.elemwise import Elemwise
 from aesara.tensor.type import scalar, vector
 from aesara.tensor.type_other import NoneConst
@@ -42,7 +42,7 @@ def test_fgraph_to_python_names():
 
     x = scalar("1x")
     y = scalar("_")
-    z = scalar()
+    z = float64()
     q = scalar("def")
     r = NoneConst
 
@@ -50,9 +50,13 @@ def test_fgraph_to_python_names():
     out_jx = fgraph_to_python(out_fg, to_python)
 
     sig = inspect.signature(out_jx)
-    assert (x.auto_name, "_", z.auto_name, q.auto_name, r.name) == tuple(
-        sig.parameters.keys()
-    )
+    assert (
+        "tensor_variable",
+        "_",
+        "scalar_variable",
+        "tensor_variable_1",
+        r.name,
+    ) == tuple(sig.parameters.keys())
     assert (1, 2, 3, 4, 5) == out_jx(1, 2, 3, 4, 5)
 
     obj = object()
@@ -191,7 +195,7 @@ def test_unique_name_generator():
     q_name_1 = unique_names(q)
     q_name_2 = unique_names(q)
 
-    assert q_name_1 == q_name_2 == q.auto_name
+    assert q_name_1 == q_name_2 == "tensor_variable"
 
     unique_names = unique_name_generator()
 


### PR DESCRIPTION
This PR fixes some storage allocation and access/usage issues in `numba_funcify_Scan`.

Closes #923

- [x] Fix truncated `Scan` input storage support
- [x] Support basic mit-mots
