### PR TITLE
Use `numba.jit` to create Numba functions

### DIFF
--- a/aesara/link/numba/dispatch/__init__.py
+++ b/aesara/link/numba/dispatch/__init__.py
@@ -2,7 +2,7 @@
 from aesara.link.numba.dispatch.basic import (
     numba_funcify,
     numba_const_convert,
-    numba_njit,
+    numba_jit,
 )
 
 # Load dispatch specializations

--- a/aesara/link/numba/dispatch/extra_ops.py
+++ b/aesara/link/numba/dispatch/extra_ops.py
@@ -23,7 +23,7 @@ from aesara.tensor.extra_ops import (
 
 @_numba_funcify.register(Bartlett)
 def numba_funcify_Bartlett(op, **kwargs):
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def bartlett(x):
         return np.bartlett(numba_basic.to_scalar(x))
 
@@ -45,7 +45,7 @@ def numba_funcify_CumOp(op, node, **kwargs):
         np_func = np.multiply
         identity = 1
 
-    @numba_basic.numba_njit(boundscheck=False, fastmath=config.numba__fastmath)
+    @numba_basic.numba_jit(boundscheck=False, fastmath=config.numba__fastmath)
     def cumop(x):
         out_dtype = x.dtype
         if x.shape[axis] < 2:
@@ -67,7 +67,7 @@ def numba_funcify_CumOp(op, node, **kwargs):
 
 @_numba_funcify.register(FillDiagonal)
 def numba_funcify_FillDiagonal(op, **kwargs):
-    @numba_basic.numba_njit
+    @numba_basic.numba_jit
     def filldiagonal(a, val):
         np.fill_diagonal(a, val)
         return a
@@ -77,7 +77,7 @@ def numba_funcify_FillDiagonal(op, **kwargs):
 
 @_numba_funcify.register(FillDiagonalOffset)
 def numba_funcify_FillDiagonalOffset(op, node, **kwargs):
-    @numba_basic.numba_njit
+    @numba_basic.numba_jit
     def filldiagonaloffset(a, val, offset):
         height, width = a.shape
 
@@ -113,25 +113,25 @@ def numba_funcify_RavelMultiIndex(op, node, **kwargs):
 
     if mode == "raise":
 
-        @numba_basic.numba_njit
+        @numba_basic.numba_jit
         def mode_fn(*args):
             raise ValueError("invalid entry in coordinates array")
 
     elif mode == "wrap":
 
-        @numba_basic.numba_njit(inline="always")
+        @numba_basic.numba_jit(inline="always")
         def mode_fn(new_arr, i, j, v, d):
             new_arr[i, j] = v % d
 
     elif mode == "clip":
 
-        @numba_basic.numba_njit(inline="always")
+        @numba_basic.numba_jit(inline="always")
         def mode_fn(new_arr, i, j, v, d):
             new_arr[i, j] = min(max(v, 0), d - 1)
 
     if node.inputs[0].ndim == 0:
 
-        @numba_basic.numba_njit
+        @numba_basic.numba_jit
         def ravelmultiindex(*inp):
             shape = inp[-1]
             arr = np.stack(inp[:-1])
@@ -147,7 +147,7 @@ def numba_funcify_RavelMultiIndex(op, node, **kwargs):
 
     else:
 
-        @numba_basic.numba_njit
+        @numba_basic.numba_jit
         def ravelmultiindex(*inp):
             shape = inp[-1]
             arr = np.stack(inp[:-1])
@@ -186,7 +186,7 @@ def numba_funcify_Repeat(op, node, **kwargs):
 
         ret_sig = get_numba_type(node.outputs[0].type)
 
-        @numba_basic.numba_njit
+        @numba_basic.numba_jit
         def repeatop(x, repeats):
             with numba.objmode(ret=ret_sig):
                 ret = np.repeat(x, repeats, axis)
@@ -197,13 +197,13 @@ def numba_funcify_Repeat(op, node, **kwargs):
 
         if repeats_ndim == 0:
 
-            @numba_basic.numba_njit(inline="always")
+            @numba_basic.numba_jit(inline="always")
             def repeatop(x, repeats):
                 return np.repeat(x, repeats.item())
 
         else:
 
-            @numba_basic.numba_njit(inline="always")
+            @numba_basic.numba_jit(inline="always")
             def repeatop(x, repeats):
                 return np.repeat(x, repeats)
 
@@ -228,7 +228,7 @@ def numba_funcify_Unique(op, node, **kwargs):
 
     if not use_python:
 
-        @numba_basic.numba_njit(inline="always")
+        @numba_basic.numba_jit(inline="always")
         def unique(x):
             return np.unique(x)
 
@@ -247,7 +247,7 @@ def numba_funcify_Unique(op, node, **kwargs):
         else:
             ret_sig = get_numba_type(node.outputs[0].type)
 
-        @numba_basic.numba_njit
+        @numba_basic.numba_jit
         def unique(x):
             with numba.objmode(ret=ret_sig):
                 ret = np.unique(x, return_index, return_inverse, return_counts, axis)
@@ -267,17 +267,17 @@ def numba_funcify_UnravelIndex(op, node, **kwargs):
 
     if len(node.outputs) == 1:
 
-        @numba_basic.numba_njit(inline="always")
+        @numba_basic.numba_jit(inline="always")
         def maybe_expand_dim(arr):
             return arr
 
     else:
 
-        @numba_basic.numba_njit(inline="always")
+        @numba_basic.numba_jit(inline="always")
         def maybe_expand_dim(arr):
             return np.expand_dims(arr, 1)
 
-    @numba_basic.numba_njit
+    @numba_basic.numba_jit
     def unravelindex(arr, shape):
         a = np.ones(len(shape), dtype=np.int64)
         a[1:] = shape[:0:-1]
@@ -310,7 +310,7 @@ def numba_funcify_Searchsorted(op, node, **kwargs):
 
         ret_sig = get_numba_type(node.outputs[0].type)
 
-        @numba_basic.numba_njit
+        @numba_basic.numba_jit
         def searchsorted(a, v, sorter):
             with numba.objmode(ret=ret_sig):
                 ret = np.searchsorted(a, v, side, sorter)
@@ -318,7 +318,7 @@ def numba_funcify_Searchsorted(op, node, **kwargs):
 
     else:
 
-        @numba_basic.numba_njit(inline="always")
+        @numba_basic.numba_jit(inline="always")
         def searchsorted(a, v):
             return np.searchsorted(a, v, side)
 
@@ -332,7 +332,7 @@ def numba_funcify_BroadcastTo(op, node, **kwargs):
         lambda _: 0, len(node.inputs) - 1
     )
 
-    @numba_basic.numba_njit
+    @numba_basic.numba_jit
     def broadcast_to(x, *shape):
         scalars_shape = create_zeros_tuple()
 

--- a/aesara/link/numba/dispatch/nlinalg.py
+++ b/aesara/link/numba/dispatch/nlinalg.py
@@ -38,7 +38,7 @@ def numba_funcify_SVD(op, node, **kwargs):
 
         ret_sig = get_numba_type(node.outputs[0].type)
 
-        @numba_basic.numba_njit
+        @numba_basic.numba_jit
         def svd(x):
             with numba.objmode(ret=ret_sig):
                 ret = np.linalg.svd(x, full_matrices, compute_uv)
@@ -49,7 +49,7 @@ def numba_funcify_SVD(op, node, **kwargs):
         out_dtype = node.outputs[0].type.numpy_dtype
         inputs_cast = int_to_float_fn(node.inputs, out_dtype)
 
-        @numba_basic.numba_njit(inline="always")
+        @numba_basic.numba_jit(inline="always")
         def svd(x):
             return np.linalg.svd(inputs_cast(x), full_matrices)
 
@@ -62,7 +62,7 @@ def numba_funcify_Det(op, node, **kwargs):
     out_dtype = node.outputs[0].type.numpy_dtype
     inputs_cast = int_to_float_fn(node.inputs, out_dtype)
 
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def det(x):
         return numba_basic.direct_cast(np.linalg.det(inputs_cast(x)), out_dtype)
 
@@ -77,7 +77,7 @@ def numba_funcify_Eig(op, node, **kwargs):
 
     inputs_cast = int_to_float_fn(node.inputs, out_dtype_1)
 
-    @numba_basic.numba_njit
+    @numba_basic.numba_jit
     def eig(x):
         out = np.linalg.eig(inputs_cast(x))
         return (out[0].astype(out_dtype_1), out[1].astype(out_dtype_2))
@@ -104,7 +104,7 @@ def numba_funcify_Eigh(op, node, **kwargs):
             [get_numba_type(node.outputs[0].type), get_numba_type(node.outputs[1].type)]
         )
 
-        @numba_basic.numba_njit
+        @numba_basic.numba_jit
         def eigh(x):
             with numba.objmode(ret=ret_sig):
                 out = np.linalg.eigh(x, UPLO=uplo)
@@ -113,7 +113,7 @@ def numba_funcify_Eigh(op, node, **kwargs):
 
     else:
 
-        @numba_basic.numba_njit(inline="always")
+        @numba_basic.numba_jit(inline="always")
         def eigh(x):
             return np.linalg.eigh(x)
 
@@ -126,7 +126,7 @@ def numba_funcify_Inv(op, node, **kwargs):
     out_dtype = node.outputs[0].type.numpy_dtype
     inputs_cast = int_to_float_fn(node.inputs, out_dtype)
 
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def inv(x):
         return np.linalg.inv(inputs_cast(x)).astype(out_dtype)
 
@@ -139,7 +139,7 @@ def numba_funcify_MatrixInverse(op, node, **kwargs):
     out_dtype = node.outputs[0].type.numpy_dtype
     inputs_cast = int_to_float_fn(node.inputs, out_dtype)
 
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def matrix_inverse(x):
         return np.linalg.inv(inputs_cast(x)).astype(out_dtype)
 
@@ -152,7 +152,7 @@ def numba_funcify_MatrixPinv(op, node, **kwargs):
     out_dtype = node.outputs[0].type.numpy_dtype
     inputs_cast = int_to_float_fn(node.inputs, out_dtype)
 
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def matrixpinv(x):
         return np.linalg.pinv(inputs_cast(x)).astype(out_dtype)
 
@@ -177,7 +177,7 @@ def numba_funcify_QRFull(op, node, **kwargs):
         else:
             ret_sig = get_numba_type(node.outputs[0].type)
 
-        @numba_basic.numba_njit
+        @numba_basic.numba_jit
         def qr_full(x):
             with numba.objmode(ret=ret_sig):
                 ret = np.linalg.qr(x, mode=mode)
@@ -188,7 +188,7 @@ def numba_funcify_QRFull(op, node, **kwargs):
         out_dtype = node.outputs[0].type.numpy_dtype
         inputs_cast = int_to_float_fn(node.inputs, out_dtype)
 
-        @numba_basic.numba_njit(inline="always")
+        @numba_basic.numba_jit(inline="always")
         def qr_full(x):
             return np.linalg.qr(inputs_cast(x))
 

--- a/aesara/link/numba/dispatch/random.py
+++ b/aesara/link/numba/dispatch/random.py
@@ -49,7 +49,7 @@ class RandomStateNumbaModel(models.StructModel):
         members = [
             # TODO: We can add support for boxing and unboxing
             # the attributes that describe a RandomState so that
-            # they can be accessed inside njit functions, if required.
+            # they can be accessed inside jit functions, if required.
             ("state_key", types.Array(types.uint32, 1, "C")),
         ]
         models.StructModel.__init__(self, dmm, fe_type, members)
@@ -202,7 +202,7 @@ def {sized_fn_name}({random_fn_input_names}):
     random_fn = compile_function_src(
         sized_fn_src, sized_fn_name, {**globals(), **random_fn_global_env}
     )
-    random_fn = numba_basic.numba_njit(random_fn)
+    random_fn = numba_basic.numba_jit(random_fn)
 
     return random_fn
 
@@ -331,7 +331,7 @@ def numba_funcify_CategoricalRV(op, node, **kwargs):
     out_dtype = node.outputs[1].type.numpy_dtype
     size_len = int(get_vector_length(node.inputs[1]))
 
-    @numba_basic.numba_njit
+    @numba_basic.numba_jit
     def categorical_rv(rng, size, dtype, p):
         if not size_len:
             size_tpl = p.shape[:-1]
@@ -360,7 +360,7 @@ def numba_funcify_DirichletRV(op, node, **kwargs):
 
     if alphas_ndim > 1:
 
-        @numba_basic.numba_njit
+        @numba_basic.numba_jit
         def dirichlet_rv(rng, size, dtype, alphas):
 
             if size_len > 0:
@@ -384,7 +384,7 @@ def numba_funcify_DirichletRV(op, node, **kwargs):
 
     else:
 
-        @numba_basic.numba_njit
+        @numba_basic.numba_jit
         def dirichlet_rv(rng, size, dtype, alphas):
             size = numba_ndarray.to_fixed_tuple(size, size_len)
             return (rng, np.random.dirichlet(alphas, size))

--- a/aesara/link/numba/dispatch/scalar.py
+++ b/aesara/link/numba/dispatch/scalar.py
@@ -125,14 +125,14 @@ def {scalar_op_fn_name}({', '.join(input_names)}):
 
     signature = create_numba_signature(node, force_scalar=True)
 
-    return numba_basic.numba_njit(
+    return numba_basic.numba_jit(
         signature, inline="always", fastmath=config.numba__fastmath
     )(scalar_op_fn)
 
 
 @_numba_funcify.register(Switch)
 def numba_funcify_Switch(op, node, **kwargs):
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def switch(condition, x, y):
         if condition:
             return x
@@ -165,7 +165,7 @@ def numba_funcify_Add(op, node, **kwargs):
 
     nary_add_fn = binary_to_nary_func(node.inputs, "add", "+")
 
-    return numba_basic.numba_njit(
+    return numba_basic.numba_jit(
         signature, inline="always", fastmath=config.numba__fastmath
     )(nary_add_fn)
 
@@ -177,7 +177,7 @@ def numba_funcify_Mul(op, node, **kwargs):
 
     nary_mul_fn = binary_to_nary_func(node.inputs, "mul", "*")
 
-    return numba_basic.numba_njit(
+    return numba_basic.numba_jit(
         signature, inline="always", fastmath=config.numba__fastmath
     )(nary_mul_fn)
 
@@ -187,7 +187,7 @@ def numba_funcify_Cast(op, node, **kwargs):
 
     dtype = np.dtype(op.o_type.dtype)
 
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def cast(x):
         return numba_basic.direct_cast(x, dtype)
 
@@ -197,7 +197,7 @@ def numba_funcify_Cast(op, node, **kwargs):
 @_numba_funcify.register(Identity)
 @_numba_funcify.register(ViewOp)
 def numba_funcify_ViewOp(op, **kwargs):
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def viewop(x):
         return x
 
@@ -206,7 +206,7 @@ def numba_funcify_ViewOp(op, **kwargs):
 
 @_numba_funcify.register(Clip)
 def numba_funcify_Clip(op, **kwargs):
-    @numba_basic.numba_njit
+    @numba_basic.numba_jit
     def clip(_x, _min, _max):
         x = numba_basic.to_scalar(_x)
         _min_scalar = numba_basic.to_scalar(_min)
@@ -228,7 +228,7 @@ def numba_funcify_Composite(op, node, **kwargs):
 
     _ = kwargs.pop("storage_map", None)
 
-    composite_fn = numba_basic.numba_njit(signature, fastmath=config.numba__fastmath)(
+    composite_fn = numba_basic.numba_jit(signature, fastmath=config.numba__fastmath)(
         numba_funcify(op.fgraph, squeeze_output=True, **kwargs)
     )
     return composite_fn
@@ -236,7 +236,7 @@ def numba_funcify_Composite(op, node, **kwargs):
 
 @_numba_funcify.register(Second)
 def numba_funcify_Second(op, node, **kwargs):
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def second(x, y):
         return y
 
@@ -245,7 +245,7 @@ def numba_funcify_Second(op, node, **kwargs):
 
 @_numba_funcify.register(Reciprocal)
 def numba_funcify_Reciprocal(op, node, **kwargs):
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def reciprocal(x):
         # TODO FIXME: This isn't really the behavior or `numpy.reciprocal` when
         # `x` is an `int`
@@ -256,7 +256,7 @@ def numba_funcify_Reciprocal(op, node, **kwargs):
 
 @_numba_funcify.register(Sigmoid)
 def numba_funcify_Sigmoid(op, node, **kwargs):
-    @numba_basic.numba_njit(inline="always", fastmath=config.numba__fastmath)
+    @numba_basic.numba_jit(inline="always", fastmath=config.numba__fastmath)
     def sigmoid(x):
         return 1 / (1 + np.exp(-x))
 
@@ -265,7 +265,7 @@ def numba_funcify_Sigmoid(op, node, **kwargs):
 
 @_numba_funcify.register(GammaLn)
 def numba_funcify_GammaLn(op, node, **kwargs):
-    @numba_basic.numba_njit(inline="always", fastmath=config.numba__fastmath)
+    @numba_basic.numba_jit(inline="always", fastmath=config.numba__fastmath)
     def gammaln(x):
         return math.lgamma(x)
 
@@ -274,7 +274,7 @@ def numba_funcify_GammaLn(op, node, **kwargs):
 
 @_numba_funcify.register(Log1mexp)
 def numba_funcify_Log1mexp(op, node, **kwargs):
-    @numba_basic.numba_njit(inline="always", fastmath=config.numba__fastmath)
+    @numba_basic.numba_jit(inline="always", fastmath=config.numba__fastmath)
     def logp1mexp(x):
         if x < np.log(0.5):
             return np.log1p(-np.exp(x))
@@ -286,7 +286,7 @@ def numba_funcify_Log1mexp(op, node, **kwargs):
 
 @_numba_funcify.register(Erf)
 def numba_funcify_Erf(op, **kwargs):
-    @numba_basic.numba_njit(inline="always", fastmath=config.numba__fastmath)
+    @numba_basic.numba_jit(inline="always", fastmath=config.numba__fastmath)
     def erf(x):
         return math.erf(x)
 
@@ -295,7 +295,7 @@ def numba_funcify_Erf(op, **kwargs):
 
 @_numba_funcify.register(Erfc)
 def numba_funcify_Erfc(op, **kwargs):
-    @numba_basic.numba_njit(inline="always", fastmath=config.numba__fastmath)
+    @numba_basic.numba_jit(inline="always", fastmath=config.numba__fastmath)
     def erfc(x):
         return math.erfc(x)
 

--- a/aesara/link/numba/dispatch/scan.py
+++ b/aesara/link/numba/dispatch/scan.py
@@ -48,7 +48,7 @@ def array0d_range(x):
 
 @_numba_funcify.register(Scan)
 def numba_funcify_Scan(op, node, **kwargs):
-    scan_inner_func = numba_basic.numba_njit(numba_funcify(op.fgraph))
+    scan_inner_func = numba_basic.numba_jit(numba_funcify(op.fgraph))
 
     outer_in_names_to_vars = {
         (f"outer_in_{i}" if i > 0 else "n_steps"): v for i, v in enumerate(node.inputs)
@@ -353,4 +353,4 @@ def scan({", ".join(outer_in_names)}):
         scan_op_src, "scan", {**globals(), **global_env}
     )
 
-    return numba_basic.numba_njit(scalar_op_fn)
+    return numba_basic.numba_jit(scalar_op_fn)

--- a/aesara/link/numba/dispatch/tensor_basic.py
+++ b/aesara/link/numba/dispatch/tensor_basic.py
@@ -56,7 +56,7 @@ def allocempty({", ".join(shape_var_names)}):
         alloc_def_src, "allocempty", {**globals(), **global_env}
     )
 
-    return numba_basic.numba_njit(alloc_fn)
+    return numba_basic.numba_jit(alloc_fn)
 
 
 @_numba_funcify.register(Alloc)
@@ -92,14 +92,14 @@ def alloc(val, {", ".join(shape_var_names)}):
 
     alloc_fn = compile_function_src(alloc_def_src, "alloc", {**globals(), **global_env})
 
-    return numba_basic.numba_njit(alloc_fn)
+    return numba_basic.numba_jit(alloc_fn)
 
 
 @_numba_funcify.register(AllocDiag)
 def numba_funcify_AllocDiag(op, **kwargs):
     offset = op.offset
 
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def allocdiag(v):
         return np.diag(v, k=offset)
 
@@ -110,7 +110,7 @@ def numba_funcify_AllocDiag(op, **kwargs):
 def numba_funcify_ARange(op, **kwargs):
     dtype = np.dtype(op.dtype)
 
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def arange(start, stop, step):
         return np.arange(
             numba_basic.to_scalar(start),
@@ -132,7 +132,7 @@ def numba_funcify_Join(op, **kwargs):
         # probably just remove it.
         raise NotImplementedError("The `view` parameter to `Join` is not supported")
 
-    @numba_basic.numba_njit
+    @numba_basic.numba_jit
     def join(axis, *tensors):
         return np.concatenate(tensors, numba_basic.to_scalar(axis))
 
@@ -141,7 +141,7 @@ def numba_funcify_Join(op, **kwargs):
 
 @_numba_funcify.register(Split)
 def numba_funcify_Split(op, **kwargs):
-    @numba_basic.numba_njit
+    @numba_basic.numba_jit
     def split(tensor, axis, indices):
         # Work around for https://github.com/numba/numba/issues/8257
         axis = axis % tensor.ndim
@@ -157,7 +157,7 @@ def numba_funcify_ExtractDiag(op, **kwargs):
     # axis1 = op.axis1
     # axis2 = op.axis2
 
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def extract_diag(x):
         return np.diag(x, k=offset)
 
@@ -168,7 +168,7 @@ def numba_funcify_ExtractDiag(op, **kwargs):
 def numba_funcify_Eye(op, **kwargs):
     dtype = np.dtype(op.dtype)
 
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def eye(N, M, k):
         return np.eye(
             numba_basic.to_scalar(N),
@@ -205,12 +205,12 @@ def makevector({", ".join(input_names)}):
         makevector_def_src, "makevector", {**globals(), **global_env}
     )
 
-    return numba_basic.numba_njit(makevector_fn)
+    return numba_basic.numba_jit(makevector_fn)
 
 
 @_numba_funcify.register(Unbroadcast)
 def numba_funcify_Unbroadcast(op, **kwargs):
-    @numba_basic.numba_njit
+    @numba_basic.numba_jit
     def unbroadcast(x):
         return x
 
@@ -219,7 +219,7 @@ def numba_funcify_Unbroadcast(op, **kwargs):
 
 @_numba_funcify.register(TensorFromScalar)
 def numba_funcify_TensorFromScalar(op, **kwargs):
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def tensor_from_scalar(x):
         return np.array(x)
 
@@ -228,7 +228,7 @@ def numba_funcify_TensorFromScalar(op, **kwargs):
 
 @_numba_funcify.register(ScalarFromTensor)
 def numba_funcify_ScalarFromTensor(op, **kwargs):
-    @numba_basic.numba_njit(inline="always")
+    @numba_basic.numba_jit(inline="always")
     def scalar_from_tensor(x):
         return numba_basic.to_scalar(x)
 

--- a/aesara/link/numba/linker.py
+++ b/aesara/link/numba/linker.py
@@ -27,9 +27,9 @@ class NumbaLinker(JITLinker):
         return numba_funcify(fgraph, **kwargs)
 
     def jit_compile(self, fn):
-        from aesara.link.numba.dispatch import numba_njit
+        from aesara.link.numba.dispatch import numba_jit
 
-        jitted_fn = numba_njit(fn)
+        jitted_fn = numba_jit(fn)
         return jitted_fn
 
     def create_thunk_inputs(self, storage_map):

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -120,7 +120,7 @@ def eval_python_only(fn_inputs, fn_outputs, inputs, mode=numba_mode):
         else:
             return x
 
-    def njit_noop(*args, **kwargs):
+    def jit_noop(*args, **kwargs):
         if len(args) == 1 and callable(args[0]):
             return args[0]
         else:
@@ -151,10 +151,10 @@ def eval_python_only(fn_inputs, fn_outputs, inputs, mode=numba_mode):
             return wrap
 
     mocks = [
-        mock.patch("numba.njit", njit_noop),
+        mock.patch("numba.jit", jit_noop),
         mock.patch("numba.vectorize", vectorize_noop),
         mock.patch("aesara.link.numba.dispatch.basic.tuple_setitem", py_tuple_setitem),
-        mock.patch("aesara.link.numba.dispatch.basic.numba_njit", njit_noop),
+        mock.patch("aesara.link.numba.dispatch.basic.numba_jit", jit_noop),
         mock.patch("aesara.link.numba.dispatch.basic.numba_vectorize", vectorize_noop),
         mock.patch("aesara.link.numba.dispatch.basic.direct_cast", lambda x, dtype: x),
         mock.patch("aesara.link.numba.dispatch.basic.to_scalar", py_to_scalar),


### PR DESCRIPTION
This PR attempts to broaden Numba support by using the object-mode fallback provided by `numba.jit`.

Closes #1294