### PR TITLE
Removes redundant dependencies from environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,13 +35,6 @@ dependencies:
   - pygments
   - pydot
   - ipython
-  # code style
-  - black
-  - isort
-  # For linting
-  - flake8
-  - pep8
-  - pyflakes
   # developer tools
   - pre-commit
   - packaging


### PR DESCRIPTION
[Issue] #1308 
[Problem] As mentioned in #960, there are some redundant dependencies in the environment.yml file
[Solution] Removed the redundant dependencies(e.g. black, isort, flake8, pep8 and pyflakes)