### PR TITLE
Make `isort` ignore Cython files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -160,7 +160,8 @@ lines_after_imports = 2
 lines_between_sections = 1
 honor_noqa = True
 skip_gitignore = True
-skip = aesara/version.py, **/__init__.py
+skip = aesara/version.py
+skip_glob = **/*.pyx
 
 [mypy]
 ignore_missing_imports = True


### PR DESCRIPTION
This is a follow-up to #1208, after which `isort` is applied to `scan_perform.pyx`.