### PR TITLE
Fix outdated stride logic in `GEMM`'s C implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython pytest coverage pytest-cov sympy
           if [[ $INSTALL_NUMBA == "1" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.55" numba-scipy; fi
-          mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax "jaxlib!=0.3.15"
+          mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib
           pip install -e ./
           mamba list && pip freeze
           python -c 'import aesara; print(aesara.config.__str__(print_doc=False))'

--- a/aesara/tensor/blas.py
+++ b/aesara/tensor/blas.py
@@ -535,6 +535,15 @@ class GemmRelated(COp):
             gettimeofday(&tv, 0);
             return (double) tv.tv_sec + (double) tv.tv_usec / 1000000.0;
         }
+
+        void compute_strides(npy_intp *shape, int N_shape, int type_size, npy_intp *res) {
+            int s;
+            res[N_shape - 1] = type_size;
+            for (int i = N_shape - 1; i > 0; i--) {
+                s = shape[i];
+                res[i - 1] = res[i] * (s > 0 ? s : 1);
+            }
+        }
         """
         return blas_header_text() + mod_str
 
@@ -672,6 +681,9 @@ class GemmRelated(COp):
             Py_XDECREF(%(_x)s);
             %(_x)s = _x_copy;
             Sx = PyArray_STRIDES(%(_x)s);
+            if ((Sx[0] < 1) || (Sx[1] < 1)) {
+                compute_strides(Nx, 2, type_size, Sx);
+            }
         }
 
         if ((Sy[0] < 1) || (Sy[1] < 1) || (Sy[0] MOD type_size) || (Sy[1] MOD type_size)
@@ -683,6 +695,9 @@ class GemmRelated(COp):
             Py_XDECREF(%(_y)s);
             %(_y)s = _y_copy;
             Sy = PyArray_STRIDES(%(_y)s);
+            if ((Sy[0] < 1) || (Sy[1] < 1)) {
+                compute_strides(Ny, 2, type_size, Sy);
+            }
         }
 
         if ((Sz[0] < 1) || (Sz[1] < 1) || (Sz[0] MOD type_size) || (Sz[1] MOD type_size)
@@ -694,6 +709,9 @@ class GemmRelated(COp):
             Py_XDECREF(%(_zout)s);
             %(_zout)s = _z_copy;
             Sz = PyArray_STRIDES(%(_zout)s);
+            if ((Sz[0] < 1) || (Sz[1] < 1)) {
+                compute_strides(Nz, 2, type_size, Sz);
+            }
         }
         """
 

--- a/aesara/tensor/sort.py
+++ b/aesara/tensor/sort.py
@@ -291,10 +291,10 @@ def _topk_py_impl(op, x, k, axis, idx_dtype):
     idx[axis] = slice(-k, None) if k > 0 else slice(-k)
 
     if not op.return_indices:
-        zv = np.partition(x, -k, axis=axis)[idx]
+        zv = np.partition(x, -k, axis=axis)[tuple(idx)]
         return zv
     elif op.return_values:
-        zi = np.argpartition(x, -k, axis=axis)[idx]
+        zi = np.argpartition(x, -k, axis=axis)[tuple(idx)]
         idx2 = tuple(
             np.arange(s).reshape((s,) + (1,) * (ndim - i - 1)) if i != axis else zi
             for i, s in enumerate(x.shape)
@@ -302,7 +302,7 @@ def _topk_py_impl(op, x, k, axis, idx_dtype):
         zv = x[idx2]
         return zv, zi.astype(idx_dtype)
     else:
-        zi = np.argpartition(x, -k, axis=axis)[idx]
+        zi = np.argpartition(x, -k, axis=axis)[tuple(idx)]
         return zi.astype(idx_dtype)
 
 

--- a/tests/tensor/signal/test_pool.py
+++ b/tests/tensor/signal/test_pool.py
@@ -216,7 +216,7 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
                         r_stride = builtins.max(r_stride, pad[i])
                         r_end = builtins.min(r_end, input.shape[-nd + i] + pad[i])
                     region.append(slice(r_stride, r_end))
-                patch = padded_input[l][region]
+                patch = padded_input[l][tuple(region)]
                 output_val[l][r] = func(patch)
         return output_val
 
@@ -325,7 +325,7 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
                     r_stride = r[i] * stride[i]
                     r_end = builtins.min(r_stride + ws[i], input.shape[-nd + i])
                     region.append(slice(r_stride, r_end))
-                patch = input[l][region]
+                patch = input[l][tuple(region)]
                 output_val[l][r] = func(patch)
         return output_val
 

--- a/tests/tensor/test_subtensor.py
+++ b/tests/tensor/test_subtensor.py
@@ -527,12 +527,6 @@ class TestSubtensor(utt.OptimizationTestMixin):
         with pytest.raises(Exception):
             n[: (2**63)]
 
-    def test_list_slice(self):
-        x = at.arange(100).reshape((5, 5, 4))
-        res = x[[slice(1, -1)] * x.ndim].eval()
-        x = np.arange(100).reshape((5, 5, 4))
-        np.allclose(res, x[[slice(1, -1)] * x.ndim])
-
     def test_slice_symbol(self):
         x = self.shared(np.random.random((5, 4)).astype(self.dtype))
         y = self.shared(np.random.random((1, 2, 3)).astype(self.dtype))
@@ -623,15 +617,15 @@ class TestSubtensor(utt.OptimizationTestMixin):
             test_array_np[np.newaxis, 1:, mask], test_array[np.newaxis, 1:, mask].eval()
         )
         assert_array_equal(
-            numpy_inc_subtensor(test_array_np, [0, mask], 1),
+            numpy_inc_subtensor(test_array_np, (0, mask), 1),
             inc_subtensor(test_array[(0,) + mask.nonzero()], 1).eval(),
         )
         assert_array_equal(
-            numpy_inc_subtensor(test_array_np, [0, mask], 1),
+            numpy_inc_subtensor(test_array_np, (0, mask), 1),
             inc_subtensor(test_array[0, mask], 1).eval(),
         )
         assert_array_equal(
-            numpy_inc_subtensor(test_array_np, [slice(None), mask], 1),
+            numpy_inc_subtensor(test_array_np, (slice(None), mask), 1),
             inc_subtensor(test_array[:, mask], 1).eval(),
         )
 
@@ -657,15 +651,15 @@ class TestSubtensor(utt.OptimizationTestMixin):
             numpy_n4[test_array_np > 2, ..., 0, 1], n4[test_array > 2, ..., 0, 1].eval()
         )
         assert_array_equal(
-            numpy_inc_subtensor(numpy_n4, [test_array_np > 2, Ellipsis], 1),
+            numpy_inc_subtensor(numpy_n4, (test_array_np > 2, Ellipsis), 1),
             inc_subtensor(n4[test_array > 2, ...], 1).eval(),
         )
         assert_array_equal(
-            numpy_inc_subtensor(numpy_n4, [test_array_np > 2, Ellipsis, 1], 1),
+            numpy_inc_subtensor(numpy_n4, (test_array_np > 2, Ellipsis, 1), 1),
             inc_subtensor(n4[test_array > 2, ..., 1], 1).eval(),
         )
         assert_array_equal(
-            numpy_inc_subtensor(numpy_n4, [test_array_np > 2, Ellipsis, 0, 1], 1),
+            numpy_inc_subtensor(numpy_n4, (test_array_np > 2, Ellipsis, 0, 1), 1),
             inc_subtensor(n4[test_array > 2, ..., 0, 1], 1).eval(),
         )
 
@@ -730,8 +724,6 @@ class TestSubtensor(utt.OptimizationTestMixin):
                 test_array.__getitem__((False,))
             with pytest.raises(TypeError):
                 test_array.__getitem__((True, False))
-            with pytest.raises(TypeError):
-                test_array.__getitem__([True, False])
             with pytest.raises(TypeError):
                 test_array.__getitem__(([0, 1], [0, False]))
             with pytest.raises(TypeError):


### PR DESCRIPTION
Closes #1220.

It looks like `jaxlib` has been update and is now required (e.g. [here](https://github.com/aesara-devs/aesara/actions/runs/3146762303/jobs/5115620271#step:6:38)), so this PR reverts the CI version pin, as well.