### PR TITLE
Add `name` argument to `Variable.clone`

### DIFF
--- a/aesara/compile/sharedvalue.py
+++ b/aesara/compile/sharedvalue.py
@@ -167,9 +167,10 @@ class SharedVariable(Variable):
         else:
             self.container.value = 0 * self.container.value
 
-    def clone(self):
+    def clone(self, **kwargs):
+        name = kwargs.get("name", self.name)
         cp = self.__class__(
-            name=self.name,
+            name=name,
             type=self.type,
             value=None,
             strict=None,

--- a/tests/graph/test_basic.py
+++ b/tests/graph/test_basic.py
@@ -354,6 +354,12 @@ class TestAutoName:
         assert r1.auto_name == "auto_" + str(autoname_id)
         assert r2.auto_name == "auto_" + str(autoname_id + 1)
 
+        assert r1.name is None and r1.name is r2.name
+
+        r3_name = "r3"
+        r3 = r1.clone(name=r3_name)
+        assert r3.name == r3_name
+
 
 def test_equal_computations():
 


### PR DESCRIPTION
**Thank you for opening a PR!**

This PR addresses this [enhancement issue](https://github.com/aesara-devs/aesara/issues/1281) and adds an optional name argument when cloning a Variable

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [ ] There is an informative high-level description of the changes.
+ [ ] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [ ] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [ ] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [ ] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
