### PR TITLE
Remove redundant `graph_inputs` usage in `OpFromGraph`

### DIFF
--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -586,10 +586,6 @@ class TestScan:
         assert np.allclose(aesara_values, v_out)
 
     def test_oinp_iinp_iout_oout_mappings(self):
-        """
-        Test the mapping produces by
-        ScanOp.get_oinp_iinp_iout_oout_mappings()
-        """
 
         rng = RandomStream(123)
 


### PR DESCRIPTION
This PR removes a redundant walk through the graph.

There are a few more important improvements needed in the `OpFromGraph` constructor.  I may add them here.