### PR TITLE
Do not always remap storage in `fgraph_to_python`

### DIFF
--- a/aesara/link/numba/dispatch/basic.py
+++ b/aesara/link/numba/dispatch/basic.py
@@ -377,6 +377,9 @@ def numba_funcify(op, node=None, storage_map=None, **kwargs):
 
 @numba_funcify.register(OpFromGraph)
 def numba_funcify_OpFromGraph(op, node=None, **kwargs):
+
+    _ = kwargs.pop("storage_map", None)
+
     fgraph_fn = numba_njit(numba_funcify(op.fgraph, **kwargs))
 
     if len(op.fgraph.outputs) == 1:

--- a/aesara/link/numba/dispatch/scalar.py
+++ b/aesara/link/numba/dispatch/scalar.py
@@ -221,6 +221,9 @@ def numba_funcify_Clip(op, **kwargs):
 @numba_funcify.register(Composite)
 def numba_funcify_Composite(op, node, **kwargs):
     signature = create_numba_signature(node, force_scalar=True)
+
+    _ = kwargs.pop("storage_map", None)
+
     composite_fn = numba_basic.numba_njit(signature, fastmath=config.numba__fastmath)(
         numba_funcify(op.fgraph, squeeze_output=True, **kwargs)
     )

--- a/aesara/link/utils.py
+++ b/aesara/link/utils.py
@@ -688,14 +688,14 @@ def fgraph_to_python(
     squeeze_output: bool = False,
     **kwargs,
 ) -> Callable:
-    """Convert a ``FunctionGraph`` into a regular Python function.
+    """Convert a `FunctionGraph` into a regular Python function.
 
     Parameters
     ==========
     fgraph
-        The ``FunctionGraph`` to convert.
+        The `FunctionGraph` to convert.
     op_conversion_fn
-        A callable used to convert nodes inside `fgraph` based on their ``Op``
+        A callable used to convert nodes inside `fgraph` based on their `Op`
         types.  It must have the signature
         ``(op: Op, node: Apply=None, storage_map: Dict[Variable, List[Optional[Any]]]=None, **kwargs)``.
     type_conversion_fn
@@ -703,13 +703,13 @@ def fgraph_to_python(
         the signature
         ``(value: Optional[Any], variable: Variable=None, storage: List[Optional[Any]]=None, **kwargs)``.
     order
-        The ``order`` argument to ``map_storage``.
+        The `order` argument to `map_storage`.
     input_storage
-        The ``input_storage`` argument to ``map_storage``.
+        The `input_storage` argument to `map_storage`.
     output_storage
-        The ``output_storage`` argument to ``map_storage``.
+        The `output_storage` argument to `map_storage`.
     storage_map
-        The ``storage_map`` argument to ``map_storage``.
+        The `storage_map` argument to `map_storage`.
     fgraph_name
         The name used for the resulting function.
     global_env
@@ -722,7 +722,7 @@ def fgraph_to_python(
         A function used to provide names for the objects referenced within the
         generated function.
     squeeze_output
-        If the ``FunctionGraph`` has only one output and this option is
+        If the `FunctionGraph` has only one output and this option is
         ``True``, return the single output instead of a tuple with the output.
     **kwargs
         The remaining keywords are passed to `python_conversion_fn`

--- a/tests/link/test_utils.py
+++ b/tests/link/test_utils.py
@@ -176,6 +176,25 @@ def test_fgraph_to_python_constant_outputs():
     assert out_py()[0] is y.data
 
 
+def test_fgraph_to_python_constant_inputs():
+    x = constant([1.0])
+    y = vector("y")
+
+    out = x + y
+    out_fg = FunctionGraph(outputs=[out], clone=False)
+
+    out_py = fgraph_to_python(out_fg, to_python, storage_map=None)
+
+    res = out_py(2.0)
+    assert res == (3.0,)
+
+    storage_map = {out: [None], x: [np.r_[2.0]], y: [None]}
+    out_py = fgraph_to_python(out_fg, to_python, storage_map=storage_map)
+
+    res = out_py(2.0)
+    assert res == (4.0,)
+
+
 def test_unique_name_generator():
 
     unique_names = unique_name_generator(["blah"], suffix_sep="_")


### PR DESCRIPTION
This PR fixes an issue resulting from re-mapped storage cells in `fgraph_to_python`.  The issue was discovered in #1289 via `TestOpFromGraph.test_grad`.

Basic `OpFromGraph` support for Numba is added in this PR as well.

- [x] Write more direct/explicit tests