### PR TITLE
Use Numba's `Generator` support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,10 +123,10 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          mamba install --yes -q "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service graphviz cython pytest coverage pytest-cov pytest-benchmark sympy
-          if [[ $INSTALL_NUMBA == "1" ]]; then mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.55" numba-scipy; fi
-          mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" jax jaxlib
-          pip install -e ./
+          mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" mkl "numpy>=1.23.3" scipy pip mkl-service graphviz cython pytest coverage pytest-cov pytest-benchmark sympy filelock etuples logical-unification miniKanren cons typing_extensions "setuptools>=48.0.0"
+          if [[ $INSTALL_NUMBA == "1" ]]; then mamba install --yes -q -c conda-forge -c numba "python~=${PYTHON_VERSION}=*_cpython" "numba>=0.57.0"; fi
+          mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" "numpy>=1.23.3" jax jaxlib
+          pip install --no-deps -e ./
           mamba list && pip freeze
           python -c 'import aesara; print(aesara.config.__str__(print_doc=False))'
           python -c 'import aesara; assert(aesara.config.blas__ldflags != "")'
@@ -181,7 +181,7 @@ jobs:
       - name: Install dependencies
         shell: bash -l {0}
         run: |
-          mamba install --yes -q -c conda-forge "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service cython pytest "numba>=0.55" numba-scipy jax jaxlib pytest-benchmark
+          mamba install --yes -q -c conda-forge -c numba "python~=${PYTHON_VERSION}=*_cpython" mkl numpy scipy pip mkl-service cython pytest jax jaxlib pytest-benchmark "numba>=0.57.0"
           pip install -e ./
           mamba list && pip freeze
           python -c 'import aesara; print(aesara.config.__str__(print_doc=False))'

--- a/aesara/link/numba/dispatch/random.py
+++ b/aesara/link/numba/dispatch/random.py
@@ -6,7 +6,9 @@ import numba
 import numba.np.unsafe.ndarray as numba_ndarray
 import numpy as np
 from numba import types
-from numba.extending import overload
+from numba.extending import overload, overload_method, register_jitable
+from numba.np.random.distributions import random_beta, random_standard_gamma
+from numba.np.random.generator_methods import check_size, check_types, is_nonelike
 
 import aesara.tensor.random.basic as aer
 from aesara.graph.basic import Apply
@@ -296,3 +298,78 @@ def numba_funcify_DirichletRV(op, node, **kwargs):
             return (rng, rng.dirichlet(alphas, size))
 
     return dirichlet_rv
+
+
+@register_jitable
+def random_dirichlet(bitgen, alpha, size):
+    """
+    This implementation is straight from ``numpy/random/_generator.pyx``.
+    """
+
+    k = len(alpha)
+    alpha_arr = np.asarray(alpha, dtype=np.float64)
+
+    if np.any(np.less_equal(alpha_arr, 0)):
+        raise ValueError("alpha <= 0")
+
+    shape = size + (k,)
+
+    diric = np.zeros(shape, np.float64)
+
+    i = 0
+    totsize = diric.size
+
+    if (k > 0) and (alpha_arr.max() < 0.1):
+        alpha_csum_arr = np.empty_like(alpha_arr)
+        csum = 0.0
+        for j in range(k - 1, -1, -1):
+            csum += alpha_arr[j]
+            alpha_csum_arr[j] = csum
+
+        while i < totsize:
+            acc = 1.0
+            for j in range(k - 1):
+                v = random_beta(bitgen, alpha_arr[j], alpha_csum_arr[j + 1])
+                diric[i + j] = acc * v
+                acc *= 1.0 - v
+            diric[i + k - 1] = acc
+            i = i + k
+
+    else:
+        while i < totsize:
+            acc = 0.0
+            for j in range(k):
+                diric[i + j] = random_standard_gamma(bitgen, alpha_arr[j])
+                acc = acc + diric[i + j]
+            invacc = 1.0 / acc
+            for j in range(k):
+                diric[i + j] = diric[i + j] * invacc
+            i = i + k
+
+    return diric
+
+
+@overload_method(types.NumPyRandomGeneratorType, "dirichlet")
+def NumPyRandomGeneratorType_dirichlet(inst, alphas, size=None):
+    check_types(alphas, [types.Array, types.List], "alphas")
+
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+
+        def impl(inst, alphas, size=None):
+            return random_dirichlet(inst.bit_generator, alphas, ())
+
+    elif isinstance(size, (int, types.Integer)):
+
+        def impl(inst, alphas, size=None):
+            return random_dirichlet(inst.bit_generator, alphas, (size,))
+
+    else:
+        check_size(size)
+
+        def impl(inst, alphas, size=None):
+            return random_dirichlet(inst.bit_generator, alphas, size)
+
+    return impl

--- a/aesara/link/numba/dispatch/random.py
+++ b/aesara/link/numba/dispatch/random.py
@@ -1,4 +1,5 @@
 from copy import copy
+from math import log
 from textwrap import dedent, indent
 from typing import Callable, Optional
 
@@ -8,6 +9,7 @@ import numpy as np
 from numba import types
 from numba.extending import overload, overload_method, register_jitable
 from numba.np.random.distributions import random_beta, random_standard_gamma
+from numba.np.random.generator_core import next_double
 from numba.np.random.generator_methods import check_size, check_types, is_nonelike
 
 import aesara.tensor.random.basic as aer
@@ -371,5 +373,41 @@ def NumPyRandomGeneratorType_dirichlet(inst, alphas, size=None):
 
         def impl(inst, alphas, size=None):
             return random_dirichlet(inst.bit_generator, alphas, size)
+
+    return impl
+
+
+@register_jitable
+def random_gumbel(bitgen, loc, scale):
+    """
+    This implementation is adapted from ``numpy/random/src/distributions/distributions.c``.
+    """
+    while True:
+        u = 1.0 - next_double(bitgen)
+        if u < 1.0:
+            return loc - scale * log(-log(u))
+
+
+@overload_method(types.NumPyRandomGeneratorType, "gumbel")
+def NumPyRandomGeneratorType_gumbel(inst, loc=0.0, scale=1.0, size=None):
+    check_types(loc, [types.Float, types.Integer, int, float], "loc")
+    check_types(scale, [types.Float, types.Integer, int, float], "scale")
+
+    if isinstance(size, types.Omitted):
+        size = size.value
+
+    if is_nonelike(size):
+
+        def impl(inst, loc=0.0, scale=1.0, size=None):
+            return random_gumbel(inst.bit_generator, loc, scale)
+
+    else:
+        check_size(size)
+
+        def impl(inst, loc=0.0, scale=1.0, size=None):
+            out = np.empty(size)
+            for i in np.ndindex(size):
+                out[i] = random_gumbel(inst.bit_generator, loc, scale)
+            return out
 
     return impl

--- a/aesara/link/numba/dispatch/random.py
+++ b/aesara/link/numba/dispatch/random.py
@@ -1,206 +1,137 @@
+from copy import copy
 from textwrap import dedent, indent
-from typing import Any, Callable, Dict, Optional
+from typing import Callable, Optional
 
+import numba
 import numba.np.unsafe.ndarray as numba_ndarray
 import numpy as np
-from numba import _helperlib, types
-from numba.core import cgutils
-from numba.extending import (
-    NativeValue,
-    box,
-    models,
-    overload,
-    register_model,
-    typeof_impl,
-    unbox,
-)
-from numpy.random import RandomState
+from numba import types
+from numba.extending import overload
 
 import aesara.tensor.random.basic as aer
 from aesara.graph.basic import Apply
-from aesara.graph.op import Op
 from aesara.link.numba.dispatch import basic as numba_basic
-from aesara.link.numba.dispatch.basic import _numba_funcify, numba_const_convert
-from aesara.link.utils import (
-    compile_function_src,
-    get_name_for_object,
-    unique_name_generator,
+from aesara.link.numba.dispatch.basic import (
+    _numba_funcify,
+    create_arg_string,
+    get_numba_type,
 )
+from aesara.link.utils import compile_function_src, unique_name_generator
 from aesara.tensor.basic import get_vector_length
-from aesara.tensor.random.type import RandomStateType
+from aesara.tensor.random.type import RandomGeneratorType
 
 
-class RandomStateNumbaType(types.Type):
-    def __init__(self):
-        super().__init__(name="RandomState")
+@get_numba_type.register(RandomGeneratorType)
+def get_numba_type_RandomGeneratorType(aesara_type, var, **kwargs):
+    return numba.types.npy_rng
 
 
-random_state_numba_type = RandomStateNumbaType()
+@overload(copy)
+def copy_NumPyRandomGeneratorType(rng):
+    if not isinstance(rng, types.NumPyRandomGeneratorType):
+        raise TypeError("`copy` only supports Generators right now")
+
+    def impl(rng):
+        # TODO: This seems rather inefficient, but also necessary at this
+        # point.  Let's keep an eye out for a better approach.
+        with numba.objmode(new_rng=types.npy_rng):
+            new_rng = copy(rng)
+
+        return new_rng
+
+    return impl
 
 
-@typeof_impl.register(RandomState)
-def typeof_index(val, c):
-    return random_state_numba_type
-
-
-@register_model(RandomStateNumbaType)
-class RandomStateNumbaModel(models.StructModel):
-    def __init__(self, dmm, fe_type):
-        members = [
-            # TODO: We can add support for boxing and unboxing
-            # the attributes that describe a RandomState so that
-            # they can be accessed inside njit functions, if required.
-            ("state_key", types.Array(types.uint32, 1, "C")),
-        ]
-        models.StructModel.__init__(self, dmm, fe_type, members)
-
-
-@unbox(RandomStateNumbaType)
-def unbox_random_state(typ, obj, c):
-    """Convert a `RandomState` object to a native `RandomStateNumbaModel` structure.
-
-    Note that this will create a 'fake' structure which will just get the
-    `RandomState` objects accepted in Numba functions but the actual information
-    of the Numba's random state is stored internally and can be accessed
-    anytime using ``numba._helperlib.rnd_get_np_state_ptr()``.
-    """
-    interval = cgutils.create_struct_proxy(typ)(c.context, c.builder)
-    is_error = cgutils.is_not_null(c.builder, c.pyapi.err_occurred())
-    return NativeValue(interval._getvalue(), is_error=is_error)
-
-
-@box(RandomStateNumbaType)
-def box_random_state(typ, val, c):
-    """Convert a native `RandomStateNumbaModel` structure to an `RandomState` object
-    using Numba's internal state array.
-
-    Note that `RandomStateNumbaModel` is just a placeholder structure with no
-    inherent information about Numba internal random state, all that information
-    is instead retrieved from Numba using ``_helperlib.rnd_get_state()`` and a new
-    `RandomState` is constructed using the Numba's current internal state.
-    """
-    pos, state_list = _helperlib.rnd_get_state(_helperlib.rnd_get_np_state_ptr())
-    rng = RandomState()
-    rng.set_state(("MT19937", state_list, pos))
-    class_obj = c.pyapi.unserialize(c.pyapi.serialize_object(rng))
-    return class_obj
-
-
-@overload(np.random.uniform)
-def uniform_empty_size(a, b, size):
-    if isinstance(size, types.Tuple) and size.count == 0:
-
-        def uniform_no_size(a, b, size):
-            return np.random.uniform(a, b)
-
-        return uniform_no_size
-
-
-@numba_const_convert.register(RandomState)
-def numba_const_convert_RandomState(state, **kwargs):
-    # The `numba_const_convert` in this case is just a passthrough function
-    # that synchronizes Numba's internal random state with the current
-    # `RandomState` object.
-    ints, index = state.get_state()[1:3]
-    ptr = _helperlib.rnd_get_np_state_ptr()
-    _helperlib.rnd_set_state(ptr, (index, [int(x) for x in ints]))
-    return state
-
-
-def make_numba_random_fn(node, np_random_func):
-    """Create Numba implementations for existing Numba-supported ``np.random`` functions.
-
-    The functions generated here add parameter broadcasting and the ``size``
-    argument to the Numba-supported scalar ``np.random`` functions.
-    """
-    if not isinstance(node.inputs[0].type, RandomStateType):
-        raise TypeError("Numba does not support NumPy `Generator`s")
+def make_numba_random_fn(
+    node: Apply, sampler_name: str, sampler_fn: Optional[Callable] = None
+):
+    """Create Numba implementations for Numba-supported `np.random` functions."""
+    if not isinstance(node.inputs[0].type, RandomGeneratorType):
+        raise TypeError("Numba does not support NumPy `RandomState`s")
 
     tuple_size = int(get_vector_length(node.inputs[1]))
     size_dims = tuple_size - max(i.ndim for i in node.inputs[3:])
 
-    # Make a broadcast-capable version of the Numba supported scalar sampling
-    # function
-    bcast_fn_name = f"aesara_random_{get_name_for_object(np_random_func)}"
+    out_dtype = node.outputs[1].type.numpy_dtype
 
-    sized_fn_name = "sized_random_variable"
+    if not node.op.inplace:
+        copy_rng_stmts = "rng = copy(rng)\n"
+    else:
+        copy_rng_stmts = ""
 
     unique_names = unique_name_generator(
         [
-            bcast_fn_name,
-            sized_fn_name,
             "np",
             "np_random_func",
-            "numba_vectorize",
             "to_fixed_tuple",
+            "out_shape",
             "tuple_size",
             "size_dims",
             "rng",
             "size",
             "dtype",
+            "i",
+            "copy",
         ],
         suffix_sep="_",
     )
 
-    bcast_fn_input_names = ", ".join(
-        [unique_names(i, force_unique=True) for i in node.inputs[3:]]
+    dist_arg_names = [unique_names(i) for i in node.inputs[3:]]
+    bcasted_input_stmts = "\n".join(
+        [
+            f"{name}_bcast = np.broadcast_to({name}, out_shape)"
+            if v.type.ndim > 0
+            else f"{name}_bcast = {name}"
+            for name, v in zip(dist_arg_names, node.inputs[3:])
+        ]
     )
-    bcast_fn_global_env = {
-        "np_random_func": np_random_func,
-        "numba_vectorize": numba_basic.numba_vectorize,
-    }
-
-    bcast_fn_src = f"""
-@numba_vectorize
-def {bcast_fn_name}({bcast_fn_input_names}):
-    return np_random_func({bcast_fn_input_names})
-    """
-    bcast_fn = compile_function_src(
-        bcast_fn_src, bcast_fn_name, {**globals(), **bcast_fn_global_env}
+    indexed_inputs = create_arg_string(
+        [
+            f"{name}_bcast[i]" if v.type.ndim > 0 else f"to_scalar({name}_bcast)"
+            for name, v in zip(dist_arg_names, node.inputs[3:])
+        ]
+    )
+    random_fn_input_names = ", ".join(["rng", "size", "dtype"] + dist_arg_names)
+    input_shape_exprs = create_arg_string(
+        [f"np.shape({name})" for name in dist_arg_names]
     )
 
-    random_fn_input_names = ", ".join(
-        ["rng", "size", "dtype"] + [unique_names(i) for i in node.inputs[3:]]
-    )
-
-    # Now, create a Numba JITable function that implements the `size` parameter
     out_dtype = node.outputs[1].type.numpy_dtype
     random_fn_global_env = {
-        bcast_fn_name: bcast_fn,
         "out_dtype": out_dtype,
+        "np": np,
+        "to_fixed_tuple": numba_ndarray.to_fixed_tuple,
+        "tuple_size": tuple_size,
+        "size_dims": size_dims,
+        "to_scalar": numba_basic.to_scalar,
+        "copy": copy,
     }
 
-    if tuple_size > 0:
-        random_fn_body = dedent(
-            f"""
-        size = to_fixed_tuple(size, tuple_size)
-
-        data = np.empty(size, dtype=out_dtype)
-        for i in np.ndindex(size[:size_dims]):
-            data[i] = {bcast_fn_name}({bcast_fn_input_names})
-
-        """
-        )
-        random_fn_global_env.update(
-            {
-                "np": np,
-                "to_fixed_tuple": numba_ndarray.to_fixed_tuple,
-                "tuple_size": tuple_size,
-                "size_dims": size_dims,
-            }
-        )
+    if sampler_fn is not None:
+        random_fn_global_env[sampler_name] = sampler_fn
+        sampler_fn_expr = f"{sampler_name}(rng, "
+        nb_sampler_fn_name = f"{sampler_name}_sampler"
     else:
-        random_fn_body = f"""data = {bcast_fn_name}({bcast_fn_input_names})"""
+        sampler_fn_expr = f"rng.{sampler_name}("
+        nb_sampler_fn_name = f"{sampler_name}_sampler"
 
-    sized_fn_src = dedent(
+    sampler_fn_src = dedent(
         f"""
-def {sized_fn_name}({random_fn_input_names}):
-{indent(random_fn_body, " " * 4)}
-    return (rng, data)
+    def {nb_sampler_fn_name}({random_fn_input_names}):
+        size_tpl = to_fixed_tuple(size, tuple_size)
+        out_shape = np.broadcast_shapes(size_tpl, {input_shape_exprs})
+{indent(bcasted_input_stmts, " " * 8)}
+{indent(copy_rng_stmts, " " * 8)}
+        samples = np.empty(out_shape, dtype=out_dtype)
+        for i in np.ndindex(out_shape):
+            samples[i] = {sampler_fn_expr}{indexed_inputs})
+
+        return (rng, samples)
     """
-    )
+    ).strip()
+
     random_fn = compile_function_src(
-        sized_fn_src, sized_fn_name, {**globals(), **random_fn_global_env}
+        sampler_fn_src, nb_sampler_fn_name, {**globals(), **random_fn_global_env}
     )
     random_fn = numba_basic.numba_njit(random_fn)
 
@@ -222,124 +153,94 @@ def {sized_fn_name}({random_fn_input_names}):
 @_numba_funcify.register(aer.VonMisesRV)
 @_numba_funcify.register(aer.PoissonRV)
 @_numba_funcify.register(aer.GeometricRV)
-@_numba_funcify.register(aer.HyperGeometricRV)
+# @_numba_funcify.register(aer.HyperGeometricRV)
 @_numba_funcify.register(aer.WaldRV)
 @_numba_funcify.register(aer.LaplaceRV)
-@_numba_funcify.register(aer.BinomialRV)
+# @_numba_funcify.register(aer.BinomialRV)
 @_numba_funcify.register(aer.MultinomialRV)
-@_numba_funcify.register(aer.RandIntRV)  # only the first two arguments are supported
 @_numba_funcify.register(aer.ChoiceRV)  # the `p` argument is not supported
 @_numba_funcify.register(aer.PermutationRV)
 def numba_funcify_RandomVariable(op, node, **kwargs):
-    name = op.name
-    np_random_func = getattr(np.random, name)
-
-    return make_numba_random_fn(node, np_random_func)
-
-
-def create_numba_random_fn(
-    op: Op,
-    node: Apply,
-    scalar_fn: Callable[[str], str],
-    global_env: Optional[Dict[str, Any]] = None,
-) -> Callable:
-    """Create a vectorized function from a callable that generates the ``str`` function body.
-
-    TODO: This could/should be generalized for other simple function
-    construction cases that need unique-ified symbol names.
-    """
-    np_random_fn_name = f"aesara_random_{get_name_for_object(op.name)}"
-
-    if global_env:
-        np_global_env = global_env.copy()
-    else:
-        np_global_env = {}
-
-    np_global_env["np"] = np
-    np_global_env["numba_vectorize"] = numba_basic.numba_vectorize
-
-    unique_names = unique_name_generator(
-        [
-            np_random_fn_name,
-        ]
-        + list(np_global_env.keys())
-        + [
-            "rng",
-            "size",
-            "dtype",
-        ],
-        suffix_sep="_",
-    )
-
-    np_names = [unique_names(i, force_unique=True) for i in node.inputs[3:]]
-    np_input_names = ", ".join(np_names)
-    np_random_fn_src = f"""
-@numba_vectorize
-def {np_random_fn_name}({np_input_names}):
-{scalar_fn(*np_names)}
-    """
-    np_random_fn = compile_function_src(
-        np_random_fn_src, np_random_fn_name, {**globals(), **np_global_env}
-    )
-
-    return make_numba_random_fn(node, np_random_fn)
+    return make_numba_random_fn(node, op.name)
 
 
 @_numba_funcify.register(aer.NegBinomialRV)
 def numba_funcify_NegBinomialRV(op, node, **kwargs):
-    return make_numba_random_fn(node, np.random.negative_binomial)
+    return make_numba_random_fn(node, "negative_binomial")
+
+
+def gamma_scalar_fn(rng, shape, scale):
+    return rng.gamma(shape, scale)
+
+
+@_numba_funcify.register(aer.GammaRV)
+def numba_funcify_GammaRV(op, node, **kwargs):
+    scalar_fn = numba_basic.numba_njit(gamma_scalar_fn)
+    return make_numba_random_fn(node, "gamma", scalar_fn)
+
+
+def cauchy_scalar_fn(rng, loc, scale):
+    return loc + rng.standard_cauchy() * scale
 
 
 @_numba_funcify.register(aer.CauchyRV)
 def numba_funcify_CauchyRV(op, node, **kwargs):
-    def body_fn(loc, scale):
-        return f"    return ({loc} + np.random.standard_cauchy()) / {scale}"
+    scalar_fn = numba_basic.numba_njit(cauchy_scalar_fn)
+    return make_numba_random_fn(node, "cauchy", scalar_fn)
 
-    return create_numba_random_fn(op, node, body_fn)
+
+def pareto_scalar_fn(rng, b, scale):
+    return rng.pareto(b) / scale
+
+
+@_numba_funcify.register(aer.ParetoRV)
+def numba_funcify_ParetoRV(op, node, **kwargs):
+    scalar_fn = numba_basic.numba_njit(pareto_scalar_fn)
+    return make_numba_random_fn(node, "pareto", scalar_fn)
+
+
+def halfnormal_scalar_fn(rng, loc, scale):
+    return loc + abs(rng.standard_normal()) * scale
 
 
 @_numba_funcify.register(aer.HalfNormalRV)
 def numba_funcify_HalfNormalRV(op, node, **kwargs):
-    def body_fn(a, b):
-        return f"    return {a} + {b} * abs(np.random.normal(0, 1))"
-
-    return create_numba_random_fn(op, node, body_fn)
+    scalar_fn = numba_basic.numba_njit(halfnormal_scalar_fn)
+    return make_numba_random_fn(node, "halfnormal", scalar_fn)
 
 
 @_numba_funcify.register(aer.BernoulliRV)
 def numba_funcify_BernoulliRV(op, node, **kwargs):
     out_dtype = node.outputs[1].type.numpy_dtype
 
-    def body_fn(a):
-        return f"""
-    if {a} < np.random.uniform(0, 1):
-        return direct_cast(0, out_dtype)
-    else:
-        return direct_cast(1, out_dtype)
-        """
+    @numba_basic.numba_njit
+    def scalar_fn(rng, a):
+        if a < rng.uniform(0, 1):
+            return numba_basic.direct_cast(0, out_dtype)
+        else:
+            return numba_basic.direct_cast(1, out_dtype)
 
-    return create_numba_random_fn(
-        op,
-        node,
-        body_fn,
-        {"out_dtype": out_dtype, "direct_cast": numba_basic.direct_cast},
-    )
+    return make_numba_random_fn(node, "bernoulli", scalar_fn)
 
 
 @_numba_funcify.register(aer.CategoricalRV)
 def numba_funcify_CategoricalRV(op, node, **kwargs):
     out_dtype = node.outputs[1].type.numpy_dtype
     size_len = int(get_vector_length(node.inputs[1]))
+    inplace = op.inplace
 
     @numba_basic.numba_njit
     def categorical_rv(rng, size, dtype, p):
+        if not inplace:
+            rng = copy(rng)
+
         if not size_len:
             size_tpl = p.shape[:-1]
         else:
             size_tpl = numba_ndarray.to_fixed_tuple(size, size_len)
             p = np.broadcast_to(p, size_tpl + p.shape[-1:])
 
-        unif_samples = np.asarray(np.random.uniform(0, 1, size_tpl))
+        unif_samples = np.asarray(rng.uniform(0, 1, size_tpl))
 
         res = np.empty(size_tpl, dtype=out_dtype)
         for idx in np.ndindex(*size_tpl):
@@ -356,11 +257,15 @@ def numba_funcify_DirichletRV(op, node, **kwargs):
     alphas_ndim = node.inputs[3].type.ndim
     neg_ind_shape_len = -alphas_ndim + 1
     size_len = int(get_vector_length(node.inputs[1]))
+    inplace = op.inplace
 
     if alphas_ndim > 1:
 
         @numba_basic.numba_njit
         def dirichlet_rv(rng, size, dtype, alphas):
+            if not inplace:
+                rng = copy(rng)
+
             if size_len > 0:
                 size_tpl = numba_ndarray.to_fixed_tuple(size, size_len)
                 if (
@@ -376,7 +281,7 @@ def numba_funcify_DirichletRV(op, node, **kwargs):
             alphas_bcast = np.broadcast_to(alphas, samples_shape)
 
             for index in np.ndindex(*samples_shape[:-1]):
-                res[index] = np.random.dirichlet(alphas_bcast[index])
+                res[index] = rng.dirichlet(alphas_bcast[index])
 
             return (rng, res)
 
@@ -384,7 +289,10 @@ def numba_funcify_DirichletRV(op, node, **kwargs):
 
         @numba_basic.numba_njit
         def dirichlet_rv(rng, size, dtype, alphas):
+            if not inplace:
+                rng = copy(rng)
+
             size = numba_ndarray.to_fixed_tuple(size, size_len)
-            return (rng, np.random.dirichlet(alphas, size))
+            return (rng, rng.dirichlet(alphas, size))
 
     return dirichlet_rv

--- a/aesara/link/numba/linker.py
+++ b/aesara/link/numba/linker.py
@@ -33,22 +33,8 @@ class NumbaLinker(JITLinker):
         return jitted_fn
 
     def create_thunk_inputs(self, storage_map):
-        from numpy.random import RandomState
-
-        from aesara.link.numba.dispatch import numba_const_convert
-
         thunk_inputs = []
         for n in self.fgraph.inputs:
-            sinput = storage_map[n]
-            if isinstance(sinput[0], RandomState):
-                new_value = numba_const_convert(
-                    sinput[0], dtype=getattr(sinput[0], "dtype", None)
-                )
-                # We need to remove the reference-based connection to the
-                # original `RandomState`/shared variable's storage, because
-                # subsequent attempts to use the same shared variable within
-                # other non-Numba-fied graphs will have problems.
-                sinput = [new_value]
-            thunk_inputs.append(sinput)
+            thunk_inputs.append(storage_map[n])
 
         return thunk_inputs

--- a/aesara/sparse/sandbox/sp.py
+++ b/aesara/sparse/sandbox/sp.py
@@ -208,7 +208,7 @@ class ConvolutionIndices(Op):
                                     # onto the sparse columns (idea of
                                     # kernel map)
                                     # n*... only for sparse
-                                    spmat[row + n * outsize, col] = tapi + 1
+                                    spmat[int(row + n * outsize), int(col)] = tapi + 1
 
                                     # total number of active taps
                                     # (used for kmap)

--- a/aesara/tensor/signal/pool.py
+++ b/aesara/tensor/signal/pool.py
@@ -600,7 +600,7 @@ class Pool(OpenMPOp):
             yk = y[k]
             # iterate over pooling regions
             for r in np.ndindex(*pool_out_shp):
-                zzk[r] = func(yk[[region_slices[i][r[i]] for i in range(nd)]])
+                zzk[r] = func(yk[tuple(region_slices[i][r[i]] for i in range(nd))])
 
     def infer_shape(self, fgraph, node, in_shapes):
         ws, stride, pad = [node.inputs[1], node.inputs[2], node.inputs[3]]
@@ -1578,7 +1578,7 @@ class AveragePoolGrad(PoolGrad):
                 else:
                     # divide by region size
                     val = gzk[r] / region_size
-                gxk[region_slice] += val
+                gxk[tuple(region_slice)] += val
 
         # unpad the image
         gx = gx[

--- a/environment-arm.yml
+++ b/environment-arm.yml
@@ -6,6 +6,7 @@
 name: aesara-dev
 channels:
   - conda-forge
+  - numba
 dependencies:
   - python
   - compilers
@@ -21,7 +22,7 @@ dependencies:
   - openblas
   - libblas=*=*openblas
   # numba backend
-  - numba>=0.55.2
+  - numba>=0.57.0
   - llvmlite>=0.38.1
   - numba-scipy
   # For testing

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@
 name: aesara-dev
 channels:
   - conda-forge
+  - numba
 dependencies:
   - python
   - compilers
@@ -21,7 +22,7 @@ dependencies:
   - mkl-service
   - libblas=*=*mkl
   # numba backend
-  - numba>=0.55
+  - numba>=0.57.0
   - numba-scipy
   # For testing
   - coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cython
 sympy
 jax>=0.4.1
 jaxlib>=0.4.1
-numba>=0.55
+numba>=0.57.0
 numba-scipy>=0.3.0
 diff-cover
 pre-commit

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -1,5 +1,6 @@
 import contextlib
 import inspect
+from copy import copy
 from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Tuple, Union
 from unittest import mock
 
@@ -17,7 +18,7 @@ from aesara.compile.function import function
 from aesara.compile.mode import Mode
 from aesara.compile.ops import ViewOp
 from aesara.compile.sharedvalue import SharedVariable
-from aesara.graph.basic import Apply, Constant
+from aesara.graph.basic import Apply, Constant, vars_between
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.op import Op, get_test_value
 from aesara.graph.rewriting.db import RewriteDatabaseQuery
@@ -223,6 +224,11 @@ def compare_numba_and_py(
 
     fn_inputs = [i for i in fn_inputs if not isinstance(i, SharedVariable)]
 
+    shared_vars_to_init_vals = {}
+    for v in vars_between(fn_inputs, fn_outputs):
+        if isinstance(v, SharedVariable):
+            shared_vars_to_init_vals[v] = copy(v.get_value(borrow=True))
+
     aesara_py_fn = function(
         fn_inputs, fn_outputs, mode=py_mode, accept_inplace=True, updates=updates
     )
@@ -235,6 +241,12 @@ def compare_numba_and_py(
         accept_inplace=True,
         updates=updates,
     )
+
+    # Reset shared variables so that the results will match between the two
+    # runs
+    for v, val in shared_vars_to_init_vals.items():
+        v.set_value(val)
+
     numba_res = aesara_numba_fn(*inputs)
 
     # Get some coverage

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -25,7 +25,6 @@ from aesara.graph.rewriting.db import RewriteDatabaseQuery
 from aesara.graph.type import Type
 from aesara.ifelse import ifelse
 from aesara.link.numba.dispatch import basic as numba_basic
-from aesara.link.numba.dispatch import numba_const_convert
 from aesara.link.numba.dispatch.sparse import CSCMatrixType, CSRMatrixType
 from aesara.link.numba.linker import NumbaLinker
 from aesara.raise_op import assert_op
@@ -336,26 +335,6 @@ def test_get_numba_type_readonly():
 def test_create_numba_signature(v, expected, force_scalar):
     res = numba_basic.create_numba_signature(v, force_scalar=force_scalar)
     assert res == expected
-
-
-@pytest.mark.parametrize(
-    "input, wrapper_fn, check_fn",
-    [
-        (
-            np.random.RandomState(1),
-            numba_const_convert,
-            lambda x, y: np.all(x.get_state()[1] == y.get_state()[1]),
-        )
-    ],
-)
-def test_box_unbox(input, wrapper_fn, check_fn):
-    input = wrapper_fn(input)
-
-    pass_through = numba.njit(lambda x: x)
-    res = pass_through(input)
-
-    assert isinstance(res, type(input))
-    assert check_fn(res, input)
 
 
 @pytest.mark.parametrize(

--- a/tests/link/numba/test_random.py
+++ b/tests/link/numba/test_random.py
@@ -520,7 +520,6 @@ def test_CategoricalRV(dist_args, size, cm):
         )
 
 
-@pytest.mark.skip(reason="Not yet supported in Numba via `Generator`s")
 @pytest.mark.parametrize(
     "a, size, cm",
     [

--- a/tests/link/numba/test_random.py
+++ b/tests/link/numba/test_random.py
@@ -362,7 +362,7 @@ def test_aligned_RandomVariable(rv_op, dist_args, size):
             "chi2",
             lambda *args: args,
         ),
-        pytest.param(
+        (
             aer.gumbel,
             [
                 set_test_value(
@@ -377,9 +377,6 @@ def test_aligned_RandomVariable(rv_op, dist_args, size):
             (2,),
             "gumbel_r",
             lambda *args: args,
-            marks=pytest.mark.skip(
-                reason="Not yet supported in Numba via `Generator`s"
-            ),
         ),
         (
             aer.negative_binomial,

--- a/tests/link/numba/test_scan.py
+++ b/tests/link/numba/test_scan.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 import aesara.tensor as at
-from aesara import config, function, grad
+from aesara import config, grad
 from aesara.compile.mode import Mode, get_mode
 from aesara.graph.fg import FunctionGraph
 from aesara.scan.basic import scan
@@ -14,7 +14,7 @@ from tests.link.numba.test_basic import compare_numba_and_py
 
 
 @pytest.mark.parametrize(
-    "fn, sequences, outputs_info, non_sequences, n_steps, input_vals, output_vals, op_check",
+    "fn, sequences, outputs_info, non_sequences, n_steps, input_vals, op_check",
     [
         # sequences
         (
@@ -24,7 +24,6 @@ from tests.link.numba.test_basic import compare_numba_and_py
             [],
             None,
             [np.arange(10)],
-            None,
             lambda op: op.info.n_seqs > 0,
         ),
         # nit-sot
@@ -35,7 +34,6 @@ from tests.link.numba.test_basic import compare_numba_and_py
             [],
             3,
             [],
-            None,
             lambda op: op.info.n_nit_sot > 0,
         ),
         # nit-sot, non_seq
@@ -46,7 +44,6 @@ from tests.link.numba.test_basic import compare_numba_and_py
             [at.dscalar("c")],
             3,
             [1.0],
-            None,
             lambda op: op.info.n_nit_sot > 0 and op.info.n_non_seqs > 0,
         ),
         # sit-sot
@@ -57,7 +54,6 @@ from tests.link.numba.test_basic import compare_numba_and_py
             [],
             3,
             [],
-            None,
             lambda op: op.info.n_sit_sot > 0,
         ),
         # sit-sot, while
@@ -68,12 +64,11 @@ from tests.link.numba.test_basic import compare_numba_and_py
             [],
             3,
             [],
-            None,
             lambda op: op.info.n_sit_sot > 0,
         ),
         # nit-sot, shared input/output
         (
-            lambda: RandomStream(seed=1930, rng_ctor=np.random.RandomState).normal(
+            lambda: RandomStream(seed=1930, rng_ctor=np.random.default_rng).normal(
                 0, 1, name="a"
             ),
             [],
@@ -81,7 +76,6 @@ from tests.link.numba.test_basic import compare_numba_and_py
             [],
             3,
             [],
-            [np.array([-1.63408257, 0.18046406, 2.43265803])],
             lambda op: op.info.n_shared_outs > 0,
         ),
         # mit-sot (that's also a type of sit-sot)
@@ -92,7 +86,6 @@ from tests.link.numba.test_basic import compare_numba_and_py
             [],
             6,
             [],
-            None,
             lambda op: op.info.n_mit_sot > 0,
         ),
         # mit-sot
@@ -106,7 +99,6 @@ from tests.link.numba.test_basic import compare_numba_and_py
             [],
             10,
             [],
-            None,
             lambda op: op.info.n_mit_sot > 0,
         ),
     ],
@@ -118,7 +110,6 @@ def test_xit_xot_types(
     non_sequences,
     n_steps,
     input_vals,
-    output_vals,
     op_check,
 ):
     """Test basic xit-xot configurations."""
@@ -143,17 +134,7 @@ def test_xit_xot_types(
 
     _ = op_check(scan_op)
 
-    if output_vals is None:
-        compare_numba_and_py(
-            (sequences + non_sequences, res), input_vals, updates=updates
-        )
-    else:
-        numba_mode = get_mode("NUMBA")
-        numba_fn = function(
-            sequences + non_sequences, res, mode=numba_mode, updates=updates
-        )
-        res_val = numba_fn(*input_vals)
-        assert np.allclose(res_val, output_vals)
+    compare_numba_and_py((sequences + non_sequences, res), input_vals, updates=updates)
 
 
 def test_scan_multiple_output(benchmark):


### PR DESCRIPTION
Closes #814.

- [x] Find a combination of packages that works with the required dev version of Numba
- [x] `dirichlet` isn't currently supported in Numba.
- [x] `gumbel` isn't currently supported in Numba.
- [x] `binomial` isn't currently supported in Numba.
    Object-mode is being used.  This will need a follow-up issue for a non-object-mode implementation.
- [x] `hypergeometric` isn't currently supported in Numba.
    Object-mode is being used.  This will need a follow-up issue for a non-object-mode implementation.
- [x] `scan` runs performed without merging produce slightly different sample results between Numba and Python modes.
    This might be due to the extra RNG state `copy`s in the Python `RandomVariable.perform` implementations, but I haven't checked yet.
    Update: It was due to the `copy`s, and they've been added to the Numba implementations; however, they require the use of object-mode, which is somewhat undesirable.  This will need a follow-up issue for a non-object-mode implementation.