### PR TITLE
Refactor output `Type` inference in `RandomVariable` and `Scan`

### DIFF
--- a/aesara/compile/debugmode.py
+++ b/aesara/compile/debugmode.py
@@ -807,7 +807,7 @@ def _get_preallocated_maps(
         for r in considered_outputs:
             if isinstance(r.type, TensorType):
                 # Build a C-contiguous buffer
-                new_buf = r.type.value_zeros(r_vals[r].shape)
+                new_buf = np.empty(r_vals[r].shape, dtype=r.type.dtype)
                 assert new_buf.flags["C_CONTIGUOUS"]
                 new_buf[...] = np.asarray(def_val).astype(r.type.dtype)
 
@@ -875,7 +875,8 @@ def _get_preallocated_maps(
                         buf_shape.append(s)
                     else:
                         buf_shape.append(s * 2)
-                new_buf = r.type.value_zeros(buf_shape)
+
+                new_buf = np.empty(buf_shape, dtype=r.type.dtype)
                 new_buf[...] = np.asarray(def_val).astype(r.type.dtype)
                 init_strided[r] = new_buf
 
@@ -950,7 +951,7 @@ def _get_preallocated_maps(
                             max((s + sd), 0)
                             for s, sd in zip(r_vals[r].shape, r_shape_diff)
                         ]
-                        new_buf = r.type.value_zeros(out_shape)
+                        new_buf = np.empty(out_shape, dtype=r.type.dtype)
                         new_buf[...] = np.asarray(def_val).astype(r.type.dtype)
                         wrong_size[r] = new_buf
 

--- a/aesara/scan/op.py
+++ b/aesara/scan/op.py
@@ -200,7 +200,7 @@ def copy_var_format(var, as_var):
         rval = as_var.type.filter_variable(rval)
     else:
         tmp = as_var.type.clone(
-            shape=(tuple(var.broadcastable[:1]) + tuple(as_var.broadcastable))
+            shape=(tuple(var.type.shape[:1]) + tuple(as_var.type.shape))
         )
         rval = tmp.filter_variable(rval)
     return rval
@@ -805,7 +805,9 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             # output sequence
             o = outputs[idx]
             self.output_types.append(
-                typeConstructor((False,) + o.type.broadcastable, o.type.dtype)
+                # TODO: What can we actually say about the shape of this
+                # added dimension?
+                typeConstructor((None,) + o.type.shape, o.type.dtype)
             )
 
             idx += len(info.mit_mot_out_slices[jdx])
@@ -816,7 +818,9 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
 
         for o in outputs[idx:end]:
             self.output_types.append(
-                typeConstructor((False,) + o.type.broadcastable, o.type.dtype)
+                # TODO: What can we actually say about the shape of this
+                # added dimension?
+                typeConstructor((None,) + o.type.shape, o.type.dtype)
             )
 
         # shared outputs + possibly the ending condition
@@ -2320,8 +2324,8 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                     # equivalent (if False). Here, we only need the variable.
                     v_shp_i = validator.check(shp_i)
                     if v_shp_i is None:
-                        if hasattr(r, "broadcastable") and r.broadcastable[i]:
-                            shp.append(1)
+                        if r.type.shape[i] is not None:
+                            shp.append(r.type.shape[i])
                         else:
                             shp.append(Shape_i(i)(r))
                     else:

--- a/aesara/scan/op.py
+++ b/aesara/scan/op.py
@@ -161,8 +161,9 @@ def check_broadcast(v1, v2):
     which may wrongly be interpreted as broadcastable.
 
     """
-    if not hasattr(v1, "broadcastable") and not hasattr(v2, "broadcastable"):
+    if not isinstance(v1.type, TensorType) and not isinstance(v2.type, TensorType):
         return
+
     msg = (
         "The broadcast pattern of the output of scan (%s) is "
         "inconsistent with the one provided in `output_info` "
@@ -173,13 +174,13 @@ def check_broadcast(v1, v2):
         "them consistent, e.g. using aesara.tensor."
         "{unbroadcast, specify_broadcastable}."
     )
-    size = min(len(v1.broadcastable), len(v2.broadcastable))
+    size = min(v1.type.ndim, v2.type.ndim)
     for n, (b1, b2) in enumerate(
-        zip(v1.broadcastable[-size:], v2.broadcastable[-size:])
+        zip(v1.type.broadcastable[-size:], v2.type.broadcastable[-size:])
     ):
         if b1 != b2:
-            a1 = n + size - len(v1.broadcastable) + 1
-            a2 = n + size - len(v2.broadcastable) + 1
+            a1 = n + size - v1.type.ndim + 1
+            a2 = n + size - v2.type.ndim + 1
             raise TypeError(msg % (v1.type, v2.type, a1, b1, b2, a2))
 
 
@@ -628,6 +629,7 @@ class ScanMethodsMixin:
                 type_input = self.inner_inputs[inner_iidx].type
                 type_output = self.inner_outputs[inner_oidx].type
                 if (
+                    # TODO: Use the `Type` interface for this
                     type_input.dtype != type_output.dtype
                     or type_input.broadcastable != type_output.broadcastable
                 ):

--- a/aesara/scan/op.py
+++ b/aesara/scan/op.py
@@ -1380,11 +1380,13 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
                         # the output value, possibly inplace, at the end of the
                         # function execution. Also, since an update is defined,
                         # a default value must also be (this is verified by
-                        # DebugMode). Use an array of size 0 with the correct
-                        # ndim and dtype (use a shape of 1 on broadcastable
-                        # dimensions, and 0 on the others).
-                        default_shape = [1 if _b else 0 for _b in inp.broadcastable]
-                        default_val = inp.type.value_zeros(default_shape)
+                        # DebugMode).
+                        # TODO FIXME: Why do we need a "default value" here?
+                        # This sounds like a serious design issue.
+                        default_shape = tuple(
+                            s if s is not None else 0 for s in inp.type.shape
+                        )
+                        default_val = np.empty(default_shape, dtype=inp.type.dtype)
                         wrapped_inp = In(
                             variable=inp,
                             value=default_val,

--- a/aesara/sparse/type.py
+++ b/aesara/sparse/type.py
@@ -224,14 +224,6 @@ class SparseTensorType(TensorType, HasDataType):
             + (shape_info[2] + shape_info[3]) * np.dtype("int32").itemsize
         )
 
-    def value_zeros(self, shape):
-        matrix_constructor = self.format_cls.get(self.format)
-
-        if matrix_constructor is None:
-            raise ValueError(f"Sparse matrix type {self.format} not found in SciPy")
-
-        return matrix_constructor(shape, dtype=self.dtype)
-
     def __eq__(self, other):
         res = super().__eq__(other)
 

--- a/aesara/tensor/random/op.py
+++ b/aesara/tensor/random/op.py
@@ -14,7 +14,7 @@ from aesara.tensor.basic import (
     constant,
     get_scalar_constant_value,
     get_vector_length,
-    infer_broadcastable,
+    infer_static_shape,
 )
 from aesara.tensor.random.type import RandomGeneratorType, RandomStateType, RandomType
 from aesara.tensor.random.utils import normalize_size_param, params_broadcast_shapes
@@ -322,7 +322,7 @@ class RandomVariable(Op):
             )
 
         shape = self._infer_shape(size, dist_params)
-        _, bcast = infer_broadcastable(shape)
+        _, static_shape = infer_static_shape(shape)
         dtype = self.dtype or dtype
 
         if dtype == "floatX":
@@ -336,7 +336,7 @@ class RandomVariable(Op):
             dtype_idx = constant(dtype, dtype="int64")
             dtype = all_dtypes[dtype_idx.data]
 
-        outtype = TensorType(dtype=dtype, shape=bcast)
+        outtype = TensorType(dtype=dtype, shape=static_shape)
         out_var = outtype()
         inputs = (rng, size, dtype_idx) + dist_params
         outputs = (rng.type(), out_var)

--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -331,13 +331,6 @@ class TensorType(CType[np.ndarray], HasDataType, HasShape):
             # `specify_shape` will combine the more precise shapes of the two types
             return aesara.tensor.specify_shape(var, self.shape)
 
-    def value_zeros(self, shape):
-        """Create an numpy ndarray full of 0 values.
-
-        TODO: Remove this trivial method.
-        """
-        return np.zeros(shape, dtype=self.dtype)
-
     @staticmethod
     def values_eq(a, b, force_same_dtype=True):
         # TODO: check to see if the shapes must match; for now, we err on safe

--- a/tests/compile/test_debugmode.py
+++ b/tests/compile/test_debugmode.py
@@ -725,10 +725,10 @@ class VecAsRowAndCol(Op):
         r, c = out
         lv = v.shape[0]
         if (r[0] is None) or (r[0].shape != (1, lv)):
-            r[0] = node.outputs[0].type.value_zeros((1, lv))
+            r[0] = np.empty((1, lv), dtype=node.outputs[0].type.dtype)
 
         if (c[0] is None) or (c[0].shape != (lv, 1)):
-            c[0] = node.outputs[1].type.value_zeros((lv, 1))
+            c[0] = np.empty((lv, 1), dtype=node.outputs[0].type.dtype)
 
         for i in range(lv):
             r[0][0, i] = v[i]

--- a/tests/scan/test_rewriting.py
+++ b/tests/scan/test_rewriting.py
@@ -1101,7 +1101,7 @@ class TestScanInplaceOptimizer:
         outputs, updates = scan(
             lambda x, y: (x + asarrayX(1), y + asarrayX(1)), [], [x0, x1], n_steps=3
         )
-        x0 = asarrayX(np.zeros((3,)))
+        x0 = asarrayX(np.zeros((4,)))
         x0[0] = vx0
         x0 = at.constant(x0)
 

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -276,8 +276,9 @@ class TestLocalCanonicalizeAlloc:
 
         assert a.owner and isinstance(a.owner.op, Alloc)
 
-        # `local_useless_alloc` should replace the `Alloc` with an `Assert`
-        with pytest.raises(AssertionError):
+        # `local_useless_alloc` should attempt to replace the `Alloc` with an
+        # `Assert` and fail when the static shape information conflicts.
+        with pytest.raises(TypeError):
             f = function([], a, mode=rewrite_mode)
 
         x = at.as_tensor(self.rng.standard_normal((6, 7)))

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -55,7 +55,7 @@ from aesara.tensor.basic import (
     get_vector_length,
     horizontal_stack,
     identity_like,
-    infer_broadcastable,
+    infer_static_shape,
     inverse_permutation,
     join,
     make_vector,
@@ -796,20 +796,20 @@ class TestAlloc:
 
 def test_infer_broadcastable():
     with pytest.raises(TypeError, match="^Shapes must be scalar integers.*"):
-        infer_broadcastable([constant(1.0)])
+        infer_static_shape([constant(1.0)])
 
     with config.change_flags(exception_verbosity="high"), pytest.raises(
         TypeError, match=r"A\. x"
     ):
-        infer_broadcastable([dscalar("x")])
+        infer_static_shape([dscalar("x")])
 
     with pytest.raises(ValueError, match=".*could not be cast to have 0 dimensions"):
-        infer_broadcastable((as_tensor_variable([[1, 2]]),))
+        infer_static_shape((as_tensor_variable([[1, 2]]),))
 
     constant_size = constant([1])
     specify_size = specify_shape(constant_size, [1])
-    sh, bcast = infer_broadcastable(specify_size)
-    assert bcast == (True,)
+    sh, static_shape = infer_static_shape(specify_size)
+    assert static_shape == (1,)
 
 
 # This is slow for the ('int8', 3) version.

--- a/tests/tensor/test_type.py
+++ b/tests/tensor/test_type.py
@@ -234,7 +234,6 @@ def test_fixed_shape_basic():
     t1 = TensorType("float64", (2, 3))
     assert t1.shape == (2, 3)
     assert t1.broadcastable == (False, False)
-    assert t1.value_zeros(t1.shape).shape == t1.shape
 
     assert str(t1) == "TensorType(float64, (2, 3))"
 


### PR DESCRIPTION
This PR provides initial fixes for #1252, and similar faulty logic that's based on the deprecated strict `TensorType.broadcastable`.