### PR TITLE
Fixing link appearances in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -122,10 +122,10 @@ Contributing
 We welcome bug reports and fixes and improvements to the documentation.
 
 For more information on contributing, please see the
-`contributing guide <https://github.com/aesara-devs/aesara/CONTRIBUTING.md>`.
+`contributing guide <https://github.com/aesara-devs/aesara/CONTRIBUTING.md>`__.
 
 A good place to start contributing is by looking through the issues
-`here <https://github.com/aesara-devs/aesara/issues`.
+`here <https://github.com/aesara-devs/aesara/issues>`__.
 
 Support
 =======


### PR DESCRIPTION
I just realized that some links in the "**Contributing**" section of the Aesara README don't look *as* aesthetic due to formatting. This simple PR fixes such instances in the file.