### PR TITLE
Add documentation for `aesara.as_symbolic()`

### DIFF
--- a/doc/library/index.rst
+++ b/doc/library/index.rst
@@ -60,6 +60,11 @@ Control flow
 
    Alias for :func:`aesara.scan.basic.scan`
 
+Convert to Variable
+====================
+
+.. autofunction:: aesara.as_symbolic(...)
+
 Debug
 =====
 


### PR DESCRIPTION
Add documentation for `aesara.as_symbolic()` function.

closes https://github.com/aesara-devs/aesara/issues/746

This is how it looks when I built the documentation locally -

<img width="806" alt="Screenshot 2022-10-17 at 6 48 58 PM" src="https://user-images.githubusercontent.com/2778341/196187350-7c6bc678-a240-432f-a062-0d1ea0c327be.png">
