### PR TITLE
Replace some uses of `TensorType.broadcastable` with `TensorType.shape`

### DIFF
--- a/aesara/gradient.py
+++ b/aesara/gradient.py
@@ -1802,13 +1802,11 @@ def verify_grad(
         mode=mode,
     )
 
-    tensor_pt = [
-        aesara.tensor.type.TensorType(
-            aesara.tensor.as_tensor_variable(p).dtype,
-            aesara.tensor.as_tensor_variable(p).broadcastable,
-        )(name=f"input {i}")
-        for i, p in enumerate(pt)
-    ]
+    tensor_pt = []
+    for i, p in enumerate(pt):
+        p_t = aesara.tensor.as_tensor_variable(p).type()
+        p_t.name = f"input {i}"
+        tensor_pt.append(p_t)
 
     # fun can be either a function or an actual Op instance
     o_output = fun(*tensor_pt)

--- a/aesara/link/c/params_type.py
+++ b/aesara/link/c/params_type.py
@@ -29,7 +29,7 @@ In your Op sub-class:
 
 .. code-block:: python
 
-    params_type = ParamsType(attr1=TensorType('int32', (False, False)), attr2=ScalarType('float64'))
+    params_type = ParamsType(attr1=TensorType('int32', shape=(None, None)), attr2=ScalarType('float64'))
 
 If your op contains attributes ``attr1`` **and** ``attr2``, the default ``op.get_params()``
 implementation will automatically try to look for it and generate an appropriate Params object.
@@ -324,7 +324,7 @@ class ParamsType(CType):
     `ParamsType` constructor takes key-value args.  Key will be the name of the
     attribute in the struct.  Value is the Aesara type of this attribute,
     ie. an instance of (a subclass of) :class:`CType`
-    (eg. ``TensorType('int64', (False,))``).
+    (eg. ``TensorType('int64', (None,))``).
 
     In a Python code any attribute named ``key`` will be available via::
 

--- a/aesara/sandbox/multinomial.py
+++ b/aesara/sandbox/multinomial.py
@@ -44,7 +44,9 @@ class MultinomialFromUniform(COp):
             odtype = pvals.dtype
         else:
             odtype = self.odtype
-        out = at.tensor(dtype=odtype, shape=pvals.type.broadcastable)
+        out = at.tensor(
+            dtype=odtype, shape=tuple(1 if s == 1 else None for s in pvals.type.shape)
+        )
         return Apply(self, [pvals, unis, as_scalar(n)], [out])
 
     def grad(self, ins, outgrads):

--- a/aesara/sparse/rewriting.py
+++ b/aesara/sparse/rewriting.py
@@ -677,7 +677,7 @@ class UsmmCscDense(_NoPythonCOp):
         assert x_ind.dtype == "int32"
         assert x_ptr.dtype == "int32"
         assert x_nrows.dtype == "int32"
-        assert alpha.ndim == 2 and alpha.type.broadcastable == (True, True)
+        assert alpha.ndim == 2 and alpha.type.shape == (1, 1)
         assert x_val.ndim == 1
         assert y.ndim == 2
         assert z.ndim == 2
@@ -905,7 +905,7 @@ local_usmm = PatternNodeRewriter(
             {
                 "pattern": "alpha",
                 "constraint": lambda expr: (
-                    all(expr.type.broadcastable) and config.blas__ldflags
+                    all(s == 1 for s in expr.type.shape) and config.blas__ldflags
                 ),
             },
             (sparse._dot, "x", "y"),

--- a/aesara/sparse/rewriting.py
+++ b/aesara/sparse/rewriting.py
@@ -126,7 +126,9 @@ class AddSD_ccode(_NoPythonCOp):
         # The magic number two here arises because L{scipy.sparse}
         # objects must be matrices (have dimension 2)
         assert y.type.ndim == 2
-        out = TensorType(dtype=out_dtype, shape=y.type.broadcastable)()
+        out = TensorType(
+            dtype=out_dtype, shape=tuple(1 if s == 1 else None for s in y.type.shape)
+        )()
         return Apply(self, [data, indices, indptr, y], [out])
 
     def c_code(self, node, name, inputs, outputs, sub):
@@ -268,7 +270,7 @@ class StructuredDotCSC(COp):
         r = Apply(
             self,
             [a_val, a_ind, a_ptr, a_nrows, b],
-            [tensor(dtype_out, (False, b.type.broadcastable[1]))],
+            [tensor(dtype_out, shape=(None, 1 if b.type.shape[1] == 1 else None))],
         )
         return r
 
@@ -463,7 +465,7 @@ class StructuredDotCSR(COp):
         r = Apply(
             self,
             [a_val, a_ind, a_ptr, b],
-            [tensor(self.dtype_out, (False, b.type.broadcastable[1]))],
+            [tensor(self.dtype_out, shape=(None, 1 if b.type.shape[1] == 1 else None))],
         )
         return r
 
@@ -703,7 +705,7 @@ class UsmmCscDense(_NoPythonCOp):
         r = Apply(
             self,
             [alpha, x_val, x_ind, x_ptr, x_nrows, y, z],
-            [tensor(dtype_out, (False, y.type.broadcastable[1]))],
+            [tensor(dtype_out, shape=(None, 1 if y.type.shape[1] == 1 else None))],
         )
         return r
 
@@ -1140,7 +1142,7 @@ class MulSDCSC(_NoPythonCOp):
         """
         assert b.type.ndim == 2
         return Apply(
-            self, [a_data, a_indices, a_indptr, b], [tensor(b.dtype, (False,))]
+            self, [a_data, a_indices, a_indptr, b], [tensor(b.dtype, shape=(None,))]
         )
 
     def c_code_cache_version(self):
@@ -1278,7 +1280,7 @@ class MulSDCSR(_NoPythonCOp):
         """
         assert b.type.ndim == 2
         return Apply(
-            self, [a_data, a_indices, a_indptr, b], [tensor(b.dtype, (False,))]
+            self, [a_data, a_indices, a_indptr, b], [tensor(b.dtype, shape=(None,))]
         )
 
     def c_code_cache_version(self):
@@ -1468,7 +1470,7 @@ class MulSVCSR(_NoPythonCOp):
         """
         assert b.type.ndim == 1
         return Apply(
-            self, [a_data, a_indices, a_indptr, b], [tensor(b.dtype, (False,))]
+            self, [a_data, a_indices, a_indptr, b], [tensor(b.dtype, shape=(None,))]
         )
 
     def c_code_cache_version(self):
@@ -1640,7 +1642,7 @@ class StructuredAddSVCSR(_NoPythonCOp):
         assert a_indptr.type.ndim == 1
         assert b.type.ndim == 1
         return Apply(
-            self, [a_data, a_indices, a_indptr, b], [tensor(b.dtype, (False,))]
+            self, [a_data, a_indices, a_indptr, b], [tensor(b.dtype, shape=(None,))]
         )
 
     def c_code_cache_version(self):
@@ -1851,9 +1853,9 @@ class SamplingDotCSR(_NoPythonCOp):
             self,
             [x, y, p_data, p_ind, p_ptr, p_ncols],
             [
-                tensor(dtype=dtype_out, shape=(False,)),
-                tensor(dtype=p_ind.type.dtype, shape=(False,)),
-                tensor(dtype=p_ptr.type.dtype, shape=(False,)),
+                tensor(dtype=dtype_out, shape=(None,)),
+                tensor(dtype=p_ind.type.dtype, shape=(None,)),
+                tensor(dtype=p_ptr.type.dtype, shape=(None,)),
             ],
         )
 

--- a/aesara/sparse/sandbox/sp.py
+++ b/aesara/sparse/sandbox/sp.py
@@ -181,7 +181,7 @@ class ConvolutionIndices(Op):
 
                                     # taking into account multiple
                                     # input features
-                                    col = (
+                                    col = int(
                                         iy * inshp[2] + ix + fmapi * np.prod(inshp[1:])
                                     )
 
@@ -196,13 +196,13 @@ class ConvolutionIndices(Op):
 
                                     # convert to row index of sparse matrix
                                     if ws:
-                                        row = (
+                                        row = int(
                                             (y * outshp[1] + x) * inshp[0] * ksize
                                             + l
                                             + fmapi * ksize
                                         )
                                     else:
-                                        row = y * outshp[1] + x
+                                        row = int(y * outshp[1] + x)
 
                                     # Store something at that location
                                     # in sparse matrix.  The written

--- a/aesara/tensor/__init__.py
+++ b/aesara/tensor/__init__.py
@@ -80,8 +80,9 @@ def get_vector_length(v: TensorLike) -> int:
     if v.type.ndim != 1:
         raise TypeError(f"Argument must be a vector; got {v.type}")
 
-    if v.type.broadcastable[0]:
-        return 1
+    static_shape: Optional[int] = v.type.shape[0]
+    if static_shape is not None:
+        return static_shape
 
     return _get_vector_length(getattr(v.owner, "op", v), v)
 

--- a/aesara/tensor/fft.py
+++ b/aesara/tensor/fft.py
@@ -15,7 +15,7 @@ class RFFTOp(Op):
 
     def output_type(self, inp):
         # add extra dim for real/imag
-        return TensorType(inp.dtype, shape=[False] * (inp.type.ndim + 1))
+        return TensorType(inp.dtype, shape=(None,) * (inp.type.ndim + 1))
 
     def make_node(self, a, s=None):
         a = as_tensor_variable(a)
@@ -76,7 +76,7 @@ class IRFFTOp(Op):
 
     def output_type(self, inp):
         # remove extra dim for real/imag
-        return TensorType(inp.dtype, shape=[False] * (inp.type.ndim - 1))
+        return TensorType(inp.dtype, shape=(None,) * (inp.type.ndim - 1))
 
     def make_node(self, a, s=None):
         a = as_tensor_variable(a)

--- a/aesara/tensor/fourier.py
+++ b/aesara/tensor/fourier.py
@@ -59,27 +59,22 @@ class Fourier(Op):
     def make_node(self, a, n, axis):
         a = as_tensor_variable(a)
         if a.ndim < 1:
-            raise TypeError(
-                f"{self.__class__.__name__}: input must be an array, not a scalar"
-            )
+            raise TypeError("Input must be an array, not a scalar")
         if axis is None:
             axis = a.ndim - 1
             axis = as_tensor_variable(axis)
         else:
             axis = as_tensor_variable(axis)
             if axis.dtype not in integer_dtypes:
-                raise TypeError(
-                    "%s: index of the transformed axis must be"
-                    " of type integer" % self.__class__.__name__
-                )
+                raise TypeError("Index of the transformed axis must be of type integer")
             elif axis.ndim != 0 or (
                 isinstance(axis, TensorConstant)
                 and (axis.data < 0 or axis.data > a.ndim - 1)
             ):
                 raise TypeError(
-                    f"{self.__class__.__name__}: index of the transformed axis must be"
-                    " a scalar not smaller than 0 and smaller than"
-                    " dimension of array"
+                    "Index of the transformed axis must be "
+                    "a scalar not smaller than 0 and smaller than "
+                    "dimension of array"
                 )
         if n is None:
             n = a.shape[axis]
@@ -88,18 +83,21 @@ class Fourier(Op):
             n = as_tensor_variable(n)
             if n.dtype not in integer_dtypes:
                 raise TypeError(
-                    "%s: length of the transformed axis must be"
-                    " of type integer" % self.__class__.__name__
+                    "Length of the transformed axis must be of type integer"
                 )
             elif n.ndim != 0 or (isinstance(n, TensorConstant) and n.data < 1):
                 raise TypeError(
-                    "%s: length of the transformed axis must be a"
-                    " strictly positive scalar" % self.__class__.__name__
+                    "Length of the transformed axis must be a strictly positive scalar"
                 )
         return Apply(
             self,
             [a, n, axis],
-            [TensorType("complex128", a.type.broadcastable)()],
+            [
+                TensorType(
+                    "complex128",
+                    shape=tuple(1 if s == 1 else None for s in a.type.shape),
+                )()
+            ],
         )
 
     def infer_shape(self, fgraph, node, in_shapes):

--- a/aesara/tensor/nnet/basic.py
+++ b/aesara/tensor/nnet/basic.py
@@ -507,8 +507,8 @@ class CrossentropySoftmaxArgmax1HotWithBias(COp):
             raise ValueError("y_idx must be 1-d tensor of [u]ints", y_idx.type)
 
         #       TODO: Is this correct? It used to be y, not y_idx
-        nll = TensorType(x.type.dtype, y_idx.type.broadcastable).make_variable()
-        #        nll = TensorType(x.dtype, y.broadcastable)
+        out_shape = tuple(1 if s == 1 else None for s in y_idx.type.shape)
+        nll = TensorType(x.type.dtype, shape=out_shape).make_variable()
         sm = x.type()
         am = y_idx.type()
         return Apply(self, [x, b, y_idx], [nll, sm, am])
@@ -986,7 +986,7 @@ class CrossentropyCategorical1Hot(Op):
         return Apply(
             self,
             [_coding_dist, _true_one_of_n],
-            [TensorType(dtype=_coding_dist.dtype, shape=[False])()],
+            [TensorType(dtype=_coding_dist.dtype, shape=(None,))()],
         )
 
     def perform(self, node, inp, out):

--- a/aesara/tensor/nnet/conv.py
+++ b/aesara/tensor/nnet/conv.py
@@ -739,10 +739,16 @@ class ConvOp(OpenMPOp):
                 "The image and the kernel must have the same type."
                 "inputs({_inputs.dtype}), kerns({_kerns.dtype})"
             )
-        bcastable23 = [self.outshp[0] == 1, self.outshp[1] == 1]
+        out_shape = (
+            _inputs.type.shape[0],
+            _kerns.type.shape[0],
+            self.outshp[0],
+            self.outshp[1],
+        )
+        out_shape = tuple(1 if s == 1 else None for s in out_shape)
         output = tensor(
             dtype=_inputs.type.dtype,
-            shape=[_inputs.broadcastable[0], _kerns.broadcastable[0]] + bcastable23,
+            shape=out_shape,
         )
 
         return Apply(self, [_inputs, _kerns], [output])

--- a/aesara/tensor/nnet/corr3d.py
+++ b/aesara/tensor/nnet/corr3d.py
@@ -631,15 +631,15 @@ class Corr3dMM(BaseCorr3dMM):
         if kern.type.ndim != 5:
             raise TypeError("kern must be 5D tensor")
 
-        broadcastable = [
-            img.type.broadcastable[0],
-            kern.type.broadcastable[0],
-            False,
-            False,
-            False,
+        out_shape = [
+            1 if img.type.shape[0] == 1 else None,
+            1 if kern.type.shape[0] == 1 else None,
+            None,
+            None,
+            None,
         ]
         dtype = img.type.dtype
-        return Apply(self, [img, kern], [TensorType(dtype, broadcastable)()])
+        return Apply(self, [img, kern], [TensorType(dtype, shape=out_shape)()])
 
     def infer_shape(self, fgraph, node, input_shape):
         imshp = input_shape[0]
@@ -708,18 +708,18 @@ class Corr3dMMGradWeights(BaseCorr3dMM):
                 as_tensor_variable(shape[2]).astype("int64"),
             ]
 
-        broadcastable = [
-            topgrad.type.broadcastable[1],
-            img.type.broadcastable[1],
-            False,
-            False,
-            False,
+        out_shape = [
+            1 if topgrad.type.shape[1] == 1 else None,
+            1 if img.type.shape[1] == 1 else None,
+            None,
+            None,
+            None,
         ]
         dtype = img.type.dtype
         return Apply(
             self,
             [img, topgrad] + height_width_depth,
-            [TensorType(dtype, broadcastable)()],
+            [TensorType(dtype, shape=out_shape)()],
         )
 
     def infer_shape(self, fgraph, node, input_shape):
@@ -829,11 +829,17 @@ class Corr3dMMGradInputs(BaseCorr3dMM):
             ]
 
         if self.num_groups > 1:
-            broadcastable = [topgrad.type.broadcastable[0], False, False, False, False]
+            out_shape = [
+                1 if topgrad.type.shape[0] == 1 else None,
+                None,
+                None,
+                None,
+                None,
+            ]
         else:
-            broadcastable = [
-                topgrad.type.broadcastable[0],
-                kern.type.broadcastable[1],
+            out_shape = [
+                1 if topgrad.type.shape[0] == 1 else None,
+                1 if kern.type.shape[1] == 1 else None,
                 False,
                 False,
                 False,
@@ -842,7 +848,7 @@ class Corr3dMMGradInputs(BaseCorr3dMM):
         return Apply(
             self,
             [kern, topgrad] + height_width_depth,
-            [TensorType(dtype, broadcastable)()],
+            [TensorType(dtype, shape=out_shape)()],
         )
 
     def infer_shape(self, fgraph, node, input_shape):

--- a/aesara/tensor/rewriting/basic.py
+++ b/aesara/tensor/rewriting/basic.py
@@ -1155,7 +1155,7 @@ def constant_folding(fgraph, node):
         if isinstance(output.type, DenseTensorType):
             output_type = TensorType(
                 output.type.dtype,
-                tuple(s == 1 for s in data.shape),
+                shape=data.shape,
                 name=output.type.name,
             )
         else:

--- a/aesara/tensor/rewriting/shape.py
+++ b/aesara/tensor/rewriting/shape.py
@@ -1020,8 +1020,8 @@ def local_Shape_of_SpecifyShape(fgraph, node):
 @register_useless
 @register_canonicalize
 @node_rewriter([Shape_i])
-def local_Shape_i_of_broadcastable(fgraph, node):
-    """Replace ``shape_i(x, i)`` with ``1`` when ``x.broadcastable[i]`` is ``True``."""
+def local_Shape_i_ground(fgraph, node):
+    """Replace ``shape_i(x, i)`` with ``s`` when ``x.type.shape[i] == s``."""
 
     if not isinstance(node.op, Shape_i):
         return False
@@ -1031,8 +1031,9 @@ def local_Shape_i_of_broadcastable(fgraph, node):
     if not isinstance(shape_arg.type, TensorType):
         return False
 
-    if shape_arg.broadcastable[node.op.i]:
-        return [as_tensor_variable(1, dtype=np.int64)]
+    s_val = shape_arg.type.shape[node.op.i]
+    if s_val is not None:
+        return [as_tensor_variable(s_val, dtype=np.int64)]
 
 
 @register_specialize

--- a/aesara/tensor/sharedvar.py
+++ b/aesara/tensor/sharedvar.py
@@ -68,7 +68,7 @@ def tensor_constructor(
     # the value might be resized in any dimension in the future.
     #
     if shape is None:
-        shape = (False,) * len(value.shape)
+        shape = (None,) * len(value.shape)
     type = TensorType(value.dtype, shape=shape)
     return TensorSharedVariable(
         type=type,

--- a/aesara/tensor/signal/pool.py
+++ b/aesara/tensor/signal/pool.py
@@ -542,8 +542,10 @@ class Pool(OpenMPOp):
         if pad.dtype not in int_dtypes:
             raise TypeError("Padding parameters must be ints.")
         # If the input shape are broadcastable we can have 0 in the output shape
-        broad = x.broadcastable[:-nd] + (False,) * nd
-        out = TensorType(x.dtype, broad)
+        out_shape = tuple(
+            1 if s == 1 else None for s in x.type.shape[:-nd] + (None,) * nd
+        )
+        out = TensorType(x.dtype, shape=out_shape)
         return Apply(self, [x, ws, stride, pad], [out()])
 
     def perform(self, node, inp, out, params):
@@ -2208,8 +2210,10 @@ class MaxPoolRop(OpenMPOp):
         if not pad.dtype.startswith("int"):
             raise TypeError("Padding parameters must be ints.")
         # If the input shape are broadcastable we can have 0 in the output shape
-        broad = x.broadcastable[:-nd] + (False,) * nd
-        out = TensorType(eval_point.dtype, broad)
+        out_shape = tuple(
+            1 if s == 1 else None for s in x.type.shape[:-nd] + (None,) * nd
+        )
+        out = TensorType(eval_point.dtype, shape=out_shape)
         return Apply(self, [x, eval_point, ws, stride, pad], [out()])
 
     def perform(self, node, inp, out, params):

--- a/aesara/tensor/slinalg.py
+++ b/aesara/tensor/slinalg.py
@@ -215,7 +215,7 @@ class CholeskySolve(Op):
         o_dtype = scipy.linalg.solve(
             np.eye(1).astype(C.dtype), np.eye(1).astype(b.dtype)
         ).dtype
-        x = tensor(shape=b.broadcastable, dtype=o_dtype)
+        x = tensor(dtype=o_dtype, shape=b.type.shape)
         return Apply(self, [C, b], [x])
 
     def perform(self, node, inputs, output_storage):
@@ -292,7 +292,7 @@ class SolveBase(Op):
         o_dtype = scipy.linalg.solve(
             np.eye(1).astype(A.dtype), np.eye(1).astype(b.dtype)
         ).dtype
-        x = tensor(shape=b.broadcastable, dtype=o_dtype)
+        x = tensor(dtype=o_dtype, shape=b.type.shape)
         return Apply(self, [A, b], [x])
 
     def infer_shape(self, fgraph, node, shapes):

--- a/aesara/tensor/sort.py
+++ b/aesara/tensor/sort.py
@@ -414,9 +414,13 @@ class TopKOp(Op):
         _check_tensor_is_scalar(kth)
         outs = []
         if self.return_values:
-            outs.append(inp.type())
+            outs.append(
+                TensorType(dtype=inp.type.dtype, shape=(None,) * inp.type.ndim)()
+            )
         if self.return_indices:
-            outs.append(TensorType(dtype=self.idx_dtype, shape=inp.type.shape)())
+            outs.append(
+                TensorType(dtype=self.idx_dtype, shape=(None,) * inp.type.ndim)()
+            )
         return Apply(self, [inp, kth], outs)
 
     def perform(self, node, inputs, output_storage):

--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -386,7 +386,18 @@ class TensorType(CType[np.ndarray], HasDataType, HasShape):
         if self.name:
             return self.name
         else:
-            return f"TensorType({self.dtype}, {self.shape})"
+
+            def shape_str(s):
+                if s is None:
+                    return "?"
+                else:
+                    return str(s)
+
+            formatted_shape = ", ".join([shape_str(s) for s in self.shape])
+            if len(self.shape) == 1:
+                formatted_shape += ","
+
+            return f"TensorType({self.dtype}, ({formatted_shape}))"
 
     def __repr__(self):
         return str(self)

--- a/aesara/tensor/type.py
+++ b/aesara/tensor/type.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import Iterable, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Iterable, Optional, Tuple, Union
 
 import numpy as np
 
@@ -13,6 +13,12 @@ from aesara.graph.utils import MetaType
 from aesara.link.c.type import CType
 from aesara.misc.safe_asarray import _asarray
 from aesara.utils import apply_across_args
+
+
+if TYPE_CHECKING:
+    from numpy.typing import DTypeLike
+
+    from aesara.tensor.var import TensorVariable
 
 
 _logger = logging.getLogger("aesara.tensor.type")
@@ -805,14 +811,14 @@ int_scalar_types = int_types
 float_scalar_types = float_types
 complex_scalar_types = complex_types
 
-cvector = TensorType("complex64", (False,))
-zvector = TensorType("complex128", (False,))
-fvector = TensorType("float32", (False,))
-dvector = TensorType("float64", (False,))
-bvector = TensorType("int8", (False,))
-wvector = TensorType("int16", (False,))
-ivector = TensorType("int32", (False,))
-lvector = TensorType("int64", (False,))
+cvector = TensorType("complex64", shape=(None,))
+zvector = TensorType("complex128", shape=(None,))
+fvector = TensorType("float32", shape=(None,))
+dvector = TensorType("float64", shape=(None,))
+bvector = TensorType("int8", shape=(None,))
+wvector = TensorType("int16", shape=(None,))
+ivector = TensorType("int32", shape=(None,))
+lvector = TensorType("int64", shape=(None,))
 
 
 def vector(name=None, dtype=None):
@@ -828,7 +834,7 @@ def vector(name=None, dtype=None):
     """
     if dtype is None:
         dtype = config.floatX
-    type = TensorType(dtype, (False,))
+    type = TensorType(dtype, shape=(None,))
     return type(name)
 
 
@@ -840,14 +846,14 @@ int_vector_types = bvector, wvector, ivector, lvector
 float_vector_types = fvector, dvector
 complex_vector_types = cvector, zvector
 
-cmatrix = TensorType("complex64", (False, False))
-zmatrix = TensorType("complex128", (False, False))
-fmatrix = TensorType("float32", (False, False))
-dmatrix = TensorType("float64", (False, False))
-bmatrix = TensorType("int8", (False, False))
-wmatrix = TensorType("int16", (False, False))
-imatrix = TensorType("int32", (False, False))
-lmatrix = TensorType("int64", (False, False))
+cmatrix = TensorType("complex64", shape=(None, None))
+zmatrix = TensorType("complex128", shape=(None, None))
+fmatrix = TensorType("float32", shape=(None, None))
+dmatrix = TensorType("float64", shape=(None, None))
+bmatrix = TensorType("int8", shape=(None, None))
+wmatrix = TensorType("int16", shape=(None, None))
+imatrix = TensorType("int32", shape=(None, None))
+lmatrix = TensorType("int64", shape=(None, None))
 
 
 def matrix(name=None, dtype=None):
@@ -863,7 +869,7 @@ def matrix(name=None, dtype=None):
     """
     if dtype is None:
         dtype = config.floatX
-    type = TensorType(dtype, (False, False))
+    type = TensorType(dtype, shape=(None, None))
     return type(name)
 
 
@@ -875,18 +881,18 @@ int_matrix_types = bmatrix, wmatrix, imatrix, lmatrix
 float_matrix_types = fmatrix, dmatrix
 complex_matrix_types = cmatrix, zmatrix
 
-crow = TensorType("complex64", (True, False))
-zrow = TensorType("complex128", (True, False))
-frow = TensorType("float32", (True, False))
-drow = TensorType("float64", (True, False))
-brow = TensorType("int8", (True, False))
-wrow = TensorType("int16", (True, False))
-irow = TensorType("int32", (True, False))
-lrow = TensorType("int64", (True, False))
+crow = TensorType("complex64", shape=(1, None))
+zrow = TensorType("complex128", shape=(1, None))
+frow = TensorType("float32", shape=(1, None))
+drow = TensorType("float64", shape=(1, None))
+brow = TensorType("int8", shape=(1, None))
+wrow = TensorType("int16", shape=(1, None))
+irow = TensorType("int32", shape=(1, None))
+lrow = TensorType("int64", shape=(1, None))
 
 
 def row(name=None, dtype=None):
-    """Return a symbolic row variable (ndim=2, shape=[True,False]).
+    """Return a symbolic row variable (i.e. shape ``(1, None)``).
 
     Parameters
     ----------
@@ -898,65 +904,69 @@ def row(name=None, dtype=None):
     """
     if dtype is None:
         dtype = config.floatX
-    type = TensorType(dtype, (True, False))
+    type = TensorType(dtype, shape=(1, None))
     return type(name)
 
 
 rows, frows, drows, irows, lrows = apply_across_args(row, frow, drow, irow, lrow)
 
-ccol = TensorType("complex64", (False, True))
-zcol = TensorType("complex128", (False, True))
-fcol = TensorType("float32", (False, True))
-dcol = TensorType("float64", (False, True))
-bcol = TensorType("int8", (False, True))
-wcol = TensorType("int16", (False, True))
-icol = TensorType("int32", (False, True))
-lcol = TensorType("int64", (False, True))
+ccol = TensorType("complex64", shape=(None, 1))
+zcol = TensorType("complex128", shape=(None, 1))
+fcol = TensorType("float32", shape=(None, 1))
+dcol = TensorType("float64", shape=(None, 1))
+bcol = TensorType("int8", shape=(None, 1))
+wcol = TensorType("int16", shape=(None, 1))
+icol = TensorType("int32", shape=(None, 1))
+lcol = TensorType("int64", shape=(None, 1))
 
 
-def col(name=None, dtype=None):
-    """Return a symbolic column variable (ndim=2, shape=[False,True]).
+def col(
+    name: Optional[str] = None, dtype: Optional["DTypeLike"] = None
+) -> "TensorVariable":
+    """Return a symbolic column variable (i.e. shape ``(None, 1)``).
 
     Parameters
     ----------
-    dtype : numeric
-        None means to use aesara.config.floatX.
     name
         A name to attach to this variable.
+    dtype
+        ``None`` means to use `aesara.config.floatX`.
 
     """
     if dtype is None:
         dtype = config.floatX
-    type = TensorType(dtype, (False, True))
+    type = TensorType(dtype, shape=(None, 1))
     return type(name)
 
 
 cols, fcols, dcols, icols, lcols = apply_across_args(col, fcol, dcol, icol, lcol)
 
-ctensor3 = TensorType("complex64", ((False,) * 3))
-ztensor3 = TensorType("complex128", ((False,) * 3))
-ftensor3 = TensorType("float32", ((False,) * 3))
-dtensor3 = TensorType("float64", ((False,) * 3))
-btensor3 = TensorType("int8", ((False,) * 3))
-wtensor3 = TensorType("int16", ((False,) * 3))
-itensor3 = TensorType("int32", ((False,) * 3))
-ltensor3 = TensorType("int64", ((False,) * 3))
+ctensor3 = TensorType("complex64", shape=((None,) * 3))
+ztensor3 = TensorType("complex128", shape=((None,) * 3))
+ftensor3 = TensorType("float32", shape=((None,) * 3))
+dtensor3 = TensorType("float64", shape=((None,) * 3))
+btensor3 = TensorType("int8", shape=((None,) * 3))
+wtensor3 = TensorType("int16", shape=((None,) * 3))
+itensor3 = TensorType("int32", shape=((None,) * 3))
+ltensor3 = TensorType("int64", shape=((None,) * 3))
 
 
-def tensor3(name=None, dtype=None):
-    """Return a symbolic 3-D variable.
+def tensor3(
+    name: Optional[str] = None, dtype: Optional["DTypeLike"] = None
+) -> "TensorVariable":
+    """Return a symbolic 3D variable.
 
     Parameters
     ----------
-    dtype: numeric type
-        None means to use aesara.config.floatX.
     name
         A name to attach to this variable.
+    dtype
+        ``None`` means to use `aesara.config.floatX`.
 
     """
     if dtype is None:
         dtype = config.floatX
-    type = TensorType(dtype, (False, False, False))
+    type = TensorType(dtype, shape=(None, None, None))
     return type(name)
 
 
@@ -964,30 +974,32 @@ tensor3s, ftensor3s, dtensor3s, itensor3s, ltensor3s = apply_across_args(
     tensor3, ftensor3, dtensor3, itensor3, ltensor3
 )
 
-ctensor4 = TensorType("complex64", ((False,) * 4))
-ztensor4 = TensorType("complex128", ((False,) * 4))
-ftensor4 = TensorType("float32", ((False,) * 4))
-dtensor4 = TensorType("float64", ((False,) * 4))
-btensor4 = TensorType("int8", ((False,) * 4))
-wtensor4 = TensorType("int16", ((False,) * 4))
-itensor4 = TensorType("int32", ((False,) * 4))
-ltensor4 = TensorType("int64", ((False,) * 4))
+ctensor4 = TensorType("complex64", shape=((None,) * 4))
+ztensor4 = TensorType("complex128", shape=((None,) * 4))
+ftensor4 = TensorType("float32", shape=((None,) * 4))
+dtensor4 = TensorType("float64", shape=((None,) * 4))
+btensor4 = TensorType("int8", shape=((None,) * 4))
+wtensor4 = TensorType("int16", shape=((None,) * 4))
+itensor4 = TensorType("int32", shape=((None,) * 4))
+ltensor4 = TensorType("int64", shape=((None,) * 4))
 
 
-def tensor4(name=None, dtype=None):
-    """Return a symbolic 4-D variable.
+def tensor4(
+    name: Optional[str] = None, dtype: Optional["DTypeLike"] = None
+) -> "TensorVariable":
+    """Return a symbolic 4D variable.
 
     Parameters
     ----------
-    dtype: numeric type
-        None means to use aesara.config.floatX.
     name
         A name to attach to this variable.
+    dtype
+        ``None`` means to use `aesara.config.floatX`.
 
     """
     if dtype is None:
         dtype = config.floatX
-    type = TensorType(dtype, (False, False, False, False))
+    type = TensorType(dtype, shape=(None, None, None, None))
     return type(name)
 
 
@@ -995,30 +1007,32 @@ tensor4s, ftensor4s, dtensor4s, itensor4s, ltensor4s = apply_across_args(
     tensor4, ftensor4, dtensor4, itensor4, ltensor4
 )
 
-ctensor5 = TensorType("complex64", ((False,) * 5))
-ztensor5 = TensorType("complex128", ((False,) * 5))
-ftensor5 = TensorType("float32", ((False,) * 5))
-dtensor5 = TensorType("float64", ((False,) * 5))
-btensor5 = TensorType("int8", ((False,) * 5))
-wtensor5 = TensorType("int16", ((False,) * 5))
-itensor5 = TensorType("int32", ((False,) * 5))
-ltensor5 = TensorType("int64", ((False,) * 5))
+ctensor5 = TensorType("complex64", shape=((None,) * 5))
+ztensor5 = TensorType("complex128", shape=((None,) * 5))
+ftensor5 = TensorType("float32", shape=((None,) * 5))
+dtensor5 = TensorType("float64", shape=((None,) * 5))
+btensor5 = TensorType("int8", shape=((None,) * 5))
+wtensor5 = TensorType("int16", shape=((None,) * 5))
+itensor5 = TensorType("int32", shape=((None,) * 5))
+ltensor5 = TensorType("int64", shape=((None,) * 5))
 
 
-def tensor5(name=None, dtype=None):
-    """Return a symbolic 5-D variable.
+def tensor5(
+    name: Optional[str] = None, dtype: Optional["DTypeLike"] = None
+) -> "TensorVariable":
+    """Return a symbolic 5D variable.
 
     Parameters
     ----------
-    dtype: numeric type
-        None means to use aesara.config.floatX.
     name
         A name to attach to this variable.
+    dtype
+        ``None`` means to use `aesara.config.floatX`.
 
     """
     if dtype is None:
         dtype = config.floatX
-    type = TensorType(dtype, (False, False, False, False, False))
+    type = TensorType(dtype, shape=(None, None, None, None, None))
     return type(name)
 
 
@@ -1026,30 +1040,32 @@ tensor5s, ftensor5s, dtensor5s, itensor5s, ltensor5s = apply_across_args(
     tensor5, ftensor5, dtensor5, itensor5, ltensor5
 )
 
-ctensor6 = TensorType("complex64", ((False,) * 6))
-ztensor6 = TensorType("complex128", ((False,) * 6))
-ftensor6 = TensorType("float32", ((False,) * 6))
-dtensor6 = TensorType("float64", ((False,) * 6))
-btensor6 = TensorType("int8", ((False,) * 6))
-wtensor6 = TensorType("int16", ((False,) * 6))
-itensor6 = TensorType("int32", ((False,) * 6))
-ltensor6 = TensorType("int64", ((False,) * 6))
+ctensor6 = TensorType("complex64", shape=((None,) * 6))
+ztensor6 = TensorType("complex128", shape=((None,) * 6))
+ftensor6 = TensorType("float32", shape=((None,) * 6))
+dtensor6 = TensorType("float64", shape=((None,) * 6))
+btensor6 = TensorType("int8", shape=((None,) * 6))
+wtensor6 = TensorType("int16", shape=((None,) * 6))
+itensor6 = TensorType("int32", shape=((None,) * 6))
+ltensor6 = TensorType("int64", shape=((None,) * 6))
 
 
-def tensor6(name=None, dtype=None):
-    """Return a symbolic 6-D variable.
+def tensor6(
+    name: Optional[str] = None, dtype: Optional["DTypeLike"] = None
+) -> "TensorVariable":
+    """Return a symbolic 6D variable.
 
     Parameters
     ----------
-    dtype: numeric type
-        None means to use aesara.config.floatX.
     name
         A name to attach to this variable.
+    dtype
+        ``None`` means to use `aesara.config.floatX`.
 
     """
     if dtype is None:
         dtype = config.floatX
-    type = TensorType(dtype, (False,) * 6)
+    type = TensorType(dtype, shape=(None,) * 6)
     return type(name)
 
 
@@ -1057,30 +1073,32 @@ tensor6s, ftensor6s, dtensor6s, itensor6s, ltensor6s = apply_across_args(
     tensor6, ftensor6, dtensor6, itensor6, ltensor6
 )
 
-ctensor7 = TensorType("complex64", ((False,) * 7))
-ztensor7 = TensorType("complex128", ((False,) * 7))
-ftensor7 = TensorType("float32", ((False,) * 7))
-dtensor7 = TensorType("float64", ((False,) * 7))
-btensor7 = TensorType("int8", ((False,) * 7))
-wtensor7 = TensorType("int16", ((False,) * 7))
-itensor7 = TensorType("int32", ((False,) * 7))
-ltensor7 = TensorType("int64", ((False,) * 7))
+ctensor7 = TensorType("complex64", shape=((None,) * 7))
+ztensor7 = TensorType("complex128", shape=((None,) * 7))
+ftensor7 = TensorType("float32", shape=((None,) * 7))
+dtensor7 = TensorType("float64", shape=((None,) * 7))
+btensor7 = TensorType("int8", shape=((None,) * 7))
+wtensor7 = TensorType("int16", shape=((None,) * 7))
+itensor7 = TensorType("int32", shape=((None,) * 7))
+ltensor7 = TensorType("int64", shape=((None,) * 7))
 
 
-def tensor7(name=None, dtype=None):
+def tensor7(
+    name: Optional[str] = None, dtype: Optional["DTypeLike"] = None
+) -> "TensorVariable":
     """Return a symbolic 7-D variable.
 
     Parameters
     ----------
-    dtype: numeric type
-        None means to use aesara.config.floatX.
     name
         A name to attach to this variable.
+    dtype
+        ``None`` means to use `aesara.config.floatX`.
 
     """
     if dtype is None:
         dtype = config.floatX
-    type = TensorType(dtype, (False,) * 7)
+    type = TensorType(dtype, shape=(None,) * 7)
     return type(name)
 
 

--- a/doc/extending/creating_a_c_op.rst
+++ b/doc/extending/creating_a_c_op.rst
@@ -618,7 +618,7 @@ C code.
             # Create an output variable of the same type as x
             output_var = aesara.tensor.type.TensorType(
                             dtype=aesara.scalar.upcast(x.dtype, y.dtype),
-                            shape=[False])()
+                            shape=(None,))()
 
             return Apply(self, [x, y], [output_var])
 
@@ -767,7 +767,7 @@ The new :class:`Op` is defined inside a Python file with the following code :
             # Create an output variable of the same type as x
             output_var = aesara.tensor.type.TensorType(
                             dtype=aesara.scalar.upcast(x.dtype, y.dtype),
-                            shape=[False])()
+                            shape=(None,))()
 
             return Apply(self, [x, y], [output_var])
 

--- a/doc/extending/creating_a_numba_jax_op.rst
+++ b/doc/extending/creating_a_numba_jax_op.rst
@@ -30,7 +30,7 @@ For example, the :class:`Eye`\ :class:`Op` current has an :meth:`Op.make_node` a
         return Apply(
             self,
             [n, m, k],
-            [TensorType(dtype=self.dtype, shape=(False, False))()],
+            [TensorType(dtype=self.dtype, shape=(None, None))()],
         )
 
 

--- a/doc/extending/extending_aesara_solution_1.py
+++ b/doc/extending/extending_aesara_solution_1.py
@@ -16,9 +16,9 @@ class ProdOp(Op):
     def make_node(self, x, y):
         x = at.as_tensor_variable(x)
         y = at.as_tensor_variable(y)
-        outdim = x.ndim
+        outdim = x.type.ndim
         output = TensorType(
-            dtype=aesara.scalar.upcast(x.dtype, y.dtype), shape=[False] * outdim
+            dtype=aesara.scalar.upcast(x.dtype, y.dtype), shape=(None,) * outdim
         )()
         return Apply(self, inputs=[x, y], outputs=[output])
 
@@ -41,12 +41,12 @@ class SumDiffOp(Op):
     def make_node(self, x, y):
         x = at.as_tensor_variable(x)
         y = at.as_tensor_variable(y)
-        outdim = x.ndim
+        outdim = x.type.ndim
         output1 = TensorType(
-            dtype=aesara.scalar.upcast(x.dtype, y.dtype), shape=[False] * outdim
+            dtype=aesara.scalar.upcast(x.dtype, y.dtype), shape=(None,) * outdim
         )()
         output2 = TensorType(
-            dtype=aesara.scalar.upcast(x.dtype, y.dtype), shape=[False] * outdim
+            dtype=aesara.scalar.upcast(x.dtype, y.dtype), shape=(None,) * outdim
         )()
         return Apply(self, inputs=[x, y], outputs=[output1, output2])
 

--- a/doc/extending/graphstructures.rst
+++ b/doc/extending/graphstructures.rst
@@ -217,7 +217,7 @@ For example, :ref:`aesara.tensor.irow <libdoc_tensor_creation>` is an instance o
 
 >>> from aesara.tensor import irow
 >>> irow()
-<TensorType(int32, (1, None))>
+<TensorType(int32, (1, ?))>
 
 As the string print-out shows, `irow` specifies the following information about
 the :class:`Variable`\s it constructs:

--- a/doc/extending/type.rst
+++ b/doc/extending/type.rst
@@ -90,7 +90,7 @@ For example, let's say we have two :class:`Variable`\s with the following
 >>> from aesara.tensor.type import TensorType
 >>> v1 = TensorType("float64", (2, None))()
 >>> v1.type
-TensorType(float64, (2, None))
+TensorType(float64, (2, ?))
 >>> v2 = TensorType("float64", (2, 1))()
 >>> v2.type
 TensorType(float64, (2, 1))
@@ -145,7 +145,7 @@ SpecifyShape.0
 >>> import aesara
 >>> aesara.dprint(v3, print_type=True)
 SpecifyShape [id A] <TensorType(float64, (2, 1))>
- |<TensorType(float64, (2, None))> [id B] <TensorType(float64, (2, None))>
+ |<TensorType(float64, (2, ?))> [id B] <TensorType(float64, (2, ?))>
  |TensorConstant{2} [id C] <TensorType(int8, ())>
  |TensorConstant{1} [id D] <TensorType(int8, ())>
 

--- a/doc/library/scan.rst
+++ b/doc/library/scan.rst
@@ -406,7 +406,7 @@ Using the original Gibbs sampling example, with ``strict=True`` added to the
     Traceback (most recent call last):
     ...
     MissingInputError: An input of the graph, used to compute
-    DimShuffle{1,0}(<TensorType(float64, (None, None))>), was not provided and
+    DimShuffle{1,0}(<TensorType(float64, (?, ?))>), was not provided and
     not given a value.Use the Aesara flag exception_verbosity='high',for
     more information on this error.
 

--- a/doc/library/tensor/basic.rst
+++ b/doc/library/tensor/basic.rst
@@ -409,7 +409,7 @@ them perfectly, but a `dscalar` otherwise.
         broadcast over the middle dimension of a 3-dimensional tensor when
         adding them together, we would define it like this:
 
-        >>> middle_broadcaster = TensorType('complex64', [False, True, False])
+        >>> middle_broadcaster = TensorType('complex64', shape=(None, 1, None))
 
     .. attribute:: ndim
 

--- a/doc/tutorial/debug_faq.rst
+++ b/doc/tutorial/debug_faq.rst
@@ -44,8 +44,8 @@ Running the code above we see:
    Traceback (most recent call last):
      ...
    ValueError: Input dimension mismatch. (input[0].shape[0] = 3, input[1].shape[0] = 2)
-   Apply node that caused the error: Elemwise{add,no_inplace}(<TensorType(float64, (None,))>, <TensorType(float64, (None,))>, <TensorType(float64, (None,))>)
-   Inputs types: [TensorType(float64, (None,)), TensorType(float64, (None,)), TensorType(float64, (None,))]
+   Apply node that caused the error: Elemwise{add,no_inplace}(<TensorType(float64, (?,))>, <TensorType(float64, (?,))>, <TensorType(float64, (?,))>)
+   Inputs types: [TensorType(float64, (?,)), TensorType(float64, (?,)), TensorType(float64, (?,))]
    Inputs shapes: [(3,), (2,), (2,)]
    Inputs strides: [(8,), (8,), (8,)]
    Inputs scalar values: ['not scalar', 'not scalar', 'not scalar']
@@ -73,11 +73,11 @@ message becomes :
         z = z + y
 
     Debugprint of the apply node:
-    Elemwise{add,no_inplace} [id A] <TensorType(float64, (None,))> ''
-     |Elemwise{add,no_inplace} [id B] <TensorType(float64, (None,))> ''
-     | |<TensorType(float64, (None,))> [id C] <TensorType(float64, (None,))>
-     | |<TensorType(float64, (None,))> [id C] <TensorType(float64, (None,))>
-     |<TensorType(float64, (None,))> [id D] <TensorType(float64, (None,))>
+    Elemwise{add,no_inplace} [id A] <TensorType(float64, (?,))> ''
+     |Elemwise{add,no_inplace} [id B] <TensorType(float64, (?,))> ''
+     | |<TensorType(float64, (?,))> [id C] <TensorType(float64, (?,))>
+     | |<TensorType(float64, (?,))> [id C] <TensorType(float64, (?,))>
+     |<TensorType(float64, (?,))> [id D] <TensorType(float64, (?,))>
 
 We can here see that the error can be traced back to the line ``z = z + y``.
 For this example, using ``optimizer=fast_compile`` worked. If it did not,
@@ -145,18 +145,18 @@ Running the above code generates the following error message:
         outputs = self.vm()
     ValueError: Shape mismatch: x has 10 cols (and 5 rows) but y has 20 rows (and 10 cols)
     Apply node that caused the error: Dot22(x, DimShuffle{1,0}.0)
-    Inputs types: [TensorType(float64, (None, None)), TensorType(float64, (None, None))]
+    Inputs types: [TensorType(float64, (?, ?)), TensorType(float64, (?, ?))]
     Inputs shapes: [(5, 10), (20, 10)]
     Inputs strides: [(80, 8), (8, 160)]
     Inputs scalar values: ['not scalar', 'not scalar']
 
     Debugprint of the apply node:
-    Dot22 [id A] <TensorType(float64, (None, None))> ''
-     |x [id B] <TensorType(float64, (None, None))>
-     |DimShuffle{1,0} [id C] <TensorType(float64, (None, None))> ''
-       |Flatten{2} [id D] <TensorType(float64, (None, None))> ''
-         |DimShuffle{2,0,1} [id E] <TensorType(float64, (None, None, None))> ''
-           |W1 [id F] <TensorType(float64, (None, None, None))>
+    Dot22 [id A] <TensorType(float64, (?, ?))> ''
+     |x [id B] <TensorType(float64, (?, ?))>
+     |DimShuffle{1,0} [id C] <TensorType(float64, (?, ?))> ''
+       |Flatten{2} [id D] <TensorType(float64, (?, ?))> ''
+         |DimShuffle{2,0,1} [id E] <TensorType(float64, (?, ?, ?))> ''
+           |W1 [id F] <TensorType(float64, (?, ?, ?))>
 
     HINT: Re-running with most Aesara optimization disabled could give you a back-traces when this node was created. This can be done with by setting the Aesara flags 'optimizer=fast_compile'. If that does not work, Aesara optimization can be disabled with 'optimizer=None'.
 
@@ -483,7 +483,7 @@ Consider this example script (``ex.py``):
    ValueError: Input dimension mismatch. (input[0].shape[0] = 3, input[1].shape[0] = 5)
    Apply node that caused the error: Elemwise{mul,no_inplace}(a, b)
    Toposort index: 0
-   Inputs types: [TensorType(float64, (None, None)), TensorType(float64, (None, None))]
+   Inputs types: [TensorType(float64, (?, ?)), TensorType(float64, (?, ?))]
    Inputs shapes: [(3, 4), (5, 5)]
    Inputs strides: [(32, 8), (40, 8)]
    Inputs values: ['not shown', 'not shown']

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -580,10 +580,10 @@ Inner graphs:
 
 OpFromGraph{inline=False} [id A]
  >Elemwise{add,no_inplace} [id E]
- > |*0-<TensorType(float64, (None, None))> [id F]
+ > |*0-<TensorType(float64, (?, ?))> [id F]
  > |Elemwise{mul,no_inplace} [id G]
- >   |*1-<TensorType(float64, (None, None))> [id H]
- >   |*2-<TensorType(float64, (None, None))> [id I]
+ >   |*1-<TensorType(float64, (?, ?))> [id H]
+ >   |*2-<TensorType(float64, (?, ?))> [id I]
 """
 
     for truth, out in zip(exp_res.split("\n"), lines):

--- a/tests/compile/test_debugmode.py
+++ b/tests/compile/test_debugmode.py
@@ -716,8 +716,8 @@ class VecAsRowAndCol(Op):
             v = at.as_tensor_variable(v)
         assert v.type.ndim == 1
         type_class = type(v.type)
-        out_r_type = type_class(dtype=v.dtype, shape=(True, False))
-        out_c_type = type_class(dtype=v.dtype, shape=(False, True))
+        out_r_type = type_class(dtype=v.dtype, shape=(1, None))
+        out_c_type = type_class(dtype=v.dtype, shape=(None, 1))
         return Apply(self, [v], [out_r_type(), out_c_type()])
 
     def perform(self, node, inp, out):

--- a/tests/compile/test_shared.py
+++ b/tests/compile/test_shared.py
@@ -36,11 +36,11 @@ class TestSharedVariable:
 
         # test tensor constructor
         b = shared(np.zeros((5, 5), dtype="int32"))
-        assert b.type == TensorType("int32", shape=[False, False])
+        assert b.type == TensorType("int32", shape=(None, None))
         b = shared(np.random.random((4, 5)))
-        assert b.type == TensorType("float64", shape=[False, False])
+        assert b.type == TensorType("float64", shape=(None, None))
         b = shared(np.random.random((5, 1, 2)))
-        assert b.type == TensorType("float64", shape=[False, False, False])
+        assert b.type == TensorType("float64", shape=(None, None, None))
 
         assert shared([]).type == generic
 
@@ -67,7 +67,7 @@ class TestSharedVariable:
         # so creation should work
         SharedVariable(
             name="u",
-            type=TensorType(shape=[False], dtype="float64"),
+            type=TensorType(dtype="float64", shape=(None,)),
             value=np.asarray([1.0, 2.0]),
             strict=False,
         )
@@ -76,7 +76,7 @@ class TestSharedVariable:
         # so creation should work
         SharedVariable(
             name="u",
-            type=TensorType(shape=[False], dtype="float64"),
+            type=TensorType(dtype="float64", shape=(None,)),
             value=[1.0, 2.0],
             strict=False,
         )
@@ -85,7 +85,7 @@ class TestSharedVariable:
         # so creation should work
         SharedVariable(
             name="u",
-            type=TensorType(shape=[False], dtype="float64"),
+            type=TensorType(dtype="float64", shape=(None,)),
             value=[1, 2],  # different dtype and not a numpy array
             strict=False,
         )
@@ -95,7 +95,7 @@ class TestSharedVariable:
         try:
             SharedVariable(
                 name="u",
-                type=TensorType(shape=[False], dtype="float64"),
+                type=TensorType(dtype="float64", shape=(None,)),
                 value=dict(),  # not an array by any stretch
                 strict=False,
             )
@@ -109,7 +109,7 @@ class TestSharedVariable:
         # so creation should work
         u = SharedVariable(
             name="u",
-            type=TensorType(shape=[False], dtype="float64"),
+            type=TensorType(dtype="float64", shape=(None,)),
             value=np.asarray([1.0, 2.0]),
             strict=False,
         )

--- a/tests/graph/rewriting/test_unify.py
+++ b/tests/graph/rewriting/test_unify.py
@@ -72,7 +72,7 @@ def test_cons():
     assert car(op1) == CustomOp
     assert cdr(op1) == (1,)
 
-    tt1 = TensorType("float32", [True, False])
+    tt1 = TensorType("float32", shape=(1, None))
 
     assert car(tt1) == TensorType
     assert cdr(tt1) == ("float32", (1, None))
@@ -247,8 +247,8 @@ def test_unify_Constant():
 
 
 def test_unify_Type():
-    t1 = TensorType(np.float64, (True, False))
-    t2 = TensorType(np.float64, (True, False))
+    t1 = TensorType(np.float64, shape=(1, None))
+    t2 = TensorType(np.float64, shape=(1, None))
 
     # `Type`, `Type`
     s = unify(t1, t2)

--- a/tests/link/c/test_params_type.py
+++ b/tests/link/c/test_params_type.py
@@ -12,7 +12,7 @@ from aesara.tensor.type import TensorType, matrix
 from tests import unittest_tools as utt
 
 
-tensor_type_0d = TensorType("float64", tuple())
+tensor_type_0d = TensorType("float64", shape=tuple())
 scalar_type = ScalarType("float64")
 generic_type = Generic()
 
@@ -127,15 +127,15 @@ class TestParamsType:
     def test_hash_and_eq_params(self):
         wp1 = ParamsType(
             a=Generic(),
-            array=TensorType("int64", (False,)),
+            array=TensorType("int64", shape=(None,)),
             floatting=ScalarType("float64"),
-            npy_scalar=TensorType("float64", tuple()),
+            npy_scalar=TensorType("float64", shape=tuple()),
         )
         wp2 = ParamsType(
             a=Generic(),
-            array=TensorType("int64", (False,)),
+            array=TensorType("int64", shape=(None,)),
             floatting=ScalarType("float64"),
-            npy_scalar=TensorType("float64", tuple()),
+            npy_scalar=TensorType("float64", shape=tuple()),
         )
         w1 = Params(
             wp1,
@@ -157,9 +157,9 @@ class TestParamsType:
         # Changing attributes names only (a -> other_name).
         wp2_other = ParamsType(
             other_name=Generic(),
-            array=TensorType("int64", (False,)),
+            array=TensorType("int64", shape=(None,)),
             floatting=ScalarType("float64"),
-            npy_scalar=TensorType("float64", tuple()),
+            npy_scalar=TensorType("float64", shape=tuple()),
         )
         w2 = Params(
             wp2_other,
@@ -190,13 +190,13 @@ class TestParamsType:
 
     def test_hash_and_eq_params_type(self):
         w1 = ParamsType(
-            a1=TensorType("int64", (False, False)),
-            a2=TensorType("int64", (False, True, False, False, True)),
+            a1=TensorType("int64", shape=(None, None)),
+            a2=TensorType("int64", shape=(None, 1, None, None, 1)),
             a3=Generic(),
         )
         w2 = ParamsType(
-            a1=TensorType("int64", (False, False)),
-            a2=TensorType("int64", (False, True, False, False, True)),
+            a1=TensorType("int64", shape=(None, None)),
+            a2=TensorType("int64", shape=(None, 1, None, None, 1)),
             a3=Generic(),
         )
         assert w1 == w2
@@ -205,24 +205,24 @@ class TestParamsType:
         assert w1.name == w2.name
         # Changing attributes names only.
         w2 = ParamsType(
-            a1=TensorType("int64", (False, False)),
+            a1=TensorType("int64", shape=(None, None)),
             other_name=TensorType(
-                "int64", (False, True, False, False, True)
+                "int64", shape=(None, 1, None, None, 1)
             ),  # a2 -> other_name
             a3=Generic(),
         )
         assert w1 != w2
         # Changing attributes types only.
         w2 = ParamsType(
-            a1=TensorType("int64", (False, False)),
+            a1=TensorType("int64", shape=(None, None)),
             a2=Generic(),  # changing class
             a3=Generic(),
         )
         assert w1 != w2
         # Changing attributes types characteristics only.
         w2 = ParamsType(
-            a1=TensorType("int64", (False, True)),  # changing broadcasting
-            a2=TensorType("int64", (False, True, False, False, True)),
+            a1=TensorType("int64", shape=(None, 1)),  # changing broadcasting
+            a2=TensorType("int64", shape=(None, 1, None, None, 1)),
             a3=Generic(),
         )
         assert w1 != w2
@@ -239,8 +239,8 @@ class TestParamsType:
         random_tensor = np.random.normal(size=size_tensor5).reshape(shape_tensor5)
 
         w = ParamsType(
-            a1=TensorType("int32", (False, False)),
-            a2=TensorType("float64", (False, False, False, False, False)),
+            a1=TensorType("int32", shape=(None, None)),
+            a2=TensorType("float64", shape=(None, None, None, None, None)),
             a3=Generic(),
         )
 

--- a/tests/link/c/test_type.py
+++ b/tests/link/c/test_type.py
@@ -44,7 +44,7 @@ class GetOp(COp):
     __props__ = ()
 
     def make_node(self, c):
-        return Apply(self, [c], [TensorType("float32", (False,))()])
+        return Apply(self, [c], [TensorType("float32", shape=(None,))()])
 
     def c_support_code(self, **kwargs):
         return """
@@ -73,7 +73,7 @@ Py_INCREF(%(out)s);
     not aesara.config.cxx, reason="G++ not available, so we need to skip this test."
 )
 def test_cdata():
-    i = TensorType("float32", (False,))()
+    i = TensorType("float32", shape=(None,))()
     c = ProdOp()(i)
     i2 = GetOp()(c)
     mode = None

--- a/tests/link/jax/test_elemwise.py
+++ b/tests/link/jax/test_elemwise.py
@@ -24,12 +24,12 @@ def test_jax_Dimshuffle():
     x_fg = FunctionGraph([a_at], [x])
     compare_jax_and_py(x_fg, [np.c_[[1.0, 2.0], [3.0, 4.0]].astype(config.floatX)])
 
-    a_at = tensor(dtype=config.floatX, shape=[False, True])
+    a_at = tensor(dtype=config.floatX, shape=(None, 1))
     x = a_at.dimshuffle((0,))
     x_fg = FunctionGraph([a_at], [x])
     compare_jax_and_py(x_fg, [np.c_[[1.0, 2.0, 3.0, 4.0]].astype(config.floatX)])
 
-    a_at = tensor(dtype=config.floatX, shape=[False, True])
+    a_at = tensor(dtype=config.floatX, shape=(None, 1))
     x = at_elemwise.DimShuffle([False, True], (0,))(a_at)
     x_fg = FunctionGraph([a_at], [x])
     compare_jax_and_py(x_fg, [np.c_[[1.0, 2.0, 3.0, 4.0]].astype(config.floatX)])

--- a/tests/link/numba/test_elemwise.py
+++ b/tests/link/numba/test_elemwise.py
@@ -140,7 +140,7 @@ def test_Elemwise(inputs, input_vals, output_fn, exc):
         # `{'drop': [1], 'shuffle': [2, 0], 'augment': [0, 2, 4]}`
         (
             set_test_value(
-                at.tensor(config.floatX, [False, True, False], name="a"),
+                at.tensor(config.floatX, shape=(None, 1, None), name="a"),
                 np.array([[[1.0, 2.0]], [[3.0, 4.0]]], dtype=config.floatX),
             ),
             ("x", 2, "x", 0, "x"),
@@ -149,21 +149,21 @@ def test_Elemwise(inputs, input_vals, output_fn, exc):
         # `{'drop': [1], 'shuffle': [0], 'augment': []}`
         (
             set_test_value(
-                at.tensor(config.floatX, [False, True], name="a"),
+                at.tensor(config.floatX, shape=(None, 1), name="a"),
                 np.array([[1.0], [2.0], [3.0], [4.0]], dtype=config.floatX),
             ),
             (0,),
         ),
         (
             set_test_value(
-                at.tensor(config.floatX, [False, True], name="a"),
+                at.tensor(config.floatX, shape=(None, 1), name="a"),
                 np.array([[1.0], [2.0], [3.0], [4.0]], dtype=config.floatX),
             ),
             (0,),
         ),
         (
             set_test_value(
-                at.tensor(config.floatX, [True, True, True], name="a"),
+                at.tensor(config.floatX, shape=(1, 1, 1), name="a"),
                 np.array([[[1.0]]], dtype=config.floatX),
             ),
             (),

--- a/tests/link/numba/test_random.py
+++ b/tests/link/numba/test_random.py
@@ -270,7 +270,7 @@ rng = np.random.default_rng(42849)
                     np.array([[1, 2], [3, 4]], dtype=np.float64),
                 ),
                 set_test_value(
-                    at.tensor("float64", [True, False, False]),
+                    at.tensor("float64", shape=(1, None, None)),
                     np.eye(2)[None, ...],
                 ),
             ],

--- a/tests/scan/test_printing.py
+++ b/tests/scan/test_printing.py
@@ -58,8 +58,8 @@ def test_debugprint_sitsot():
 
     for{cpu,scan_fn} [id C] (outer_out_sit_sot-0)
      >Elemwise{mul,no_inplace} [id W] (inner_out_sit_sot-0)
-     > |*0-<TensorType(float64, (None,))> [id X] -> [id E] (inner_in_sit_sot-0)
-     > |*1-<TensorType(float64, (None,))> [id Y] -> [id M] (inner_in_non_seqs-0)"""
+     > |*0-<TensorType(float64, (?,))> [id X] -> [id E] (inner_in_sit_sot-0)
+     > |*1-<TensorType(float64, (?,))> [id Y] -> [id M] (inner_in_non_seqs-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -113,8 +113,8 @@ def test_debugprint_sitsot_no_extra_info():
 
     for{cpu,scan_fn} [id C]
      >Elemwise{mul,no_inplace} [id W]
-     > |*0-<TensorType(float64, (None,))> [id X] -> [id E]
-     > |*1-<TensorType(float64, (None,))> [id Y] -> [id M]"""
+     > |*0-<TensorType(float64, (?,))> [id X] -> [id E]
+     > |*1-<TensorType(float64, (?,))> [id Y] -> [id M]"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -264,7 +264,7 @@ def test_debugprint_nested_scans():
     >   | | | | | |   | |Unbroadcast{0} [id BL]
     >   | | | | | |   |   |InplaceDimShuffle{x,0} [id BM]
     >   | | | | | |   |     |Elemwise{second,no_inplace} [id BN]
-    >   | | | | | |   |       |*2-<TensorType(float64, (None,))> [id BO] -> [id W] (inner_in_non_seqs-0)
+    >   | | | | | |   |       |*2-<TensorType(float64, (?,))> [id BO] -> [id W] (inner_in_non_seqs-0)
     >   | | | | | |   |       |InplaceDimShuffle{x} [id BP]
     >   | | | | | |   |         |TensorConstant{1.0} [id BQ]
     >   | | | | | |   |ScalarConstant{0} [id BR]
@@ -275,7 +275,7 @@ def test_debugprint_nested_scans():
     >   | | | | |Unbroadcast{0} [id BL]
     >   | | | | |ScalarFromTensor [id BV]
     >   | | | |   |Subtensor{int64} [id BJ]
-    >   | | | |*2-<TensorType(float64, (None,))> [id BO] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
+    >   | | | |*2-<TensorType(float64, (?,))> [id BO] -> [id W] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
     >   | | |ScalarConstant{1} [id BW]
     >   | |ScalarConstant{-1} [id BX]
     >   |InplaceDimShuffle{x} [id BY]
@@ -283,8 +283,8 @@ def test_debugprint_nested_scans():
 
     for{cpu,scan_fn} [id BE] (outer_out_sit_sot-0)
     >Elemwise{mul,no_inplace} [id CA] (inner_out_sit_sot-0)
-    > |*0-<TensorType(float64, (None,))> [id CB] -> [id BG] (inner_in_sit_sot-0)
-    > |*1-<TensorType(float64, (None,))> [id CC] -> [id BO] (inner_in_non_seqs-0)"""
+    > |*0-<TensorType(float64, (?,))> [id CB] -> [id BG] (inner_in_sit_sot-0)
+    > |*1-<TensorType(float64, (?,))> [id CC] -> [id BO] (inner_in_non_seqs-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -334,7 +334,7 @@ def test_debugprint_nested_scans():
     for{cpu,scan_fn} [id E] (outer_out_nit_sot-0)
     -*0-<TensorType(float64, ())> [id Y] -> [id U] (inner_in_seqs-0)
     -*1-<TensorType(int64, ())> [id Z] -> [id W] (inner_in_seqs-1)
-    -*2-<TensorType(float64, (None,))> [id BA] -> [id C] (inner_in_non_seqs-0)
+    -*2-<TensorType(float64, (?,))> [id BA] -> [id C] (inner_in_non_seqs-0)
     -*3-<TensorType(int32, ())> [id BB] -> [id B] (inner_in_non_seqs-1)
     >Elemwise{mul,no_inplace} [id BC] (inner_out_nit_sot-0)
     > |InplaceDimShuffle{x} [id BD]
@@ -353,7 +353,7 @@ def test_debugprint_nested_scans():
     >   | | | | | |   | |Unbroadcast{0} [id BN]
     >   | | | | | |   |   |InplaceDimShuffle{x,0} [id BO]
     >   | | | | | |   |     |Elemwise{second,no_inplace} [id BP]
-    >   | | | | | |   |       |*2-<TensorType(float64, (None,))> [id BA] (inner_in_non_seqs-0)
+    >   | | | | | |   |       |*2-<TensorType(float64, (?,))> [id BA] (inner_in_non_seqs-0)
     >   | | | | | |   |       |InplaceDimShuffle{x} [id BQ]
     >   | | | | | |   |         |TensorConstant{1.0} [id BR]
     >   | | | | | |   |ScalarConstant{0} [id BS]
@@ -364,18 +364,18 @@ def test_debugprint_nested_scans():
     >   | | | | |Unbroadcast{0} [id BN]
     >   | | | | |ScalarFromTensor [id BW]
     >   | | | |   |Subtensor{int64} [id BL]
-    >   | | | |*2-<TensorType(float64, (None,))> [id BA] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
+    >   | | | |*2-<TensorType(float64, (?,))> [id BA] (inner_in_non_seqs-0) (outer_in_non_seqs-0)
     >   | | |ScalarConstant{1} [id BX]
     >   | |ScalarConstant{-1} [id BY]
     >   |InplaceDimShuffle{x} [id BZ]
     >     |*1-<TensorType(int64, ())> [id Z] (inner_in_seqs-1)
 
     for{cpu,scan_fn} [id BH] (outer_out_sit_sot-0)
-    -*0-<TensorType(float64, (None,))> [id CA] -> [id BI] (inner_in_sit_sot-0)
-    -*1-<TensorType(float64, (None,))> [id CB] -> [id BA] (inner_in_non_seqs-0)
+    -*0-<TensorType(float64, (?,))> [id CA] -> [id BI] (inner_in_sit_sot-0)
+    -*1-<TensorType(float64, (?,))> [id CB] -> [id BA] (inner_in_non_seqs-0)
     >Elemwise{mul,no_inplace} [id CC] (inner_out_sit_sot-0)
-    > |*0-<TensorType(float64, (None,))> [id CA] (inner_in_sit_sot-0)
-    > |*1-<TensorType(float64, (None,))> [id CB] (inner_in_non_seqs-0)"""
+    > |*0-<TensorType(float64, (?,))> [id CA] (inner_in_sit_sot-0)
+    > |*1-<TensorType(float64, (?,))> [id CB] (inner_in_non_seqs-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()
@@ -413,7 +413,7 @@ def test_debugprint_mitsot():
     | | | |   |Subtensor{int64} [id H]
     | | | |     |Shape [id I]
     | | | |     | |Subtensor{:int64:} [id J]
-    | | | |     |   |<TensorType(int64, (None,))> [id K]
+    | | | |     |   |<TensorType(int64, (?,))> [id K]
     | | | |     |   |ScalarConstant{2} [id L]
     | | | |     |ScalarConstant{0} [id M]
     | | | |Subtensor{:int64:} [id J]
@@ -426,7 +426,7 @@ def test_debugprint_mitsot():
     | |   |   |Subtensor{int64} [id R]
     | |   |     |Shape [id S]
     | |   |     | |Subtensor{:int64:} [id T]
-    | |   |     |   |<TensorType(int64, (None,))> [id U]
+    | |   |     |   |<TensorType(int64, (?,))> [id U]
     | |   |     |   |ScalarConstant{2} [id V]
     | |   |     |ScalarConstant{0} [id W]
     | |   |Subtensor{:int64:} [id T]
@@ -562,19 +562,19 @@ def test_debugprint_mitmot():
     for{cpu,grad_of_scan_fn}.1 [id B] (outer_out_sit_sot-0)
     >Elemwise{add,no_inplace} [id CM] (inner_out_mit_mot-0-0)
     > |Elemwise{mul} [id CN]
-    > | |*2-<TensorType(float64, (None,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
-    > | |*5-<TensorType(float64, (None,))> [id CP] -> [id P] (inner_in_non_seqs-0)
-    > |*3-<TensorType(float64, (None,))> [id CQ] -> [id BL] (inner_in_mit_mot-0-1)
+    > | |*2-<TensorType(float64, (?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
+    > | |*5-<TensorType(float64, (?,))> [id CP] -> [id P] (inner_in_non_seqs-0)
+    > |*3-<TensorType(float64, (?,))> [id CQ] -> [id BL] (inner_in_mit_mot-0-1)
     >Elemwise{add,no_inplace} [id CR] (inner_out_sit_sot-0)
     > |Elemwise{mul} [id CS]
-    > | |*2-<TensorType(float64, (None,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
-    > | |*0-<TensorType(float64, (None,))> [id CT] -> [id Z] (inner_in_seqs-0)
-    > |*4-<TensorType(float64, (None,))> [id CU] -> [id CE] (inner_in_sit_sot-0)
+    > | |*2-<TensorType(float64, (?,))> [id CO] -> [id BL] (inner_in_mit_mot-0-0)
+    > | |*0-<TensorType(float64, (?,))> [id CT] -> [id Z] (inner_in_seqs-0)
+    > |*4-<TensorType(float64, (?,))> [id CU] -> [id CE] (inner_in_sit_sot-0)
 
     for{cpu,scan_fn} [id F] (outer_out_sit_sot-0)
     >Elemwise{mul,no_inplace} [id CV] (inner_out_sit_sot-0)
-    > |*0-<TensorType(float64, (None,))> [id CT] -> [id H] (inner_in_sit_sot-0)
-    > |*1-<TensorType(float64, (None,))> [id CW] -> [id P] (inner_in_non_seqs-0)"""
+    > |*0-<TensorType(float64, (?,))> [id CT] -> [id H] (inner_in_sit_sot-0)
+    > |*1-<TensorType(float64, (?,))> [id CW] -> [id P] (inner_in_non_seqs-0)"""
 
     for truth, out in zip(expected_output.split("\n"), lines):
         assert truth.strip() == out.strip()

--- a/tests/sparse/test_basic.py
+++ b/tests/sparse/test_basic.py
@@ -693,7 +693,7 @@ class TestConstructSparseFromList:
 
     def test_err(self):
         for ndim in [1, 3]:
-            t = TensorType(dtype=config.floatX, shape=(False,) * ndim)()
+            t = TensorType(dtype=config.floatX, shape=(None,) * ndim)()
             v = ivector()
             sub = t[v]
 
@@ -1084,7 +1084,7 @@ class TestConversion:
 
     @staticmethod
     def check_format_ndim(format, ndim):
-        x = tensor(dtype=config.floatX, shape=([False] * ndim), name="x")
+        x = tensor(dtype=config.floatX, shape=(None,) * ndim, name="x")
 
         s = SparseFromDense(format)(x)
         s_m = -s
@@ -1171,7 +1171,7 @@ class TestCsm:
 
         for format in ("csc", "csr"):
             for dtype in ("float32", "float64"):
-                x = tensor(dtype=dtype, shape=(False,))
+                x = tensor(dtype=dtype, shape=(None,))
                 y = ivector()
                 z = ivector()
                 s = ivector()
@@ -1224,7 +1224,7 @@ class TestCsm:
 
         for format in ("csc", "csr"):
             for dtype in ("float32", "float64"):
-                x = tensor(dtype=dtype, shape=(False,))
+                x = tensor(dtype=dtype, shape=(None,))
                 y = ivector()
                 z = ivector()
                 s = ivector()
@@ -1334,7 +1334,7 @@ class TestStructuredDot:
 
         return
         #
-        kerns = TensorType(dtype="int64", shape=[False])("kerns")
+        kerns = TensorType(dtype="int64", shape=(None,))("kerns")
         spmat = sp.sparse.lil_matrix((4, 6), dtype="int64")
         for i in range(5):
             # set non-zeros in random locations (row x, col y)
@@ -1343,7 +1343,7 @@ class TestStructuredDot:
             spmat[x, y] = np.random.random() * 10
         spmat = sp.sparse.csc_matrix(spmat)
 
-        images = TensorType(dtype="float32", shape=[False, False])("images")
+        images = TensorType(dtype="float32", shape=(None, None))("images")
 
         cscmat = CSC(kerns, spmat.indices[: spmat.size], spmat.indptr, spmat.shape)
         f = aesara.function([kerns, images], structured_dot(cscmat, images.T))
@@ -3275,7 +3275,7 @@ class TestTrueDot(utt.InferShapeTester):
                 variable, data = sparse_random_inputs(
                     format, shape=(10, 10), out_dtype=dtype, n=2, p=0.1
                 )
-                variable[1] = TensorType(dtype=dtype, shape=(False, False))()
+                variable[1] = TensorType(dtype=dtype, shape=(None, None))()
                 data[1] = data[1].toarray()
 
                 f = aesara.function(variable, self.op(*variable))

--- a/tests/tensor/nnet/speed_test_conv.py
+++ b/tests/tensor/nnet/speed_test_conv.py
@@ -39,7 +39,7 @@ def flip(kern, kshp):
 
 global_rng = np.random.default_rng(3423489)
 
-dmatrix4 = TensorType("float64", (False, False, False, False))
+dmatrix4 = TensorType("float64", shape=(None, None, None, None))
 
 
 def exec_multilayer_conv_nnet_old(

--- a/tests/tensor/nnet/test_abstract_conv.py
+++ b/tests/tensor/nnet/test_abstract_conv.py
@@ -2529,7 +2529,7 @@ class TestUnsharedConv:
         self.ref_mode = "FAST_RUN"
 
     def test_fwd(self):
-        tensor6 = TensorType(config.floatX, (False,) * 6)
+        tensor6 = TensorType(config.floatX, shape=(None,) * 6)
         img_sym = tensor4("img")
         kern_sym = tensor6("kern")
         ref_kern_sym = tensor4("ref_kern")
@@ -2652,7 +2652,7 @@ class TestUnsharedConv:
                 utt.verify_grad(conv_gradweight, [img, top], mode=self.mode, eps=1)
 
     def test_gradinput(self):
-        tensor6 = TensorType(config.floatX, (False,) * 6)
+        tensor6 = TensorType(config.floatX, shape=(None,) * 6)
         kern_sym = tensor6("kern")
         top_sym = tensor4("top")
         ref_kern_sym = tensor4("ref_kern")

--- a/tests/tensor/nnet/test_batchnorm.py
+++ b/tests/tensor/nnet/test_batchnorm.py
@@ -495,7 +495,7 @@ def test_batch_normalization_train_broadcast():
                 params_dimshuffle[axis] = i
 
             # construct non-broadcasted parameter variables
-            param_type = TensorType(x.dtype, (False,) * len(non_bc_axes))
+            param_type = TensorType(x.dtype, shape=(None,) * len(non_bc_axes))
             scale, bias, running_mean, running_var = (
                 param_type(n) for n in ("scale", "bias", "running_mean", "running_var")
             )

--- a/tests/tensor/random/test_basic.py
+++ b/tests/tensor/random/test_basic.py
@@ -607,7 +607,7 @@ def test_mvnormal_ShapeFeature():
     assert M_at in graph_inputs([s2])
 
     # Test broadcasted shapes
-    mean = tensor(config.floatX, [True, False])
+    mean = tensor(config.floatX, shape=(1, None))
     mean.tag.test_value = np.array([[0, 1, 2]], dtype=config.floatX)
 
     test_covar = np.diag(np.array([1, 10, 100], dtype=config.floatX))

--- a/tests/tensor/random/test_op.py
+++ b/tests/tensor/random/test_op.py
@@ -125,9 +125,9 @@ def test_RandomVariable_basics():
 def test_RandomVariable_bcast():
     rv = RandomVariable("normal", 0, [0, 0], config.floatX, inplace=True)
 
-    mu = tensor(config.floatX, [True, False, False])
+    mu = tensor(config.floatX, shape=(1, None, None))
     mu.tag.test_value = np.zeros((1, 2, 3)).astype(config.floatX)
-    sd = tensor(config.floatX, [False, False])
+    sd = tensor(config.floatX, shape=(None, None))
     sd.tag.test_value = np.ones((2, 3)).astype(config.floatX)
 
     s1 = iscalar()
@@ -160,14 +160,14 @@ def test_RandomVariable_bcast_specify_shape():
     s3 = Assert("testing")(s3, eq(s1, 1))
 
     size = specify_shape(at.as_tensor([s1, s3, s2, s2, s1]), (5,))
-    mu = tensor(config.floatX, [False, False, True])
+    mu = tensor(config.floatX, shape=(None, None, 1))
     mu.tag.test_value = np.random.normal(size=(2, 2, 1)).astype(config.floatX)
 
-    std = tensor(config.floatX, [False, True, True])
+    std = tensor(config.floatX, shape=(None, 1, 1))
     std.tag.test_value = np.ones((2, 1, 1)).astype(config.floatX)
 
     res = rv(mu, std, size=size)
-    assert res.broadcastable == (True, False, False, False, True)
+    assert res.type.shape == (1, None, None, None, 1)
 
 
 def test_RandomVariable_floatX():

--- a/tests/tensor/random/test_utils.py
+++ b/tests/tensor/random/test_utils.py
@@ -69,7 +69,7 @@ def test_broadcast_params():
 
     # Try it in Aesara
     with config.change_flags(compute_test_value="raise"):
-        mean = tensor(config.floatX, [False, True])
+        mean = tensor(config.floatX, shape=(None, 1))
         mean.tag.test_value = np.array([[0], [10], [100]], dtype=config.floatX)
         cov = matrix()
         cov.tag.test_value = np.diag(np.array([1e-6], dtype=config.floatX))

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -1693,8 +1693,8 @@ class TestLocalElemwiseAlloc:
         ],
     )
     def test_basic(self, expr, x_shape, y_shape):
-        x = at.tensor("int64", (False,) * len(x_shape), name="x")
-        y = at.tensor("int64", (False,) * len(y_shape), name="y")
+        x = at.tensor("int64", shape=(None,) * len(x_shape), name="x")
+        y = at.tensor("int64", shape=(None,) * len(y_shape), name="y")
         z = expr(x, y)
 
         z_opt = aesara.function(
@@ -1872,7 +1872,7 @@ class TestLocalElemwiseAlloc:
 
     def test_misc(self):
         x = row(dtype=self.dtype)
-        y = tensor(dtype=self.dtype, shape=(False, False, True))
+        y = tensor(dtype=self.dtype, shape=(None, None, 1))
 
         out = at.alloc(x, 5, 5).dimshuffle(0, 1, "x") + y
         func = function([y, x], out, mode=self.fast_run_mode)

--- a/tests/tensor/rewriting/test_basic.py
+++ b/tests/tensor/rewriting/test_basic.py
@@ -614,8 +614,8 @@ class TestUselessElemwise:
         f2 = function([x], eq(x, x), mode=self.mode)
         assert np.all(f2(vx) == np.ones((5, 4)))
         topo2 = f2.maker.fgraph.toposort()
-        # Shape_i{1}(<TensorType(float64, (None, None))>),
-        # Shape_i{0}(<TensorType(float64, (None, None))>), Alloc([[1]], Shape_i{0}.0,
+        # Shape_i{1}(<TensorType(float64, (?, ?))>),
+        # Shape_i{0}(<TensorType(float64, (?, ?))>), Alloc([[1]], Shape_i{0}.0,
         # Shape_i{1}.0
         assert len(topo2) == 3
         assert isinstance(topo2[-1].op, Alloc)

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -82,6 +82,7 @@ class TestDimshuffleLift:
         x, y, z = inputs()
         e = ds(ds(x, (1, 0)), (1, 0))
         g = FunctionGraph([x], [e])
+        # TODO FIXME: Construct these graphs and compare them.
         assert (
             str(g) == "FunctionGraph(InplaceDimShuffle{1,0}(InplaceDimShuffle{1,0}(x)))"
         )
@@ -93,6 +94,7 @@ class TestDimshuffleLift:
         x, y, z = inputs()
         e = ds(ds(x, (1, "x", 0)), (2, 0, "x", 1))
         g = FunctionGraph([x], [e])
+        # TODO FIXME: Construct these graphs and compare them.
         assert (
             str(g)
             == "FunctionGraph(InplaceDimShuffle{2,0,x,1}(InplaceDimShuffle{1,x,0}(x)))"
@@ -106,6 +108,7 @@ class TestDimshuffleLift:
         x, y, z = inputs()
         e = ds(ds(ds(x, (0, "x", 1)), (2, 0, "x", 1)), (1, 0))
         g = FunctionGraph([x], [e])
+        # TODO FIXME: Construct these graphs and compare them.
         assert str(g) == (
             "FunctionGraph(InplaceDimShuffle{1,0}(InplaceDimShuffle{2,0,x,1}"
             "(InplaceDimShuffle{0,x,1}(x))))"
@@ -119,6 +122,7 @@ class TestDimshuffleLift:
         e = x + y + z
         g = FunctionGraph([x, y, z], [e])
 
+        # TODO FIXME: Construct these graphs and compare them.
         # It does not really matter if the DimShuffles are inplace
         # or not.
         init_str_g_inplace = (
@@ -149,13 +153,14 @@ class TestDimshuffleLift:
         m = matrix(dtype="float64")
         out = ((v + 42) * (m + 84)).T
         g = FunctionGraph([v, m], [out])
+        # TODO FIXME: Construct these graphs and compare them.
         init_str_g = (
             "FunctionGraph(InplaceDimShuffle{1,0}(Elemwise{mul,no_inplace}"
             "(InplaceDimShuffle{x,0}(Elemwise{add,no_inplace}"
-            "(<TensorType(float64, (None,))>, "
+            "(<TensorType(float64, (?,))>, "
             "InplaceDimShuffle{x}(TensorConstant{42}))), "
             "Elemwise{add,no_inplace}"
-            "(<TensorType(float64, (None, None))>, "
+            "(<TensorType(float64, (?, ?))>, "
             "InplaceDimShuffle{x,x}(TensorConstant{84})))))"
         )
         assert str(g) == init_str_g
@@ -163,10 +168,10 @@ class TestDimshuffleLift:
         new_g = FunctionGraph(g.inputs, [new_out])
         rewrite_str_g = (
             "FunctionGraph(Elemwise{mul,no_inplace}(Elemwise{add,no_inplace}"
-            "(InplaceDimShuffle{0,x}(<TensorType(float64, (None,))>), "
+            "(InplaceDimShuffle{0,x}(<TensorType(float64, (?,))>), "
             "InplaceDimShuffle{x,x}(TensorConstant{42})), "
             "Elemwise{add,no_inplace}(InplaceDimShuffle{1,0}"
-            "(<TensorType(float64, (None, None))>), "
+            "(<TensorType(float64, (?, ?))>), "
             "InplaceDimShuffle{x,x}(TensorConstant{84}))))"
         )
         assert str(new_g) == rewrite_str_g
@@ -177,6 +182,7 @@ class TestDimshuffleLift:
         x, _, _ = inputs()
         e = ds(x, (0, 1))
         g = FunctionGraph([x], [e])
+        # TODO FIXME: Construct these graphs and compare them.
         assert str(g) == "FunctionGraph(InplaceDimShuffle{0,1}(x))"
         dimshuffle_lift.rewrite(g)
         assert str(g) == "FunctionGraph(x)"
@@ -191,6 +197,7 @@ class TestDimshuffleLift:
         ds_z = ds(z, (2, 1, 0))  # useful
         ds_u = ds(u, ("x"))  # useful
         g = FunctionGraph([x, y, z, u], [ds_x, ds_y, ds_z, ds_u])
+        # TODO FIXME: Construct these graphs and compare them.
         assert (
             str(g)
             == "FunctionGraph(InplaceDimShuffle{0,x}(x), InplaceDimShuffle{2,1,0}(y), InplaceDimShuffle{2,1,0}(z), InplaceDimShuffle{x}(TensorConstant{1}))"
@@ -225,6 +232,7 @@ def test_local_useless_dimshuffle_in_reshape():
         ],
     )
 
+    # TODO FIXME: Construct these graphs and compare them.
     assert str(g) == (
         "FunctionGraph(Reshape{1}(InplaceDimShuffle{x,0}(vector), Shape(vector)), "
         "Reshape{2}(InplaceDimShuffle{x,0,x,1}(mat), Shape(mat)), "

--- a/tests/tensor/rewriting/test_elemwise.py
+++ b/tests/tensor/rewriting/test_elemwise.py
@@ -71,9 +71,9 @@ def ds(x, y):
 
 
 def inputs(xbc=(0, 0), ybc=(0, 0), zbc=(0, 0)):
-    x = TensorType(shape=xbc, dtype="float64")("x")
-    y = TensorType(shape=ybc, dtype="float64")("y")
-    z = TensorType(shape=zbc, dtype="float64")("z")
+    x = TensorType(dtype="float64", shape=xbc)("x")
+    y = TensorType(dtype="float64", shape=ybc)("y")
+    z = TensorType(dtype="float64", shape=zbc)("z")
     return x, y, z
 
 
@@ -205,10 +205,10 @@ class TestDimshuffleLift:
 
 
 def test_local_useless_dimshuffle_in_reshape():
-    vec = TensorType(shape=(False,), dtype="float64")("vector")
-    mat = TensorType(shape=(False, False), dtype="float64")("mat")
-    row = TensorType(shape=(True, False), dtype="float64")("row")
-    col = TensorType(shape=(False, True), dtype="float64")("col")
+    vec = TensorType(dtype="float64", shape=(None,))("vector")
+    mat = TensorType(dtype="float64", shape=(None, None))("mat")
+    row = TensorType(dtype="float64", shape=(1, None))("row")
+    col = TensorType(dtype="float64", shape=(None, 1))("col")
 
     reshape_dimshuffle_vector = reshape(vec.dimshuffle("x", 0), vec.shape)
     reshape_dimshuffle_mat = reshape(mat.dimshuffle("x", 0, "x", 1), mat.shape)
@@ -270,12 +270,12 @@ class TestFusion:
         return np.zeros((5, 5), dtype=dtype) + num
 
     fw, fx, fy, fz = [
-        tensor(dtype="float32", shape=[False] * 2, name=n) for n in "wxyz"
+        tensor(dtype="float32", shape=(None,) * 2, name=n) for n in "wxyz"
     ]
     dw, dx, dy, dz = [
-        tensor(dtype="float64", shape=[False] * 2, name=n) for n in "wxyz"
+        tensor(dtype="float64", shape=(None,) * 2, name=n) for n in "wxyz"
     ]
-    ix, iy, iz = [tensor(dtype="int32", shape=[False] * 2, name=n) for n in "xyz"]
+    ix, iy, iz = [tensor(dtype="int32", shape=(None,) * 2, name=n) for n in "xyz"]
     fv = fvector("v")
     fs = fscalar("s")
     fwv = my_init("float32", 1)

--- a/tests/tensor/rewriting/test_math.py
+++ b/tests/tensor/rewriting/test_math.py
@@ -161,9 +161,9 @@ def rewrite(g, level="fast_run"):
 
 
 def inputs(xbc=(0, 0), ybc=(0, 0), zbc=(0, 0)):
-    x = TensorType(shape=xbc, dtype="float64")("x")
-    y = TensorType(shape=ybc, dtype="float64")("y")
-    z = TensorType(shape=zbc, dtype="float64")("z")
+    x = TensorType(dtype="float64", shape=xbc)("x")
+    y = TensorType(dtype="float64", shape=ybc)("y")
+    z = TensorType(dtype="float64", shape=zbc)("z")
     return x, y, z
 
 
@@ -959,11 +959,11 @@ class TestAlgebraicCanonizer:
 
     def test_mismatching_types(self):
         a = at.as_tensor([[0.0]], dtype=np.float64)
-        b = tensor("float64", (None,)).dimshuffle("x", 0)
+        b = tensor("float64", shape=(None,)).dimshuffle("x", 0)
         z = add(a, b)
         # Construct a node with the wrong output `Type`
         z = Apply(
-            z.owner.op, z.owner.inputs, [tensor("float64", (None, None))]
+            z.owner.op, z.owner.inputs, [tensor("float64", shape=(None, None))]
         ).outputs[0]
 
         z_rewritten = rewrite_graph(
@@ -1098,13 +1098,13 @@ class TestFusion:
             return ret
 
         fw, fx, fy, fz = [
-            tensor(dtype="float32", shape=[False] * len(shp), name=n) for n in "wxyz"
+            tensor(dtype="float32", shape=(None,) * len(shp), name=n) for n in "wxyz"
         ]
         dw, dx, dy, dz = [
-            tensor(dtype="float64", shape=[False] * len(shp), name=n) for n in "wxyz"
+            tensor(dtype="float64", shape=(None,) * len(shp), name=n) for n in "wxyz"
         ]
         ix, iy, iz = [
-            tensor(dtype="int32", shape=[False] * len(shp), name=n) for n in "xyz"
+            tensor(dtype="int32", shape=(None,) * len(shp), name=n) for n in "xyz"
         ]
         fv = fvector("v")
         fs = fscalar("s")
@@ -3558,7 +3558,7 @@ class TestLocalReduce:
             at_max,
             at_min,
         ]:
-            x = TensorType("int64", (True, True, True))()
+            x = TensorType("int64", shape=(1, 1, 1))()
             f = function([x], [fct(x)], mode=self.mode)
             assert not any(
                 isinstance(node.op, CAReduce) for node in f.maker.fgraph.toposort()
@@ -3573,7 +3573,7 @@ class TestLocalReduce:
             at_max,
             at_min,
         ]:
-            x = TensorType("int64", (True, True))()
+            x = TensorType("int64", shape=(1, 1))()
             f = function([x], [fct(x, axis=[0, 1])], mode=self.mode)
             assert not any(
                 isinstance(node.op, CAReduce) for node in f.maker.fgraph.toposort()
@@ -3588,7 +3588,7 @@ class TestLocalReduce:
             at_max,
             at_min,
         ]:
-            x = TensorType("int64", (True, False, True))()
+            x = TensorType("int64", shape=(1, None, 1))()
             f = function([x], [fct(x, axis=[0, 1])], mode=self.mode)
 
             order = f.maker.fgraph.toposort()
@@ -3613,7 +3613,7 @@ class TestLocalReduce:
             at_max,
             at_min,
         ]:
-            x = TensorType("int64", (True, True, True))()
+            x = TensorType("int64", shape=(1, 1, 1))()
             f = function([x], [fct(x, axis=[0, 2])], mode=self.mode)
             assert not any(
                 isinstance(node.op, CAReduce) for node in f.maker.fgraph.toposort()
@@ -4097,7 +4097,7 @@ def test_local_log_sum_exp_maximum():
     check_max_log_sum_exp(x, axis=2, dimshuffle_op=transpose_op)
 
     # If the sum is performed with keepdims=True
-    x = TensorType(dtype="floatX", shape=(False, True, False))("x")
+    x = TensorType(dtype="floatX", shape=(None, 1, None))("x")
     sum_keepdims_op = x.sum(axis=(0, 1), keepdims=True).owner.op
     check_max_log_sum_exp(x, axis=(0, 1), dimshuffle_op=sum_keepdims_op)
 

--- a/tests/tensor/rewriting/test_shape.py
+++ b/tests/tensor/rewriting/test_shape.py
@@ -493,15 +493,15 @@ def test_local_Shape_of_SpecifyShape_partial(s1):
     assert not any(isinstance(apply.op, SpecifyShape) for apply in fgraph.apply_nodes)
 
 
-def test_local_Shape_i_of_broadcastable():
-    x = tensor(np.float64, shape=(None, 1))
+def test_local_Shape_i_ground():
+    x = tensor(np.float64, shape=(None, 2))
     s = Shape_i(1)(x)
 
     fgraph = FunctionGraph(outputs=[s], clone=False)
     _ = rewrite_graph(fgraph, clone=False)
 
     assert x not in fgraph.variables
-    assert fgraph.outputs[0].data == 1
+    assert fgraph.outputs[0].data == 2
 
     # A test for a non-`TensorType`
     class MyType(Type):

--- a/tests/tensor/rewriting/test_uncanonicalize.py
+++ b/tests/tensor/rewriting/test_uncanonicalize.py
@@ -192,7 +192,7 @@ def test_local_dimshuffle_subtensor():
     assert not all(isinstance(x, DimShuffle) for x in topo)
 
     # Test dimshuffle remove dimensions the subtensor don't "see".
-    x = tensor(shape=(False, True, False), dtype="float64")
+    x = tensor(dtype="float64", shape=(None, 1, None))
     out = x[i].dimshuffle(1)
 
     g = FunctionGraph([x, i], [out])
@@ -203,7 +203,7 @@ def test_local_dimshuffle_subtensor():
 
     # Test dimshuffle remove dimensions the subtensor don't "see" but
     # have in between dimensions.
-    x = tensor(shape=(False, True, False, True), dtype="float64")
+    x = tensor(dtype="float64", shape=(None, 1, None, 1))
     out = x[i].dimshuffle(1)
 
     f = aesara.function([x, i], out)

--- a/tests/tensor/signal/test_conv.py
+++ b/tests/tensor/signal/test_conv.py
@@ -16,8 +16,8 @@ class TestSignalConv2D:
 
         image_dim = len(image_shape)
         filter_dim = len(filter_shape)
-        input = TensorType("float64", [False] * image_dim)()
-        filters = TensorType("float64", [False] * filter_dim)()
+        input = TensorType("float64", shape=(None,) * image_dim)()
+        filters = TensorType("float64", shape=(None,) * filter_dim)()
 
         bsize = image_shape[0]
         if image_dim != 3:

--- a/tests/tensor/signal/test_pool.py
+++ b/tests/tensor/signal/test_pool.py
@@ -1122,7 +1122,7 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
         rng = np.random.default_rng(utt.fetch_seed())
         maxpoolshps = [(3, 2)]
         imval = rng.random((2, 1, 1, 1, 3, 4))
-        images = TensorType("float64", [False] * 6)()
+        images = TensorType("float64", shape=(None,) * 6)()
 
         for maxpoolshp, ignore_border, mode in product(
             maxpoolshps,
@@ -1204,7 +1204,7 @@ class TestDownsampleFactorMax(utt.InferShapeTester):
                         warn=False,
                     )
         # checking with broadcastable input
-        image = tensor(dtype="float64", shape=(False, False, True, True))
+        image = tensor(dtype="float64", shape=(None, None, 1, 1))
         image_val = rng.random((4, 6, 1, 1))
         self._compile_and_check(
             [image],

--- a/tests/tensor/test_basic.py
+++ b/tests/tensor/test_basic.py
@@ -1177,6 +1177,8 @@ def test_get_vector_length():
     # Test `Alloc`s
     assert 3 == get_vector_length(alloc(0, 3))
 
+    assert 5 == get_vector_length(tensor(np.float64, shape=(5,)))
+
 
 class TestJoinAndSplit:
     # Split is tested by each verify_grad method.

--- a/tests/tensor/test_blas.py
+++ b/tests/tensor/test_blas.py
@@ -1469,7 +1469,7 @@ class TestGemv(unittest_tools.OptimizationTestMixin):
         v2 = shared(v2_orig)
         m = shared(
             np.array(rng.uniform(size=(1, 2)), dtype="float32"),
-            shape=(True, False),
+            shape=(1, None),
         )
         o = aesara.tensor.dot(m, v1)
         f = function([], o + v2, mode=mode_blas_opt)
@@ -1779,20 +1779,20 @@ class TestDgemv(BaseGemv, unittest_tools.OptimizationTestMixin):
 
 class TestGerMakeNode:
     def setup_method(self):
-        self.iv = tensor(dtype="int32", shape=(False,))
-        self.fv = tensor(dtype="float32", shape=(False,))
-        self.fv1 = tensor(dtype="float32", shape=(True,))
-        self.dv = tensor(dtype="float64", shape=(False,))
-        self.dv1 = tensor(dtype="float64", shape=(True,))
-        self.cv = tensor(dtype="complex64", shape=(False,))
-        self.zv = tensor(dtype="complex128", shape=(False,))
+        self.iv = tensor(dtype="int32", shape=(None,))
+        self.fv = tensor(dtype="float32", shape=(None,))
+        self.fv1 = tensor(dtype="float32", shape=(1,))
+        self.dv = tensor(dtype="float64", shape=(None,))
+        self.dv1 = tensor(dtype="float64", shape=(1,))
+        self.cv = tensor(dtype="complex64", shape=(None,))
+        self.zv = tensor(dtype="complex128", shape=(None,))
 
-        self.fv_2 = tensor(dtype="float32", shape=(False,))
-        self.fv1_2 = tensor(dtype="float32", shape=(True,))
-        self.dv_2 = tensor(dtype="float64", shape=(False,))
-        self.dv1_2 = tensor(dtype="float64", shape=(True,))
-        self.cv_2 = tensor(dtype="complex64", shape=(False,))
-        self.zv_2 = tensor(dtype="complex128", shape=(False,))
+        self.fv_2 = tensor(dtype="float32", shape=(None,))
+        self.fv1_2 = tensor(dtype="float32", shape=(1,))
+        self.dv_2 = tensor(dtype="float64", shape=(None,))
+        self.dv1_2 = tensor(dtype="float64", shape=(1,))
+        self.cv_2 = tensor(dtype="complex64", shape=(None,))
+        self.zv_2 = tensor(dtype="complex128", shape=(None,))
 
         self.fm = fmatrix()
         self.dm = dmatrix()
@@ -1866,10 +1866,10 @@ class TestGer(unittest_tools.OptimizationTestMixin):
         self.mode = aesara.compile.get_default_mode().including("fast_run")
         self.mode = self.mode.excluding("c_blas", "scipy_blas")
         dtype = self.dtype = "float64"  # optimization isn't dtype-dependent
-        self.A = tensor(dtype=dtype, shape=(False, False))
+        self.A = tensor(dtype=dtype, shape=(None, None))
         self.a = tensor(dtype=dtype, shape=())
-        self.x = tensor(dtype=dtype, shape=(False,))
-        self.y = tensor(dtype=dtype, shape=(False,))
+        self.x = tensor(dtype=dtype, shape=(None,))
+        self.y = tensor(dtype=dtype, shape=(None,))
         self.ger = ger
         self.ger_destructive = ger_destructive
         self.gemm = gemm_no_inplace
@@ -2000,9 +2000,9 @@ class TestGer(unittest_tools.OptimizationTestMixin):
         # test corner case shape and dtype
         rng = np.random.default_rng(unittest_tools.fetch_seed())
 
-        A = tensor(dtype=dtype, shape=(False, False))
-        x = tensor(dtype=dtype, shape=(False,))
-        y = tensor(dtype=dtype, shape=(False,))
+        A = tensor(dtype=dtype, shape=(None, None))
+        x = tensor(dtype=dtype, shape=(None,))
+        y = tensor(dtype=dtype, shape=(None,))
 
         f = self.function([A, x, y], A + 0.1 * outer(x, y))
         self.assertFunctionContains(

--- a/tests/tensor/test_blas_c.py
+++ b/tests/tensor/test_blas_c.py
@@ -41,10 +41,10 @@ class TestCGer(OptimizationTestMixin):
         # This tests can run even when aesara.config.blas__ldflags is empty.
         self.dtype = dtype
         self.mode = aesara.compile.get_default_mode().including("fast_run")
-        self.A = tensor(dtype=dtype, shape=(False, False))
+        self.A = tensor(dtype=dtype, shape=(None, None))
         self.a = tensor(dtype=dtype, shape=())
-        self.x = tensor(dtype=dtype, shape=(False,))
-        self.y = tensor(dtype=dtype, shape=(False,))
+        self.x = tensor(dtype=dtype, shape=(None,))
+        self.y = tensor(dtype=dtype, shape=(None,))
         self.Aval = np.ones((2, 3), dtype=dtype)
         self.xval = np.asarray([1, 2], dtype=dtype)
         self.yval = np.asarray([1.5, 2.7, 3.9], dtype=dtype)
@@ -131,12 +131,12 @@ class TestCGemv(OptimizationTestMixin):
         self.dtype = dtype
         self.mode = aesara.compile.get_default_mode().including("fast_run")
         # matrix
-        self.A = tensor(dtype=dtype, shape=(False, False))
+        self.A = tensor(dtype=dtype, shape=(None, None))
         self.Aval = np.ones((2, 3), dtype=dtype)
 
         # vector
-        self.x = tensor(dtype=dtype, shape=(False,))
-        self.y = tensor(dtype=dtype, shape=(False,))
+        self.x = tensor(dtype=dtype, shape=(None,))
+        self.y = tensor(dtype=dtype, shape=(None,))
         self.xval = np.asarray([1, 2], dtype=dtype)
         self.yval = np.asarray([1.5, 2.7, 3.9], dtype=dtype)
 

--- a/tests/tensor/test_blas_scipy.py
+++ b/tests/tensor/test_blas_scipy.py
@@ -17,10 +17,10 @@ class TestScipyGer(OptimizationTestMixin):
         self.mode = self.mode.including("fast_run")
         self.mode = self.mode.excluding("c_blas")  # c_blas trumps scipy Ops
         dtype = self.dtype = "float64"  # optimization isn't dtype-dependent
-        self.A = tensor(dtype=dtype, shape=(False, False))
+        self.A = tensor(dtype=dtype, shape=(None, None))
         self.a = tensor(dtype=dtype, shape=())
-        self.x = tensor(dtype=dtype, shape=(False,))
-        self.y = tensor(dtype=dtype, shape=(False,))
+        self.x = tensor(dtype=dtype, shape=(None,))
+        self.y = tensor(dtype=dtype, shape=(None,))
         self.Aval = np.ones((2, 3), dtype=dtype)
         self.xval = np.asarray([1, 2], dtype=dtype)
         self.yval = np.asarray([1.5, 2.7, 3.9], dtype=dtype)

--- a/tests/tensor/test_casting.py
+++ b/tests/tensor/test_casting.py
@@ -75,7 +75,7 @@ class TestCasting:
         ),
     )
     def test_basic(self, type1, type2, converter):
-        x = TensorType(dtype=type1, shape=(False,))()
+        x = TensorType(dtype=type1, shape=(None,))()
         y = converter(x)
         f = function([In(x, strict=True)], y)
         a = np.arange(10, dtype=type1)
@@ -86,8 +86,8 @@ class TestCasting:
         val64 = np.ones(3, dtype="complex64") + 0.5j
         val128 = np.ones(3, dtype="complex128") + 0.5j
 
-        vec64 = TensorType("complex64", (False,))()
-        vec128 = TensorType("complex128", (False,))()
+        vec64 = TensorType("complex64", shape=(None,))()
+        vec128 = TensorType("complex128", shape=(None,))()
 
         f = function([vec64], _convert_to_complex128(vec64))
         # we need to compare with the same type.

--- a/tests/tensor/test_io.py
+++ b/tests/tensor/test_io.py
@@ -20,7 +20,7 @@ class TestLoadTensor:
         path = Variable(Generic(), None)
         # Not specifying mmap_mode defaults to None, and the data is
         # copied into main memory
-        x = load(path, "int32", (False,))
+        x = load(path, "int32", (None,))
         y = x * 2
         fn = function([path], y)
         assert (fn(self.filename) == (self.data * 2)).all()
@@ -32,14 +32,14 @@ class TestLoadTensor:
         path = Variable(Generic(), None)
         for mmap_mode in ("r+", "r", "w+", "toto"):
             with pytest.raises(ValueError):
-                load(path, "int32", (False,), mmap_mode)
+                load(path, "int32", (None,), mmap_mode)
 
-    def test1(self):
+    def test_copy_on_write(self):
         path = Variable(Generic(), None)
         # 'c' means "copy-on-write", which allow the array to be overwritten
         # by an inplace Op in the graph, without modifying the underlying
         # file.
-        x = load(path, "int32", (False,), "c")
+        x = load(path, "int32", (None,), "c")
         # x ** 2 has been chosen because it will work inplace.
         y = (x**2).sum()
         fn = function([path], y)
@@ -49,7 +49,7 @@ class TestLoadTensor:
 
     def test_memmap(self):
         path = Variable(Generic(), None)
-        x = load(path, "int32", (False,), mmap_mode="c")
+        x = load(path, "int32", (None,), mmap_mode="c")
         fn = function([path], x)
         assert type(fn(self.filename)) == np.core.memmap
 

--- a/tests/tensor/test_math.py
+++ b/tests/tensor/test_math.py
@@ -562,7 +562,7 @@ TestCosBroadcast = makeBroadcastTester(
 
 
 def test_py_c_match():
-    a = TensorType(dtype="int8", shape=(False,))()
+    a = TensorType(dtype="int8", shape=(None,))()
     f = function([a], arccos(a), mode="DebugMode")
     # This can fail in DebugMode
     f(np.asarray([1, 0, -1], dtype="int8"))
@@ -1460,8 +1460,8 @@ class TestOuter:
     def test_outer(self):
         for m in range(4):
             for n in range(4):
-                x = tensor(dtype="floatX", shape=(False,) * m)
-                y = tensor(dtype="floatX", shape=(False,) * n)
+                x = tensor(dtype="floatX", shape=(None,) * m)
+                y = tensor(dtype="floatX", shape=(None,) * n)
                 s1 = self.rng.integers(1, 10, m)
                 s2 = self.rng.integers(1, 10, n)
                 v1 = np.asarray(self.rng.random(s1)).astype(config.floatX)
@@ -1927,21 +1927,21 @@ class TestDot:
         for dtype0 in ("float32", "float64", "complex64"):
             for dtype1 in ("float32", "complex64", "complex128"):
                 for bc0 in (
-                    (True,),
-                    (False,),
-                    (True, True),
-                    (True, False),
-                    (False, True),
-                    (False, False),
+                    (1,),
+                    (None,),
+                    (1, 1),
+                    (1, None),
+                    (None, 1),
+                    (None, None),
                 ):
                     x = TensorType(dtype=dtype0, shape=bc0)()
                     for bc1 in (
-                        (True,),
-                        (False,),
-                        (True, True),
-                        (True, False),
-                        (False, True),
-                        (False, False),
+                        (1,),
+                        (None,),
+                        (1, 1),
+                        (1, None),
+                        (None, 1),
+                        (None, None),
                     ):
 
                         y = TensorType(dtype=dtype1, shape=bc1)()
@@ -2117,7 +2117,7 @@ class TestTensordot:
 
     def test_broadcastable1(self):
         rng = np.random.default_rng(seed=utt.fetch_seed())
-        x = TensorType(dtype=config.floatX, shape=(True, False, False))("x")
+        x = TensorType(dtype=config.floatX, shape=(1, None, None))("x")
         y = tensor3("y")
         z = tensordot(x, y)
         assert z.broadcastable == (True, False)
@@ -2129,7 +2129,7 @@ class TestTensordot:
 
     def test_broadcastable2(self):
         rng = np.random.default_rng(seed=utt.fetch_seed())
-        x = TensorType(dtype=config.floatX, shape=(True, False, False))("x")
+        x = TensorType(dtype=config.floatX, shape=(1, None, None))("x")
         y = tensor3("y")
         axes = [[2, 1], [0, 1]]
         z = tensordot(x, y, axes=axes)
@@ -2156,7 +2156,7 @@ def test_smallest():
 
 
 def test_var():
-    a = TensorType(dtype="float64", shape=[False, False, False])()
+    a = TensorType(dtype="float64", shape=(None, None, None))()
     f = function([a], var(a))
 
     a_val = np.arange(6).reshape(1, 2, 3)
@@ -2206,7 +2206,7 @@ def test_var():
 class TestSum:
     def test_sum_overflow(self):
         # Ensure that overflow errors are a little bit harder to get
-        a = TensorType(dtype="int8", shape=[False])()
+        a = TensorType(dtype="int8", shape=(None,))()
         f = function([a], at_sum(a))
         assert f([1] * 300) == 300
 
@@ -3262,7 +3262,7 @@ def test_grad_useless_sum():
 
     mode = get_default_mode().including("canonicalize")
     mode.check_isfinite = False
-    x = TensorType(config.floatX, (True,))("x")
+    x = TensorType(config.floatX, shape=(1,))("x")
     l = log(1.0 - sigmoid(x))[0]
     g = grad(l, x)
 
@@ -3287,8 +3287,8 @@ def test_tanh_grad_broadcast():
     # FIXME: This is not a real test.
     # This crashed in the past.
 
-    x = tensor(dtype="float32", shape=(True, False, False, False))
-    y = tensor(dtype="float32", shape=(True, True, False, False))
+    x = tensor(dtype="float32", shape=(1, None, None, None))
+    y = tensor(dtype="float32", shape=(1, 1, None, None))
 
     # TODO FIXME: This is a bad test
     grad(tanh(x).sum(), x)

--- a/tests/tensor/test_shape.py
+++ b/tests/tensor/test_shape.py
@@ -9,6 +9,7 @@ from aesara.graph.basic import Variable
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.type import Type
 from aesara.misc.safe_asarray import _asarray
+from aesara.scalar.basic import ScalarConstant
 from aesara.tensor import as_tensor_variable, get_vector_length, row
 from aesara.tensor.basic import MakeVector, constant
 from aesara.tensor.elemwise import DimShuffle, Elemwise
@@ -22,6 +23,7 @@ from aesara.tensor.shape import (
     reshape,
     shape,
     shape_i,
+    shape_tuple,
     specify_broadcastable,
     specify_shape,
     unbroadcast,
@@ -46,6 +48,7 @@ from aesara.tensor.type_other import NoneConst
 from aesara.tensor.var import TensorVariable
 from aesara.typed_list import make_list
 from tests import unittest_tools as utt
+from tests.graph.utils import MyType2
 from tests.tensor.utils import eval_outputs, random
 from tests.test_rop import RopLopChecker
 
@@ -657,3 +660,18 @@ class TestUnbroadcastInferShape(utt.InferShapeTester):
             Unbroadcast,
             warn=False,
         )
+
+
+def test_shape_tuple():
+
+    x = Variable(MyType2(), None, None)
+    assert shape_tuple(x) == ()
+
+    x = tensor(np.float64, shape=(1, 2, None))
+    res = shape_tuple(x)
+    assert isinstance(res, tuple)
+    assert isinstance(res[0], ScalarConstant)
+    assert res[0].data == 1
+    assert isinstance(res[1], ScalarConstant)
+    assert res[1].data == 2
+    assert not isinstance(res[2], ScalarConstant)

--- a/tests/tensor/test_sharedvar.py
+++ b/tests/tensor/test_sharedvar.py
@@ -513,7 +513,7 @@ def makeSharedTester(
             )
             topo = f.maker.fgraph.toposort()
             f()
-            # [Gemm{inplace}(<TensorType(float64, (None, None))>, 0.01, <TensorType(float64, (None, None))>, <TensorType(float64, (None, None))>, 2e-06)]
+            # [Gemm{inplace}(<TensorType(float64, (?, ?))>, 0.01, <TensorType(float64, (?, ?))>, <TensorType(float64, (?, ?))>, 2e-06)]
             if aesara.config.mode != "FAST_COMPILE":
                 assert (
                     sum(

--- a/tests/tensor/test_sharedvar.py
+++ b/tests/tensor/test_sharedvar.py
@@ -658,10 +658,3 @@ def test_scalar_shared_options():
 def test_get_vector_length():
     x = aesara.shared(np.array((2, 3, 4, 5)))
     assert get_vector_length(x) == 4
-
-
-def test_deprecated_kwargs():
-    with pytest.warns(DeprecationWarning, match=".*broadcastable.*"):
-        res = aesara.shared(np.array([[1.0]]), broadcastable=(True, False))
-
-    assert res.type.shape == (1, None)

--- a/tests/tensor/test_slinalg.py
+++ b/tests/tensor/test_slinalg.py
@@ -178,13 +178,13 @@ class TestSolveBase(utt.InferShapeTester):
         [
             (vector, matrix, "`A` must be a matrix.*"),
             (
-                functools.partial(tensor, dtype="floatX", shape=(False,) * 3),
+                functools.partial(tensor, dtype="floatX", shape=(None,) * 3),
                 matrix,
                 "`A` must be a matrix.*",
             ),
             (
                 matrix,
-                functools.partial(tensor, dtype="floatX", shape=(False,) * 3),
+                functools.partial(tensor, dtype="floatX", shape=(None,) * 3),
                 "`b` must be a matrix or a vector.*",
             ),
         ],
@@ -523,12 +523,12 @@ class TestKron(utt.InferShapeTester):
 
     def test_perform(self):
         for shp0 in [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)]:
-            x = tensor(dtype="floatX", shape=(False,) * len(shp0))
+            x = tensor(dtype="floatX", shape=(None,) * len(shp0))
             a = np.asarray(self.rng.random(shp0)).astype(config.floatX)
             for shp1 in [(6,), (6, 7), (6, 7, 8), (6, 7, 8, 9)]:
                 if len(shp0) + len(shp1) == 2:
                     continue
-                y = tensor(dtype="floatX", shape=(False,) * len(shp1))
+                y = tensor(dtype="floatX", shape=(None,) * len(shp1))
                 f = function([x, y], kron(x, y))
                 b = self.rng.random(shp1).astype(config.floatX)
                 out = f(a, b)
@@ -542,12 +542,12 @@ class TestKron(utt.InferShapeTester):
 
     def test_numpy_2d(self):
         for shp0 in [(2, 3)]:
-            x = tensor(dtype="floatX", shape=(False,) * len(shp0))
+            x = tensor(dtype="floatX", shape=(None,) * len(shp0))
             a = np.asarray(self.rng.random(shp0)).astype(config.floatX)
             for shp1 in [(6, 7)]:
                 if len(shp0) + len(shp1) == 2:
                     continue
-                y = tensor(dtype="floatX", shape=(False,) * len(shp1))
+                y = tensor(dtype="floatX", shape=(None,) * len(shp1))
                 f = function([x, y], kron(x, y))
                 b = self.rng.random(shp1).astype(config.floatX)
                 out = f(a, b)

--- a/tests/tensor/test_sort.py
+++ b/tests/tensor/test_sort.py
@@ -459,7 +459,7 @@ class TestTopK:
             if k == 0:
                 continue
 
-            x = tensor(name="x", shape=(False,) * len(shp), dtype=dtype)
+            x = tensor(name="x", shape=(None,) * len(shp), dtype=dtype)
             y = argtopk(x, k, axis=axis, sorted=sorted, idx_dtype=idx_dtype)
             fn = aesara.function([x], y, mode=self.mode)
             assert any(
@@ -515,7 +515,7 @@ class TestTopKInferShape(utt.InferShapeTester):
             if k == 0:
                 continue
 
-            x = tensor(name="x", shape=(False,) * len(shp), dtype=aesara.config.floatX)
+            x = tensor(name="x", shape=(None,) * len(shp), dtype=aesara.config.floatX)
             yv, yi = topk_and_argtopk(x, k, axis=axis, sorted=False, idx_dtype="int32")
             size = reduce(int.__mul__, shp)
             xval = gen_unique_vector(size, aesara.config.floatX).reshape(shp)

--- a/tests/tensor/test_type.py
+++ b/tests/tensor/test_type.py
@@ -31,6 +31,10 @@ def test_in_same_class():
     assert test_type.in_same_class(test_type)
     assert not test_type.in_same_class(test_type2)
 
+    test_type = TensorType(config.floatX, shape=())
+    test_type2 = TensorType(config.floatX, shape=(None,))
+    assert not test_type.in_same_class(test_type2)
+
 
 def test_is_super():
     test_type = TensorType(config.floatX, shape=(None, None))

--- a/tests/tensor/test_type.py
+++ b/tests/tensor/test_type.py
@@ -25,30 +25,30 @@ def test_numpy_dtype(dtype, exp_dtype):
 
 
 def test_in_same_class():
-    test_type = TensorType(config.floatX, [False, False])
-    test_type2 = TensorType(config.floatX, [False, True])
+    test_type = TensorType(config.floatX, shape=(None, None))
+    test_type2 = TensorType(config.floatX, shape=(None, 1))
 
     assert test_type.in_same_class(test_type)
     assert not test_type.in_same_class(test_type2)
 
 
 def test_is_super():
-    test_type = TensorType(config.floatX, [False, False])
-    test_type2 = TensorType(config.floatX, [False, True])
+    test_type = TensorType(config.floatX, shape=(None, None))
+    test_type2 = TensorType(config.floatX, shape=(None, 1))
 
     assert test_type.is_super(test_type)
     assert test_type.is_super(test_type2)
     assert not test_type2.is_super(test_type)
 
-    test_type3 = TensorType(config.floatX, [False, False, False])
+    test_type3 = TensorType(config.floatX, shape=(None, None, None))
     assert not test_type3.is_super(test_type)
 
 
 def test_convert_variable():
-    test_type = TensorType(config.floatX, [False, False])
+    test_type = TensorType(config.floatX, shape=(None, None))
     test_var = test_type()
 
-    test_type2 = TensorType(config.floatX, [True, False])
+    test_type2 = TensorType(config.floatX, shape=(1, None))
     test_var2 = test_type2()
 
     res = test_type.convert_variable(test_var)
@@ -60,7 +60,7 @@ def test_convert_variable():
     res = test_type2.convert_variable(test_var)
     assert res.type == test_type2
 
-    test_type3 = TensorType(config.floatX, [True, False, True])
+    test_type3 = TensorType(config.floatX, shape=(1, None, 1))
     test_var3 = test_type3()
 
     res = test_type2.convert_variable(test_var3)
@@ -84,12 +84,12 @@ def test_convert_variable_mixed_specificity():
 
 
 def test_filter_variable():
-    test_type = TensorType(config.floatX, [])
+    test_type = TensorType(config.floatX, shape=())
 
     with pytest.raises(TypeError):
         test_type.filter(test_type())
 
-    test_type = TensorType(config.floatX, [True, False])
+    test_type = TensorType(config.floatX, shape=(1, None))
 
     with pytest.raises(TypeError):
         test_type.filter(np.empty((0, 1), dtype=config.floatX))
@@ -103,7 +103,7 @@ def test_filter_variable():
         test_type.filter_checks_isfinite = True
         test_type.filter(np.full((1, 2), np.inf, dtype=config.floatX))
 
-    test_type2 = TensorType(config.floatX, [False, False])
+    test_type2 = TensorType(config.floatX, shape=(None, None))
     test_var = test_type()
     test_var2 = test_type2()
 
@@ -120,7 +120,7 @@ def test_filter_variable():
 
 
 def test_filter_strict():
-    test_type = TensorType(config.floatX, [])
+    test_type = TensorType(config.floatX, shape=())
 
     with pytest.raises(TypeError):
         test_type.filter(1, strict=True)
@@ -131,7 +131,7 @@ def test_filter_strict():
 
 def test_filter_ndarray_subclass():
     """Make sure `TensorType.filter` can handle NumPy `ndarray` subclasses."""
-    test_type = TensorType(config.floatX, [False])
+    test_type = TensorType(config.floatX, shape=(None,))
 
     class MyNdarray(np.ndarray):
         pass
@@ -147,7 +147,7 @@ def test_filter_ndarray_subclass():
 def test_filter_float_subclass():
     """Make sure `TensorType.filter` can handle `float` subclasses."""
     with config.change_flags(floatX="float64"):
-        test_type = TensorType("float64", shape=[])
+        test_type = TensorType("float64", shape=())
 
         nan = np.array([np.nan], dtype="float64")[0]
         assert isinstance(nan, float) and not isinstance(nan, np.ndarray)
@@ -157,7 +157,7 @@ def test_filter_float_subclass():
 
     with config.change_flags(floatX="float32"):
         # Try again, except this time `nan` isn't a `float`
-        test_type = TensorType("float32", shape=[])
+        test_type = TensorType("float32", shape=())
 
         nan = np.array([np.nan], dtype="float32")[0]
         assert isinstance(nan, np.floating) and not isinstance(nan, np.ndarray)
@@ -173,7 +173,7 @@ def test_filter_memmap():
     filename = path.join(mkdtemp(), "newfile.dat")
     fp = np.memmap(filename, dtype=config.floatX, mode="w+", shape=(3, 4))
 
-    test_type = TensorType(config.floatX, [False, False])
+    test_type = TensorType(config.floatX, shape=(None, None))
 
     res = test_type.filter(fp)
     assert res is fp
@@ -219,25 +219,25 @@ def test_tensor_values_eq_approx():
 
 
 def test_fixed_shape_basic():
-    t1 = TensorType("float64", (1, 1))
+    t1 = TensorType("float64", shape=(1, 1))
     assert t1.shape == (1, 1)
     assert t1.broadcastable == (True, True)
 
-    t1 = TensorType("float64", (0,))
+    t1 = TensorType("float64", shape=(0,))
     assert t1.shape == (0,)
     assert t1.broadcastable == (False,)
 
-    t1 = TensorType("float64", (False, False))
+    t1 = TensorType("float64", shape=(None, None))
     assert t1.shape == (None, None)
     assert t1.broadcastable == (False, False)
 
-    t1 = TensorType("float64", (2, 3))
+    t1 = TensorType("float64", shape=(2, 3))
     assert t1.shape == (2, 3)
     assert t1.broadcastable == (False, False)
 
     assert str(t1) == "TensorType(float64, (2, 3))"
 
-    t1 = TensorType("float64", (1,))
+    t1 = TensorType("float64", shape=(1,))
     assert t1.shape == (1,)
     assert t1.broadcastable == (True,)
 
@@ -256,13 +256,13 @@ def test_fixed_shape_clone():
     t2 = t1.clone(dtype="float32", shape=(2, 4))
     assert t2.shape == (2, 4)
 
-    t2 = t1.clone(dtype="float32", shape=(False, False))
+    t2 = t1.clone(dtype="float32", shape=(None, None))
     assert t2.shape == (None, None)
 
 
 def test_fixed_shape_comparisons():
-    t1 = TensorType("float64", (True, True))
-    t2 = TensorType("float64", (1, 1))
+    t1 = TensorType("float64", shape=(1, 1))
+    t2 = TensorType("float64", shape=(1, 1))
     assert t1 == t2
 
     assert t1.is_super(t2)
@@ -270,19 +270,19 @@ def test_fixed_shape_comparisons():
 
     assert hash(t1) == hash(t2)
 
-    t3 = TensorType("float64", (True, False))
-    t4 = TensorType("float64", (1, 2))
+    t3 = TensorType("float64", shape=(1, None))
+    t4 = TensorType("float64", shape=(1, 2))
     assert t3 != t4
 
-    t1 = TensorType("float64", (True, True))
-    t2 = TensorType("float64", ())
+    t1 = TensorType("float64", shape=(1, 1))
+    t2 = TensorType("float64", shape=())
     assert t1 != t2
 
 
 def test_fixed_shape_convert_variable():
     # These are equivalent types
-    t1 = TensorType("float64", (True, True))
-    t2 = TensorType("float64", (1, 1))
+    t1 = TensorType("float64", shape=(1, 1))
+    t2 = TensorType("float64", shape=(1, 1))
 
     assert t1 == t2
     assert t1.shape == t2.shape
@@ -298,13 +298,13 @@ def test_fixed_shape_convert_variable():
     res = t2.convert_variable(t1_var)
     assert res is t1_var
 
-    t3 = TensorType("float64", (False, True))
+    t3 = TensorType("float64", shape=(None, 1))
     t3_var = t3()
     res = t2.convert_variable(t3_var)
     assert isinstance(res.owner.op, SpecifyShape)
 
-    t3 = TensorType("float64", (False, False))
-    t4 = TensorType("float64", (3, 2))
+    t3 = TensorType("float64", shape=(None, None))
+    t4 = TensorType("float64", shape=(3, 2))
     t4_var = t4()
     assert t3.shape == (None, None)
     res = t3.convert_variable(t4_var)

--- a/tests/tensor/test_var.py
+++ b/tests/tensor/test_var.py
@@ -155,18 +155,18 @@ def test__getitem__Subtensor():
 
 def test__getitem__AdvancedSubtensor_bool():
     x = matrix("x")
-    i = TensorType("bool", (False, False))("i")
+    i = TensorType("bool", shape=(None, None))("i")
 
     z = x[i]
     op_types = [type(node.op) for node in aesara.graph.basic.io_toposort([x, i], [z])]
     assert op_types[-1] == AdvancedSubtensor
 
-    i = TensorType("bool", (False,))("i")
+    i = TensorType("bool", shape=(None,))("i")
     z = x[:, i]
     op_types = [type(node.op) for node in aesara.graph.basic.io_toposort([x, i], [z])]
     assert op_types[-1] == AdvancedSubtensor
 
-    i = TensorType("bool", (False,))("i")
+    i = TensorType("bool", shape=(None,))("i")
     z = x[..., i]
     op_types = [type(node.op) for node in aesara.graph.basic.io_toposort([x, i], [z])]
     assert op_types[-1] == AdvancedSubtensor
@@ -244,23 +244,25 @@ def test__getitem__newaxis(x, indices, new_order):
 
 
 def test_fixed_shape_variable_basic():
-    x = TensorVariable(TensorType("int64", (4,)), None)
+    x = TensorVariable(TensorType("int64", shape=(4,)), None)
     assert isinstance(x.shape, Constant)
     assert np.array_equal(x.shape.data, (4,))
 
-    x = TensorConstant(TensorType("int64", (False, False)), np.array([[1, 2], [2, 3]]))
+    x = TensorConstant(
+        TensorType("int64", shape=(None, None)), np.array([[1, 2], [2, 3]])
+    )
     assert x.type.shape == (2, 2)
 
     with pytest.raises(ValueError):
-        TensorConstant(TensorType("int64", (True, False)), np.array([[1, 2], [2, 3]]))
+        TensorConstant(TensorType("int64", shape=(1, None)), np.array([[1, 2], [2, 3]]))
 
 
 def test_get_vector_length():
-    x = TensorVariable(TensorType("int64", (4,)), None)
+    x = TensorVariable(TensorType("int64", shape=(4,)), None)
     res = get_vector_length(x)
     assert res == 4
 
-    x = TensorVariable(TensorType("int64", (None,)), None)
+    x = TensorVariable(TensorType("int64", shape=(None,)), None)
     with pytest.raises(ValueError):
         get_vector_length(x)
 

--- a/tests/tensor/utils.py
+++ b/tests/tensor/utils.py
@@ -449,7 +449,9 @@ def makeTester(
                 inputrs = [
                     TensorType(
                         dtype=input.dtype,
-                        shape=[shape_elem == 1 for shape_elem in input.shape],
+                        shape=tuple(
+                            1 if shape_elem == 1 else None for shape_elem in input.shape
+                        ),
                     )()
                     for input in inputs
                 ]
@@ -611,7 +613,9 @@ def makeTester(
                 inputrs = [
                     TensorType(
                         dtype=input.dtype,
-                        shape=[shape_elem == 1 for shape_elem in input.shape],
+                        shape=tuple(
+                            1 if shape_elem == 1 else None for shape_elem in input.shape
+                        ),
                     )()
                     for input in inputs
                 ]
@@ -632,8 +636,10 @@ def makeTester(
                         dtype = config.floatX
                     else:
                         dtype = str(out.dtype)
-                    bcast = [shape_elem == 1 for shape_elem in out.shape]
-                    var = TensorType(dtype=dtype, shape=bcast)()
+                    out_shape = tuple(
+                        1 if shape_elem == 1 else None for shape_elem in out.shape
+                    )
+                    var = TensorType(dtype=dtype, shape=out_shape)()
                     out_grad_vars.append(var)
 
                 try:

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -282,7 +282,7 @@ def test_debugprint():
          |   |   |B
          |   |TensorConstant{1.0}
          |   |B
-         |   |<TensorType(float64, (None,))>
+         |   |<TensorType(float64, (?,))>
          |   |TensorConstant{0.0}
          |D
         """
@@ -306,9 +306,9 @@ def test_debugprint_id_type():
 
     exp_res = f"""Elemwise{{add,no_inplace}} [id {e_at.auto_name}]
  |dot [id {d_at.auto_name}]
- | |<TensorType(float64, (None, None))> [id {b_at.auto_name}]
- | |<TensorType(float64, (None,))> [id {a_at.auto_name}]
- |<TensorType(float64, (None,))> [id {a_at.auto_name}]
+ | |<TensorType(float64, (?, ?))> [id {b_at.auto_name}]
+ | |<TensorType(float64, (?,))> [id {a_at.auto_name}]
+ |<TensorType(float64, (?,))> [id {a_at.auto_name}]
     """
 
     assert [l.strip() for l in s.split("\n")] == [
@@ -319,7 +319,7 @@ def test_debugprint_id_type():
 def test_pprint():
     x = dvector()
     y = x[1]
-    assert pp(y) == "<TensorType(float64, (None,))>[1]"
+    assert pp(y) == "<TensorType(float64, (?,))>[1]"
 
 
 def test_debugprint_inner_graph():

--- a/tests/typed_list/test_basic.py
+++ b/tests/typed_list/test_basic.py
@@ -57,7 +57,7 @@ class TestGetItem:
     def test_sanity_check_slice(self):
 
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         mySymbolicSlice = SliceType()()
@@ -75,7 +75,7 @@ class TestGetItem:
     def test_sanity_check_single(self):
 
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         mySymbolicScalar = scalar(dtype="int64")
@@ -90,7 +90,7 @@ class TestGetItem:
 
     def test_interface(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         mySymbolicScalar = scalar(dtype="int64")
 
@@ -110,7 +110,7 @@ class TestGetItem:
 
     def test_wrong_input(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         mySymbolicMatrix = matrix()
 
@@ -119,7 +119,7 @@ class TestGetItem:
 
     def test_constant_input(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         z = GetItem()(mySymbolicMatricesList, 0)
@@ -140,7 +140,7 @@ class TestGetItem:
 class TestAppend:
     def test_inplace(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         myMatrix = matrix()
 
@@ -156,7 +156,7 @@ class TestAppend:
 
     def test_sanity_check(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         myMatrix = matrix()
 
@@ -172,7 +172,7 @@ class TestAppend:
 
     def test_interfaces(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         myMatrix = matrix()
 
@@ -190,10 +190,10 @@ class TestAppend:
 class TestExtend:
     def test_inplace(self):
         mySymbolicMatricesList1 = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         mySymbolicMatricesList2 = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         z = Extend(True)(mySymbolicMatricesList1, mySymbolicMatricesList2)
@@ -210,10 +210,10 @@ class TestExtend:
 
     def test_sanity_check(self):
         mySymbolicMatricesList1 = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         mySymbolicMatricesList2 = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         z = Extend()(mySymbolicMatricesList1, mySymbolicMatricesList2)
@@ -228,10 +228,10 @@ class TestExtend:
 
     def test_interface(self):
         mySymbolicMatricesList1 = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         mySymbolicMatricesList2 = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         z = mySymbolicMatricesList1.extend(mySymbolicMatricesList2)
@@ -248,7 +248,7 @@ class TestExtend:
 class TestInsert:
     def test_inplace(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         myMatrix = matrix()
         myScalar = scalar(dtype="int64")
@@ -267,7 +267,7 @@ class TestInsert:
 
     def test_sanity_check(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         myMatrix = matrix()
         myScalar = scalar(dtype="int64")
@@ -284,7 +284,7 @@ class TestInsert:
 
     def test_interface(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         myMatrix = matrix()
         myScalar = scalar(dtype="int64")
@@ -303,7 +303,7 @@ class TestInsert:
 class TestRemove:
     def test_inplace(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         myMatrix = matrix()
 
@@ -319,7 +319,7 @@ class TestRemove:
 
     def test_sanity_check(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         myMatrix = matrix()
 
@@ -335,7 +335,7 @@ class TestRemove:
 
     def test_interface(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         myMatrix = matrix()
 
@@ -353,7 +353,7 @@ class TestRemove:
 class TestReverse:
     def test_inplace(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         z = Reverse(True)(mySymbolicMatricesList)
@@ -368,7 +368,7 @@ class TestReverse:
 
     def test_sanity_check(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         z = Reverse()(mySymbolicMatricesList)
@@ -383,7 +383,7 @@ class TestReverse:
 
     def test_interface(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         z = mySymbolicMatricesList.reverse()
@@ -400,7 +400,7 @@ class TestReverse:
 class TestIndex:
     def test_sanity_check(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         myMatrix = matrix()
 
@@ -416,7 +416,7 @@ class TestIndex:
 
     def test_interface(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         myMatrix = matrix()
 
@@ -432,10 +432,10 @@ class TestIndex:
 
     def test_non_tensor_type(self):
         mySymbolicNestedMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False)), 1
+            TensorType(aesara.config.floatX, shape=(None, None)), 1
         )()
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         z = Index()(mySymbolicNestedMatricesList, mySymbolicMatricesList)
@@ -468,7 +468,7 @@ class TestIndex:
 class TestCount:
     def test_sanity_check(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         myMatrix = matrix()
 
@@ -484,7 +484,7 @@ class TestCount:
 
     def test_interface(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         myMatrix = matrix()
 
@@ -500,10 +500,10 @@ class TestCount:
 
     def test_non_tensor_type(self):
         mySymbolicNestedMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False)), 1
+            TensorType(aesara.config.floatX, shape=(None, None)), 1
         )()
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         z = Count()(mySymbolicNestedMatricesList, mySymbolicMatricesList)
@@ -536,7 +536,7 @@ class TestCount:
 class TestLength:
     def test_sanity_check(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         z = Length()(mySymbolicMatricesList)
@@ -549,7 +549,7 @@ class TestLength:
 
     def test_interface(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         z = mySymbolicMatricesList.__len__()
 

--- a/tests/typed_list/test_rewriting.py
+++ b/tests/typed_list/test_rewriting.py
@@ -13,7 +13,7 @@ from tests.tensor.utils import random_ranged
 class TestInplace:
     def test_reverse_inplace(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         z = Reverse()(mySymbolicMatricesList)
@@ -36,7 +36,7 @@ class TestInplace:
 
     def test_append_inplace(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         mySymbolicMatrix = matrix()
         z = Append()(mySymbolicMatricesList, mySymbolicMatrix)
@@ -62,11 +62,11 @@ class TestInplace:
 
     def test_extend_inplace(self):
         mySymbolicMatricesList1 = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         mySymbolicMatricesList2 = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         z = Extend()(mySymbolicMatricesList1, mySymbolicMatricesList2)
@@ -91,7 +91,7 @@ class TestInplace:
 
     def test_insert_inplace(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         mySymbolicIndex = scalar(dtype="int64")
         mySymbolicMatrix = matrix()
@@ -121,7 +121,7 @@ class TestInplace:
 
     def test_remove_inplace(self):
         mySymbolicMatricesList = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
         mySymbolicMatrix = matrix()
         z = Remove()(mySymbolicMatricesList, mySymbolicMatrix)

--- a/tests/typed_list/test_type.py
+++ b/tests/typed_list/test_type.py
@@ -24,7 +24,7 @@ class TestTypedListType:
         # specified on creation
 
         # list of matrices
-        myType = TypedListType(TensorType(aesara.config.floatX, (False, False)))
+        myType = TypedListType(TensorType(aesara.config.floatX, shape=(None, None)))
 
         with pytest.raises(TypeError):
             myType.filter([4])
@@ -34,7 +34,7 @@ class TestTypedListType:
         # if no iterable variable is given on input
 
         # list of matrices
-        myType = TypedListType(TensorType(aesara.config.floatX, (False, False)))
+        myType = TypedListType(TensorType(aesara.config.floatX, shape=(None, None)))
 
         with pytest.raises(TypeError):
             myType.filter(4)
@@ -45,11 +45,11 @@ class TestTypedListType:
         # variables
 
         # list of matrices
-        myType1 = TypedListType(TensorType(aesara.config.floatX, (False, False)))
+        myType1 = TypedListType(TensorType(aesara.config.floatX, shape=(None, None)))
         # list of matrices
-        myType2 = TypedListType(TensorType(aesara.config.floatX, (False, False)))
+        myType2 = TypedListType(TensorType(aesara.config.floatX, shape=(None, None)))
         # list of scalars
-        myType3 = TypedListType(TensorType(aesara.config.floatX, ()))
+        myType3 = TypedListType(TensorType(aesara.config.floatX, shape=()))
 
         assert myType2 == myType1
         assert myType3 != myType1
@@ -57,7 +57,7 @@ class TestTypedListType:
     def test_filter_sanity_check(self):
         # Simple test on typed list type filter
 
-        myType = TypedListType(TensorType(aesara.config.floatX, (False, False)))
+        myType = TypedListType(TensorType(aesara.config.floatX, shape=(None, None)))
 
         x = random_ranged(-1000, 1000, [100, 100])
 
@@ -68,14 +68,14 @@ class TestTypedListType:
         # filtered. If they weren't this code would raise
         # an exception.
 
-        myType = TypedListType(TensorType("float64", (False, False)))
+        myType = TypedListType(TensorType("float64", shape=(None, None)))
 
         x = np.asarray([[4, 5], [4, 5]], dtype="float32")
 
         assert np.array_equal(myType.filter([x]), [x])
 
     def test_load_alot(self):
-        myType = TypedListType(TensorType(aesara.config.floatX, (False, False)))
+        myType = TypedListType(TensorType(aesara.config.floatX, shape=(None, None)))
 
         x = random_ranged(-1000, 1000, [10, 10])
         testList = []
@@ -87,7 +87,9 @@ class TestTypedListType:
     def test_basic_nested_list(self):
         # Testing nested list with one level of depth
 
-        myNestedType = TypedListType(TensorType(aesara.config.floatX, (False, False)))
+        myNestedType = TypedListType(
+            TensorType(aesara.config.floatX, shape=(None, None))
+        )
 
         myType = TypedListType(myNestedType)
 
@@ -98,7 +100,9 @@ class TestTypedListType:
     def test_comparison_different_depth(self):
         # Nested list with different depth aren't the same
 
-        myNestedType = TypedListType(TensorType(aesara.config.floatX, (False, False)))
+        myNestedType = TypedListType(
+            TensorType(aesara.config.floatX, shape=(None, None))
+        )
 
         myNestedType2 = TypedListType(myNestedType)
 
@@ -110,10 +114,10 @@ class TestTypedListType:
         # test for the 'depth' optional argument
 
         myNestedType = TypedListType(
-            TensorType(aesara.config.floatX, (False, False)), 3
+            TensorType(aesara.config.floatX, shape=(None, None)), 3
         )
 
-        myType = TypedListType(TensorType(aesara.config.floatX, (False, False)))
+        myType = TypedListType(TensorType(aesara.config.floatX, shape=(None, None)))
 
         myManualNestedType = TypedListType(TypedListType(TypedListType(myType)))
 
@@ -122,7 +126,7 @@ class TestTypedListType:
     def test_get_depth(self):
         # test case for get_depth utilitary function
 
-        myType = TypedListType(TensorType(aesara.config.floatX, (False, False)))
+        myType = TypedListType(TensorType(aesara.config.floatX, shape=(None, None)))
 
         myManualNestedType = TypedListType(TypedListType(TypedListType(myType)))
 
@@ -131,7 +135,7 @@ class TestTypedListType:
     def test_comparison_uneven_nested(self):
         # test for comparison between uneven nested list
 
-        myType = TypedListType(TensorType(aesara.config.floatX, (False, False)))
+        myType = TypedListType(TensorType(aesara.config.floatX, shape=(None, None)))
 
         myManualNestedType1 = TypedListType(TypedListType(TypedListType(myType)))
 
@@ -142,7 +146,7 @@ class TestTypedListType:
 
     def test_variable_is_Typed_List_variable(self):
         mySymbolicVariable = TypedListType(
-            TensorType(aesara.config.floatX, (False, False))
+            TensorType(aesara.config.floatX, shape=(None, None))
         )()
 
         assert isinstance(mySymbolicVariable, TypedListVariable)


### PR DESCRIPTION
This PR contains important and independent `TensorType.shape` refactoring from #1280.  Aside from superficial `TensorType.broadcastable`-to-`TensorType.shape` refactoring, these changes contain improvements to our static `Type`-level shape inference capabilities.