### PR TITLE
Fix `SharedVariable.value` usage in `broadcast_shape_iter`

### DIFF
--- a/aesara/tensor/extra_ops.py
+++ b/aesara/tensor/extra_ops.py
@@ -1493,7 +1493,7 @@ def broadcast_shape_iter(
             (one_at,) * (max_dims - len(a))
             + tuple(
                 one_at
-                if getattr(sh, "value", sh) == 1
+                if sh == 1 or isinstance(sh, Constant) and sh.value == 1
                 else (aes.as_scalar(sh) if not isinstance(sh, Variable) else sh)
                 for sh in a
             )

--- a/tests/tensor/test_extra_ops.py
+++ b/tests/tensor/test_extra_ops.py
@@ -1142,6 +1142,12 @@ def test_broadcast_shape_basic():
     b_at = broadcast_shape(x_at, y_at)
     assert isinstance(b_at[-1].owner.op, Assert)
 
+    # N.B. Shared variable shape values shouldn't be treated as constants,
+    # because they can change.
+    s = aesara.shared(1)
+    b_at = broadcast_shape((s, 2), (2, 1), arrays_are_shapes=True)
+    assert isinstance(b_at[0].owner.op, Assert)
+
 
 def test_broadcast_shape_constants():
     """Make sure `broadcast_shape` uses constants when it can."""


### PR DESCRIPTION
Closes #1255