### PR TITLE
Type hint of `specify_shape` does not allow for None in shape

### DIFF
--- a/aesara/tensor/shape.py
+++ b/aesara/tensor/shape.py
@@ -22,6 +22,9 @@ from aesara.tensor.type_other import NoneConst
 from aesara.tensor.var import TensorConstant, TensorVariable
 
 
+ShapeValueType = Union[None, np.integer, int, Variable]
+
+
 def register_shape_c_code(type, code, version=()):
     """
     Tell Shape Op how to generate C code for an Aesara Type.
@@ -541,9 +544,7 @@ _specify_shape = SpecifyShape()
 
 def specify_shape(
     x: Union[np.ndarray, Number, Variable],
-    shape: Union[
-        int, List[Union[int, Variable]], Tuple[Union[int, Variable]], Variable
-    ],
+    shape: Union[ShapeValueType, List[ShapeValueType], Tuple[ShapeValueType]],
 ):
     """Specify a fixed shape for a `Variable`.
 


### PR DESCRIPTION
fixes #1164
Updated `specify_shape` type hint , allowed None in shape 


Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.