### PR TITLE
Refactor Numba dispatching and interfaces

### DIFF
--- a/aesara/link/jax/dispatch/basic.py
+++ b/aesara/link/jax/dispatch/basic.py
@@ -49,7 +49,7 @@ def jax_funcify_FunctionGraph(
     return fgraph_to_python(
         fgraph,
         jax_funcify,
-        type_conversion_fn=jax_typify,
+        const_conversion_fn=jax_typify,
         fgraph_name=fgraph_name,
         **kwargs,
     )

--- a/aesara/link/numba/dispatch/__init__.py
+++ b/aesara/link/numba/dispatch/__init__.py
@@ -1,5 +1,9 @@
 # isort: off
-from aesara.link.numba.dispatch.basic import numba_funcify, numba_const_convert
+from aesara.link.numba.dispatch.basic import (
+    numba_funcify,
+    numba_const_convert,
+    numba_njit,
+)
 
 # Load dispatch specializations
 import aesara.link.numba.dispatch.scalar

--- a/aesara/link/numba/dispatch/__init__.py
+++ b/aesara/link/numba/dispatch/__init__.py
@@ -1,5 +1,5 @@
 # isort: off
-from aesara.link.numba.dispatch.basic import numba_funcify, numba_typify
+from aesara.link.numba.dispatch.basic import numba_funcify, numba_const_convert
 
 # Load dispatch specializations
 import aesara.link.numba.dispatch.scalar

--- a/aesara/link/numba/dispatch/basic.py
+++ b/aesara/link/numba/dispatch/basic.py
@@ -419,7 +419,7 @@ def numba_funcify_FunctionGraph(
     return fgraph_to_python(
         fgraph,
         numba_funcify,
-        type_conversion_fn=numba_typify,
+        const_conversion_fn=numba_typify,
         fgraph_name=fgraph_name,
         **kwargs,
     )

--- a/aesara/link/numba/dispatch/basic.py
+++ b/aesara/link/numba/dispatch/basic.py
@@ -3,7 +3,7 @@ import warnings
 from contextlib import contextmanager
 from functools import singledispatch
 from textwrap import dedent
-from typing import Union
+from typing import TYPE_CHECKING, Callable, Optional, Union, cast
 
 import numba
 import numba.np.unsafe.ndarray as numba_ndarray
@@ -22,6 +22,7 @@ from aesara.compile.builders import OpFromGraph
 from aesara.compile.ops import DeepCopyOp
 from aesara.graph.basic import Apply, NoParams
 from aesara.graph.fg import FunctionGraph
+from aesara.graph.op import Op
 from aesara.graph.type import Type
 from aesara.ifelse import IfElse
 from aesara.link.utils import (
@@ -46,6 +47,10 @@ from aesara.tensor.subtensor import (
 )
 from aesara.tensor.type import TensorType
 from aesara.tensor.type_other import MakeSlice, NoneConst
+
+
+if TYPE_CHECKING:
+    from aesara.graph.op import StorageMapType
 
 
 def numba_njit(*args, **kwargs):
@@ -335,9 +340,42 @@ def numba_const_convert(data, dtype=None, **kwargs):
     return data
 
 
+def numba_funcify(obj, node=None, storage_map=None, **kwargs) -> Callable:
+    """Convert `obj` to a Numba-JITable object."""
+    return _numba_funcify(obj, node=node, storage_map=storage_map, **kwargs)
+
+
 @singledispatch
-def numba_funcify(op, node=None, storage_map=None, **kwargs):
-    """Create a Numba compatible function from an Aesara `Op`."""
+def _numba_funcify(
+    obj,
+    node: Optional[Apply] = None,
+    storage_map: Optional["StorageMapType"] = None,
+    **kwargs,
+) -> Callable:
+    r"""Dispatch on Aesara object types to perform Numba conversions.
+
+    Arguments
+    ---------
+    obj
+        The object used to determine the appropriate conversion function based
+        on its type.  This is generally an `Op` instance, but `FunctionGraph`\s
+        are also supported.
+    node
+        When `obj` is an `Op`, this value should be the corresponding `Apply` node.
+    storage_map
+        A storage map with, for example, the constant and `SharedVariable` values
+        of the graph being converted.
+
+    Returns
+    -------
+    A `Callable` that can be JIT-compiled in Numba using `numba.jit`.
+
+    """
+
+
+@_numba_funcify.register(Op)
+def numba_funcify_perform(op, node, storage_map=None, **kwargs) -> Callable:
+    """Create a Numba compatible function from an Aesara `Op.perform`."""
 
     warnings.warn(
         f"Numba will use object mode to run {op}'s perform method",
@@ -388,10 +426,10 @@ def numba_funcify(op, node=None, storage_map=None, **kwargs):
             ret = py_perform_return(inputs)
         return ret
 
-    return perform
+    return cast(Callable, perform)
 
 
-@numba_funcify.register(OpFromGraph)
+@_numba_funcify.register(OpFromGraph)
 def numba_funcify_OpFromGraph(op, node=None, **kwargs):
 
     _ = kwargs.pop("storage_map", None)
@@ -413,7 +451,7 @@ def numba_funcify_OpFromGraph(op, node=None, **kwargs):
     return opfromgraph
 
 
-@numba_funcify.register(FunctionGraph)
+@_numba_funcify.register(FunctionGraph)
 def numba_funcify_FunctionGraph(
     fgraph,
     node=None,
@@ -521,9 +559,9 @@ def {fn_name}({", ".join(input_names)}):
     return subtensor_def_src
 
 
-@numba_funcify.register(Subtensor)
-@numba_funcify.register(AdvancedSubtensor)
-@numba_funcify.register(AdvancedSubtensor1)
+@_numba_funcify.register(Subtensor)
+@_numba_funcify.register(AdvancedSubtensor)
+@_numba_funcify.register(AdvancedSubtensor1)
 def numba_funcify_Subtensor(op, node, **kwargs):
 
     subtensor_def_src = create_index_func(
@@ -539,8 +577,8 @@ def numba_funcify_Subtensor(op, node, **kwargs):
     return numba_njit(subtensor_fn)
 
 
-@numba_funcify.register(IncSubtensor)
-@numba_funcify.register(AdvancedIncSubtensor)
+@_numba_funcify.register(IncSubtensor)
+@_numba_funcify.register(AdvancedIncSubtensor)
 def numba_funcify_IncSubtensor(op, node, **kwargs):
 
     incsubtensor_def_src = create_index_func(
@@ -556,7 +594,7 @@ def numba_funcify_IncSubtensor(op, node, **kwargs):
     return numba_njit(incsubtensor_fn)
 
 
-@numba_funcify.register(AdvancedIncSubtensor1)
+@_numba_funcify.register(AdvancedIncSubtensor1)
 def numba_funcify_AdvancedIncSubtensor1(op, node, **kwargs):
     inplace = op.inplace
     set_instead_of_inc = op.set_instead_of_inc
@@ -589,7 +627,7 @@ def numba_funcify_AdvancedIncSubtensor1(op, node, **kwargs):
         return advancedincsubtensor1
 
 
-@numba_funcify.register(DeepCopyOp)
+@_numba_funcify.register(DeepCopyOp)
 def numba_funcify_DeepCopyOp(op, node, **kwargs):
 
     # Scalars are apparently returned as actual Python scalar types and not
@@ -611,8 +649,8 @@ def numba_funcify_DeepCopyOp(op, node, **kwargs):
     return deepcopyop
 
 
-@numba_funcify.register(MakeSlice)
-def numba_funcify_MakeSlice(op, **kwargs):
+@_numba_funcify.register(MakeSlice)
+def numba_funcify_MakeSlice(op, node, **kwargs):
     @numba_njit
     def makeslice(*x):
         return slice(*x)
@@ -620,8 +658,8 @@ def numba_funcify_MakeSlice(op, **kwargs):
     return makeslice
 
 
-@numba_funcify.register(Shape)
-def numba_funcify_Shape(op, **kwargs):
+@_numba_funcify.register(Shape)
+def numba_funcify_Shape(op, node, **kwargs):
     @numba_njit(inline="always")
     def shape(x):
         return np.asarray(np.shape(x))
@@ -629,8 +667,8 @@ def numba_funcify_Shape(op, **kwargs):
     return shape
 
 
-@numba_funcify.register(Shape_i)
-def numba_funcify_Shape_i(op, **kwargs):
+@_numba_funcify.register(Shape_i)
+def numba_funcify_Shape_i(op, node, **kwargs):
     i = op.i
 
     @numba_njit(inline="always")
@@ -660,8 +698,8 @@ def direct_cast(typingctx, val, typ):
     return sig, codegen
 
 
-@numba_funcify.register(Reshape)
-def numba_funcify_Reshape(op, **kwargs):
+@_numba_funcify.register(Reshape)
+def numba_funcify_Reshape(op, node, **kwargs):
     ndim = op.ndim
 
     if ndim == 0:
@@ -683,7 +721,7 @@ def numba_funcify_Reshape(op, **kwargs):
     return reshape
 
 
-@numba_funcify.register(SpecifyShape)
+@_numba_funcify.register(SpecifyShape)
 def numba_funcify_SpecifyShape(op, node, **kwargs):
     shape_inputs = node.inputs[1:]
     shape_input_names = ["shape_" + str(i) for i in range(len(shape_inputs))]
@@ -730,7 +768,7 @@ def int_to_float_fn(inputs, out_dtype):
     return inputs_cast
 
 
-@numba_funcify.register(Dot)
+@_numba_funcify.register(Dot)
 def numba_funcify_Dot(op, node, **kwargs):
     # Numba's `np.dot` does not support integer dtypes, so we need to cast to
     # float.
@@ -745,7 +783,7 @@ def numba_funcify_Dot(op, node, **kwargs):
     return dot
 
 
-@numba_funcify.register(Softplus)
+@_numba_funcify.register(Softplus)
 def numba_funcify_Softplus(op, node, **kwargs):
 
     x_dtype = np.dtype(node.inputs[0].dtype)
@@ -764,7 +802,7 @@ def numba_funcify_Softplus(op, node, **kwargs):
     return softplus
 
 
-@numba_funcify.register(Cholesky)
+@_numba_funcify.register(Cholesky)
 def numba_funcify_Cholesky(op, node, **kwargs):
     lower = op.lower
 
@@ -800,7 +838,7 @@ def numba_funcify_Cholesky(op, node, **kwargs):
     return cholesky
 
 
-@numba_funcify.register(Solve)
+@_numba_funcify.register(Solve)
 def numba_funcify_Solve(op, node, **kwargs):
 
     assume_a = op.assume_a
@@ -847,7 +885,7 @@ def numba_funcify_Solve(op, node, **kwargs):
     return solve
 
 
-@numba_funcify.register(BatchedDot)
+@_numba_funcify.register(BatchedDot)
 def numba_funcify_BatchedDot(op, node, **kwargs):
     dtype = node.outputs[0].type.numpy_dtype
 
@@ -868,7 +906,7 @@ def numba_funcify_BatchedDot(op, node, **kwargs):
 # optimizations are apparently already performed by Numba
 
 
-@numba_funcify.register(IfElse)
+@_numba_funcify.register(IfElse)
 def numba_funcify_IfElse(op, **kwargs):
     n_outs = op.n_outs
 

--- a/aesara/link/numba/dispatch/basic.py
+++ b/aesara/link/numba/dispatch/basic.py
@@ -31,6 +31,7 @@ from aesara.link.utils import (
 )
 from aesara.scalar.basic import ScalarType
 from aesara.scalar.math import Softplus
+from aesara.sparse.type import SparseTensorType
 from aesara.tensor.blas import BatchedDot
 from aesara.tensor.math import Dot
 from aesara.tensor.shape import Reshape, Shape, Shape_i, SpecifyShape
@@ -73,14 +74,33 @@ generated_jit = _jit(
 )
 
 
-def get_numba_type(
-    aesara_type: Type,
+@singledispatch
+def get_numba_type(aesara_type: Type, **kwargs) -> numba.types.Type:
+    r"""Create a Numba type object for a :class:`Type`."""
+    return numba.types.pyobject
+
+
+@get_numba_type.register(SparseTensorType)
+def get_numba_type_SparseType(aesara_type, **kwargs):
+    # This is needed to differentiate `SparseTensorType` from `TensorType`
+    return numba.types.pyobject
+
+
+@get_numba_type.register(ScalarType)
+def get_numba_type_ScalarType(aesara_type, **kwargs):
+    dtype = np.dtype(aesara_type.dtype)
+    numba_dtype = numba.from_dtype(dtype)
+    return numba_dtype
+
+
+@get_numba_type.register(TensorType)
+def get_numba_type_TensorType(
+    aesara_type,
     layout: str = "A",
     force_scalar: bool = False,
     reduce_to_scalar: bool = False,
-) -> numba.types.Type:
-    r"""Create a Numba type object for a :class:`Type`.
-
+):
+    r"""
     Parameters
     ----------
     aesara_type
@@ -92,44 +112,27 @@ def get_numba_type(
     reduce_to_scalar
         Return Numba scalars for zero dimensional :class:`TensorType`\s.
     """
-
-    if isinstance(aesara_type, TensorType):
-        dtype = aesara_type.numpy_dtype
-        numba_dtype = numba.from_dtype(dtype)
-        if force_scalar or (
-            reduce_to_scalar and getattr(aesara_type, "ndim", None) == 0
-        ):
-            return numba_dtype
-        return numba.types.Array(numba_dtype, aesara_type.ndim, layout)
-    elif isinstance(aesara_type, ScalarType):
-        dtype = np.dtype(aesara_type.dtype)
-        numba_dtype = numba.from_dtype(dtype)
+    dtype = aesara_type.numpy_dtype
+    numba_dtype = numba.from_dtype(dtype)
+    if force_scalar or (reduce_to_scalar and getattr(aesara_type, "ndim", None) == 0):
         return numba_dtype
-    else:
-        raise NotImplementedError(f"Numba type not implemented for {aesara_type}")
+    return numba.types.Array(numba_dtype, aesara_type.ndim, layout)
 
 
 def create_numba_signature(
-    node_or_fgraph: Union[FunctionGraph, Apply],
-    force_scalar: bool = False,
-    reduce_to_scalar: bool = False,
+    node_or_fgraph: Union[FunctionGraph, Apply], **kwargs
 ) -> numba.types.Type:
     """Create a Numba type for the signature of an `Apply` node or `FunctionGraph`."""
     input_types = []
     for inp in node_or_fgraph.inputs:
-        input_types.append(
-            get_numba_type(
-                inp.type, force_scalar=force_scalar, reduce_to_scalar=reduce_to_scalar
-            )
-        )
+        input_types.append(get_numba_type(inp.type, **kwargs))
 
     output_types = []
     for out in node_or_fgraph.outputs:
-        output_types.append(
-            get_numba_type(
-                out.type, force_scalar=force_scalar, reduce_to_scalar=reduce_to_scalar
-            )
-        )
+        output_types.append(get_numba_type(out.type, **kwargs))
+
+    if isinstance(node_or_fgraph, FunctionGraph):
+        return numba.types.Tuple(output_types)(*input_types)
 
     if len(output_types) > 1:
         return numba.types.Tuple(output_types)(*input_types)

--- a/aesara/link/numba/dispatch/basic.py
+++ b/aesara/link/numba/dispatch/basic.py
@@ -327,7 +327,8 @@ def use_optimized_cheap_pass(*args, **kwargs):
 
 
 @singledispatch
-def numba_typify(data, dtype=None, **kwargs):
+def numba_const_convert(data, dtype=None, **kwargs):
+    """Create a Numba compatible constant from an Aesara `Constant`."""
     return data
 
 
@@ -419,7 +420,7 @@ def numba_funcify_FunctionGraph(
     return fgraph_to_python(
         fgraph,
         numba_funcify,
-        const_conversion_fn=numba_typify,
+        const_conversion_fn=numba_const_convert,
         fgraph_name=fgraph_name,
         **kwargs,
     )

--- a/aesara/link/numba/dispatch/elemwise.py
+++ b/aesara/link/numba/dispatch/elemwise.py
@@ -12,6 +12,7 @@ from aesara.graph.basic import Apply
 from aesara.graph.op import Op
 from aesara.link.numba.dispatch import basic as numba_basic
 from aesara.link.numba.dispatch.basic import (
+    _numba_funcify,
     create_numba_signature,
     create_tuple_creator,
     numba_funcify,
@@ -422,7 +423,7 @@ def create_axis_apply_fn(fn, axis, ndim, dtype):
     return axis_apply_fn
 
 
-@numba_funcify.register(Elemwise)
+@_numba_funcify.register(Elemwise)
 def numba_funcify_Elemwise(op, node, **kwargs):
 
     scalar_op_fn = numba_funcify(op.scalar_op, node=node, inline="always", **kwargs)
@@ -474,7 +475,7 @@ def {inplace_elemwise_fn_name}({input_signature_str}):
     return elemwise_fn
 
 
-@numba_funcify.register(CAReduce)
+@_numba_funcify.register(CAReduce)
 def numba_funcify_CAReduce(op, node, **kwargs):
     axes = op.axis
     if axes is None:
@@ -512,7 +513,7 @@ def numba_funcify_CAReduce(op, node, **kwargs):
     return careduce_fn
 
 
-@numba_funcify.register(DimShuffle)
+@_numba_funcify.register(DimShuffle)
 def numba_funcify_DimShuffle(op, **kwargs):
     shuffle = tuple(op.shuffle)
     transposition = tuple(op.transposition)
@@ -590,7 +591,7 @@ def numba_funcify_DimShuffle(op, **kwargs):
     return dimshuffle
 
 
-@numba_funcify.register(Softmax)
+@_numba_funcify.register(Softmax)
 def numba_funcify_Softmax(op, node, **kwargs):
 
     x_at = node.inputs[0]
@@ -627,7 +628,7 @@ def numba_funcify_Softmax(op, node, **kwargs):
     return softmax
 
 
-@numba_funcify.register(SoftmaxGrad)
+@_numba_funcify.register(SoftmaxGrad)
 def numba_funcify_SoftmaxGrad(op, node, **kwargs):
 
     sm_at = node.inputs[1]
@@ -658,7 +659,7 @@ def numba_funcify_SoftmaxGrad(op, node, **kwargs):
     return softmax_grad
 
 
-@numba_funcify.register(LogSoftmax)
+@_numba_funcify.register(LogSoftmax)
 def numba_funcify_LogSoftmax(op, node, **kwargs):
 
     x_at = node.inputs[0]
@@ -692,7 +693,7 @@ def numba_funcify_LogSoftmax(op, node, **kwargs):
     return log_softmax
 
 
-@numba_funcify.register(MaxAndArgmax)
+@_numba_funcify.register(MaxAndArgmax)
 def numba_funcify_MaxAndArgmax(op, node, **kwargs):
     axis = op.axis
     x_at = node.inputs[0]

--- a/aesara/link/numba/dispatch/extra_ops.py
+++ b/aesara/link/numba/dispatch/extra_ops.py
@@ -6,7 +6,7 @@ from numba.misc.special import literal_unroll
 
 from aesara import config
 from aesara.link.numba.dispatch import basic as numba_basic
-from aesara.link.numba.dispatch.basic import get_numba_type, numba_funcify
+from aesara.link.numba.dispatch.basic import _numba_funcify, get_numba_type
 from aesara.tensor.extra_ops import (
     Bartlett,
     BroadcastTo,
@@ -21,7 +21,7 @@ from aesara.tensor.extra_ops import (
 )
 
 
-@numba_funcify.register(Bartlett)
+@_numba_funcify.register(Bartlett)
 def numba_funcify_Bartlett(op, **kwargs):
     @numba_basic.numba_njit(inline="always")
     def bartlett(x):
@@ -30,7 +30,7 @@ def numba_funcify_Bartlett(op, **kwargs):
     return bartlett
 
 
-@numba_funcify.register(CumOp)
+@_numba_funcify.register(CumOp)
 def numba_funcify_CumOp(op, node, **kwargs):
     axis = op.axis
     mode = op.mode
@@ -65,7 +65,7 @@ def numba_funcify_CumOp(op, node, **kwargs):
     return cumop
 
 
-@numba_funcify.register(FillDiagonal)
+@_numba_funcify.register(FillDiagonal)
 def numba_funcify_FillDiagonal(op, **kwargs):
     @numba_basic.numba_njit
     def filldiagonal(a, val):
@@ -75,7 +75,7 @@ def numba_funcify_FillDiagonal(op, **kwargs):
     return filldiagonal
 
 
-@numba_funcify.register(FillDiagonalOffset)
+@_numba_funcify.register(FillDiagonalOffset)
 def numba_funcify_FillDiagonalOffset(op, node, **kwargs):
     @numba_basic.numba_njit
     def filldiagonaloffset(a, val, offset):
@@ -100,7 +100,7 @@ def numba_funcify_FillDiagonalOffset(op, node, **kwargs):
     return filldiagonaloffset
 
 
-@numba_funcify.register(RavelMultiIndex)
+@_numba_funcify.register(RavelMultiIndex)
 def numba_funcify_RavelMultiIndex(op, node, **kwargs):
 
     mode = op.mode
@@ -165,7 +165,7 @@ def numba_funcify_RavelMultiIndex(op, node, **kwargs):
     return ravelmultiindex
 
 
-@numba_funcify.register(Repeat)
+@_numba_funcify.register(Repeat)
 def numba_funcify_Repeat(op, node, **kwargs):
     axis = op.axis
 
@@ -210,7 +210,7 @@ def numba_funcify_Repeat(op, node, **kwargs):
     return repeatop
 
 
-@numba_funcify.register(Unique)
+@_numba_funcify.register(Unique)
 def numba_funcify_Unique(op, node, **kwargs):
     axis = op.axis
 
@@ -256,7 +256,7 @@ def numba_funcify_Unique(op, node, **kwargs):
     return unique
 
 
-@numba_funcify.register(UnravelIndex)
+@_numba_funcify.register(UnravelIndex)
 def numba_funcify_UnravelIndex(op, node, **kwargs):
     order = op.order
 
@@ -291,7 +291,7 @@ def numba_funcify_UnravelIndex(op, node, **kwargs):
     return unravelindex
 
 
-@numba_funcify.register(SearchsortedOp)
+@_numba_funcify.register(SearchsortedOp)
 def numba_funcify_Searchsorted(op, node, **kwargs):
     side = op.side
 
@@ -325,7 +325,7 @@ def numba_funcify_Searchsorted(op, node, **kwargs):
     return searchsorted
 
 
-@numba_funcify.register(BroadcastTo)
+@_numba_funcify.register(BroadcastTo)
 def numba_funcify_BroadcastTo(op, node, **kwargs):
 
     create_zeros_tuple = numba_basic.create_tuple_creator(

--- a/aesara/link/numba/dispatch/nlinalg.py
+++ b/aesara/link/numba/dispatch/nlinalg.py
@@ -5,9 +5,9 @@ import numpy as np
 
 from aesara.link.numba.dispatch import basic as numba_basic
 from aesara.link.numba.dispatch.basic import (
+    _numba_funcify,
     get_numba_type,
     int_to_float_fn,
-    numba_funcify,
 )
 from aesara.tensor.nlinalg import (
     SVD,
@@ -21,7 +21,7 @@ from aesara.tensor.nlinalg import (
 )
 
 
-@numba_funcify.register(SVD)
+@_numba_funcify.register(SVD)
 def numba_funcify_SVD(op, node, **kwargs):
     full_matrices = op.full_matrices
     compute_uv = op.compute_uv
@@ -56,7 +56,7 @@ def numba_funcify_SVD(op, node, **kwargs):
     return svd
 
 
-@numba_funcify.register(Det)
+@_numba_funcify.register(Det)
 def numba_funcify_Det(op, node, **kwargs):
 
     out_dtype = node.outputs[0].type.numpy_dtype
@@ -69,7 +69,7 @@ def numba_funcify_Det(op, node, **kwargs):
     return det
 
 
-@numba_funcify.register(Eig)
+@_numba_funcify.register(Eig)
 def numba_funcify_Eig(op, node, **kwargs):
 
     out_dtype_1 = node.outputs[0].type.numpy_dtype
@@ -85,7 +85,7 @@ def numba_funcify_Eig(op, node, **kwargs):
     return eig
 
 
-@numba_funcify.register(Eigh)
+@_numba_funcify.register(Eigh)
 def numba_funcify_Eigh(op, node, **kwargs):
     uplo = op.UPLO
 
@@ -120,7 +120,7 @@ def numba_funcify_Eigh(op, node, **kwargs):
     return eigh
 
 
-@numba_funcify.register(Inv)
+@_numba_funcify.register(Inv)
 def numba_funcify_Inv(op, node, **kwargs):
 
     out_dtype = node.outputs[0].type.numpy_dtype
@@ -133,7 +133,7 @@ def numba_funcify_Inv(op, node, **kwargs):
     return inv
 
 
-@numba_funcify.register(MatrixInverse)
+@_numba_funcify.register(MatrixInverse)
 def numba_funcify_MatrixInverse(op, node, **kwargs):
 
     out_dtype = node.outputs[0].type.numpy_dtype
@@ -146,7 +146,7 @@ def numba_funcify_MatrixInverse(op, node, **kwargs):
     return matrix_inverse
 
 
-@numba_funcify.register(MatrixPinv)
+@_numba_funcify.register(MatrixPinv)
 def numba_funcify_MatrixPinv(op, node, **kwargs):
 
     out_dtype = node.outputs[0].type.numpy_dtype
@@ -159,7 +159,7 @@ def numba_funcify_MatrixPinv(op, node, **kwargs):
     return matrixpinv
 
 
-@numba_funcify.register(QRFull)
+@_numba_funcify.register(QRFull)
 def numba_funcify_QRFull(op, node, **kwargs):
     mode = op.mode
 

--- a/aesara/link/numba/dispatch/random.py
+++ b/aesara/link/numba/dispatch/random.py
@@ -20,7 +20,7 @@ import aesara.tensor.random.basic as aer
 from aesara.graph.basic import Apply
 from aesara.graph.op import Op
 from aesara.link.numba.dispatch import basic as numba_basic
-from aesara.link.numba.dispatch.basic import numba_funcify, numba_typify
+from aesara.link.numba.dispatch.basic import numba_const_convert, numba_funcify
 from aesara.link.utils import (
     compile_function_src,
     get_name_for_object,
@@ -96,11 +96,11 @@ def uniform_empty_size(a, b, size):
         return uniform_no_size
 
 
-@numba_typify.register(RandomState)
-def numba_typify_RandomState(state, **kwargs):
-    # The numba_typify in this case is just an passthrough function
+@numba_const_convert.register(RandomState)
+def numba_const_convert_RandomState(state, **kwargs):
+    # The `numba_const_convert` in this case is just a passthrough function
     # that synchronizes Numba's internal random state with the current
-    # RandomState object
+    # `RandomState` object.
     ints, index = state.get_state()[1:3]
     ptr = _helperlib.rnd_get_np_state_ptr()
     _helperlib.rnd_set_state(ptr, (index, [int(x) for x in ints]))

--- a/aesara/link/numba/dispatch/random.py
+++ b/aesara/link/numba/dispatch/random.py
@@ -20,7 +20,7 @@ import aesara.tensor.random.basic as aer
 from aesara.graph.basic import Apply
 from aesara.graph.op import Op
 from aesara.link.numba.dispatch import basic as numba_basic
-from aesara.link.numba.dispatch.basic import numba_const_convert, numba_funcify
+from aesara.link.numba.dispatch.basic import _numba_funcify, numba_const_convert
 from aesara.link.utils import (
     compile_function_src,
     get_name_for_object,
@@ -207,29 +207,29 @@ def {sized_fn_name}({random_fn_input_names}):
     return random_fn
 
 
-@numba_funcify.register(aer.UniformRV)
-@numba_funcify.register(aer.TriangularRV)
-@numba_funcify.register(aer.BetaRV)
-@numba_funcify.register(aer.NormalRV)
-@numba_funcify.register(aer.LogNormalRV)
-@numba_funcify.register(aer.GammaRV)
-@numba_funcify.register(aer.ChiSquareRV)
-@numba_funcify.register(aer.ParetoRV)
-@numba_funcify.register(aer.GumbelRV)
-@numba_funcify.register(aer.ExponentialRV)
-@numba_funcify.register(aer.WeibullRV)
-@numba_funcify.register(aer.LogisticRV)
-@numba_funcify.register(aer.VonMisesRV)
-@numba_funcify.register(aer.PoissonRV)
-@numba_funcify.register(aer.GeometricRV)
-@numba_funcify.register(aer.HyperGeometricRV)
-@numba_funcify.register(aer.WaldRV)
-@numba_funcify.register(aer.LaplaceRV)
-@numba_funcify.register(aer.BinomialRV)
-@numba_funcify.register(aer.MultinomialRV)
-@numba_funcify.register(aer.RandIntRV)  # only the first two arguments are supported
-@numba_funcify.register(aer.ChoiceRV)  # the `p` argument is not supported
-@numba_funcify.register(aer.PermutationRV)
+@_numba_funcify.register(aer.UniformRV)
+@_numba_funcify.register(aer.TriangularRV)
+@_numba_funcify.register(aer.BetaRV)
+@_numba_funcify.register(aer.NormalRV)
+@_numba_funcify.register(aer.LogNormalRV)
+@_numba_funcify.register(aer.GammaRV)
+@_numba_funcify.register(aer.ChiSquareRV)
+@_numba_funcify.register(aer.ParetoRV)
+@_numba_funcify.register(aer.GumbelRV)
+@_numba_funcify.register(aer.ExponentialRV)
+@_numba_funcify.register(aer.WeibullRV)
+@_numba_funcify.register(aer.LogisticRV)
+@_numba_funcify.register(aer.VonMisesRV)
+@_numba_funcify.register(aer.PoissonRV)
+@_numba_funcify.register(aer.GeometricRV)
+@_numba_funcify.register(aer.HyperGeometricRV)
+@_numba_funcify.register(aer.WaldRV)
+@_numba_funcify.register(aer.LaplaceRV)
+@_numba_funcify.register(aer.BinomialRV)
+@_numba_funcify.register(aer.MultinomialRV)
+@_numba_funcify.register(aer.RandIntRV)  # only the first two arguments are supported
+@_numba_funcify.register(aer.ChoiceRV)  # the `p` argument is not supported
+@_numba_funcify.register(aer.PermutationRV)
 def numba_funcify_RandomVariable(op, node, **kwargs):
     name = op.name
     np_random_func = getattr(np.random, name)
@@ -285,12 +285,12 @@ def {np_random_fn_name}({np_input_names}):
     return make_numba_random_fn(node, np_random_fn)
 
 
-@numba_funcify.register(aer.NegBinomialRV)
+@_numba_funcify.register(aer.NegBinomialRV)
 def numba_funcify_NegBinomialRV(op, node, **kwargs):
     return make_numba_random_fn(node, np.random.negative_binomial)
 
 
-@numba_funcify.register(aer.CauchyRV)
+@_numba_funcify.register(aer.CauchyRV)
 def numba_funcify_CauchyRV(op, node, **kwargs):
     def body_fn(loc, scale):
         return f"    return ({loc} + np.random.standard_cauchy()) / {scale}"
@@ -298,7 +298,7 @@ def numba_funcify_CauchyRV(op, node, **kwargs):
     return create_numba_random_fn(op, node, body_fn)
 
 
-@numba_funcify.register(aer.HalfNormalRV)
+@_numba_funcify.register(aer.HalfNormalRV)
 def numba_funcify_HalfNormalRV(op, node, **kwargs):
     def body_fn(a, b):
         return f"    return {a} + {b} * abs(np.random.normal(0, 1))"
@@ -306,7 +306,7 @@ def numba_funcify_HalfNormalRV(op, node, **kwargs):
     return create_numba_random_fn(op, node, body_fn)
 
 
-@numba_funcify.register(aer.BernoulliRV)
+@_numba_funcify.register(aer.BernoulliRV)
 def numba_funcify_BernoulliRV(op, node, **kwargs):
     out_dtype = node.outputs[1].type.numpy_dtype
 
@@ -326,7 +326,7 @@ def numba_funcify_BernoulliRV(op, node, **kwargs):
     )
 
 
-@numba_funcify.register(aer.CategoricalRV)
+@_numba_funcify.register(aer.CategoricalRV)
 def numba_funcify_CategoricalRV(op, node, **kwargs):
     out_dtype = node.outputs[1].type.numpy_dtype
     size_len = int(get_vector_length(node.inputs[1]))
@@ -350,7 +350,7 @@ def numba_funcify_CategoricalRV(op, node, **kwargs):
     return categorical_rv
 
 
-@numba_funcify.register(aer.DirichletRV)
+@_numba_funcify.register(aer.DirichletRV)
 def numba_funcify_DirichletRV(op, node, **kwargs):
 
     out_dtype = node.outputs[1].type.numpy_dtype

--- a/aesara/link/numba/dispatch/scalar.py
+++ b/aesara/link/numba/dispatch/scalar.py
@@ -10,7 +10,11 @@ from aesara import config
 from aesara.compile.ops import ViewOp
 from aesara.graph.basic import Variable
 from aesara.link.numba.dispatch import basic as numba_basic
-from aesara.link.numba.dispatch.basic import create_numba_signature, numba_funcify
+from aesara.link.numba.dispatch.basic import (
+    _numba_funcify,
+    create_numba_signature,
+    numba_funcify,
+)
 from aesara.link.utils import (
     compile_function_src,
     get_name_for_object,
@@ -31,7 +35,7 @@ from aesara.scalar.basic import (
 from aesara.scalar.math import Erf, Erfc, GammaLn, Log1mexp, Sigmoid
 
 
-@numba_funcify.register(ScalarOp)
+@_numba_funcify.register(ScalarOp)
 def numba_funcify_ScalarOp(op, node, **kwargs):
     # TODO: Do we need to cache these functions so that we don't end up
     # compiling the same Numba function over and over again?
@@ -126,7 +130,7 @@ def {scalar_op_fn_name}({', '.join(input_names)}):
     )(scalar_op_fn)
 
 
-@numba_funcify.register(Switch)
+@_numba_funcify.register(Switch)
 def numba_funcify_Switch(op, node, **kwargs):
     @numba_basic.numba_njit(inline="always")
     def switch(condition, x, y):
@@ -154,7 +158,7 @@ def {binary_op_name}({input_signature}):
     return nary_fn
 
 
-@numba_funcify.register(Add)
+@_numba_funcify.register(Add)
 def numba_funcify_Add(op, node, **kwargs):
 
     signature = create_numba_signature(node, force_scalar=True)
@@ -166,7 +170,7 @@ def numba_funcify_Add(op, node, **kwargs):
     )(nary_add_fn)
 
 
-@numba_funcify.register(Mul)
+@_numba_funcify.register(Mul)
 def numba_funcify_Mul(op, node, **kwargs):
 
     signature = create_numba_signature(node, force_scalar=True)
@@ -178,7 +182,7 @@ def numba_funcify_Mul(op, node, **kwargs):
     )(nary_mul_fn)
 
 
-@numba_funcify.register(Cast)
+@_numba_funcify.register(Cast)
 def numba_funcify_Cast(op, node, **kwargs):
 
     dtype = np.dtype(op.o_type.dtype)
@@ -190,8 +194,8 @@ def numba_funcify_Cast(op, node, **kwargs):
     return cast
 
 
-@numba_funcify.register(Identity)
-@numba_funcify.register(ViewOp)
+@_numba_funcify.register(Identity)
+@_numba_funcify.register(ViewOp)
 def numba_funcify_ViewOp(op, **kwargs):
     @numba_basic.numba_njit(inline="always")
     def viewop(x):
@@ -200,7 +204,7 @@ def numba_funcify_ViewOp(op, **kwargs):
     return viewop
 
 
-@numba_funcify.register(Clip)
+@_numba_funcify.register(Clip)
 def numba_funcify_Clip(op, **kwargs):
     @numba_basic.numba_njit
     def clip(_x, _min, _max):
@@ -218,7 +222,7 @@ def numba_funcify_Clip(op, **kwargs):
     return clip
 
 
-@numba_funcify.register(Composite)
+@_numba_funcify.register(Composite)
 def numba_funcify_Composite(op, node, **kwargs):
     signature = create_numba_signature(node, force_scalar=True)
 
@@ -230,7 +234,7 @@ def numba_funcify_Composite(op, node, **kwargs):
     return composite_fn
 
 
-@numba_funcify.register(Second)
+@_numba_funcify.register(Second)
 def numba_funcify_Second(op, node, **kwargs):
     @numba_basic.numba_njit(inline="always")
     def second(x, y):
@@ -239,7 +243,7 @@ def numba_funcify_Second(op, node, **kwargs):
     return second
 
 
-@numba_funcify.register(Reciprocal)
+@_numba_funcify.register(Reciprocal)
 def numba_funcify_Reciprocal(op, node, **kwargs):
     @numba_basic.numba_njit(inline="always")
     def reciprocal(x):
@@ -250,7 +254,7 @@ def numba_funcify_Reciprocal(op, node, **kwargs):
     return reciprocal
 
 
-@numba_funcify.register(Sigmoid)
+@_numba_funcify.register(Sigmoid)
 def numba_funcify_Sigmoid(op, node, **kwargs):
     @numba_basic.numba_njit(inline="always", fastmath=config.numba__fastmath)
     def sigmoid(x):
@@ -259,7 +263,7 @@ def numba_funcify_Sigmoid(op, node, **kwargs):
     return sigmoid
 
 
-@numba_funcify.register(GammaLn)
+@_numba_funcify.register(GammaLn)
 def numba_funcify_GammaLn(op, node, **kwargs):
     @numba_basic.numba_njit(inline="always", fastmath=config.numba__fastmath)
     def gammaln(x):
@@ -268,7 +272,7 @@ def numba_funcify_GammaLn(op, node, **kwargs):
     return gammaln
 
 
-@numba_funcify.register(Log1mexp)
+@_numba_funcify.register(Log1mexp)
 def numba_funcify_Log1mexp(op, node, **kwargs):
     @numba_basic.numba_njit(inline="always", fastmath=config.numba__fastmath)
     def logp1mexp(x):
@@ -280,7 +284,7 @@ def numba_funcify_Log1mexp(op, node, **kwargs):
     return logp1mexp
 
 
-@numba_funcify.register(Erf)
+@_numba_funcify.register(Erf)
 def numba_funcify_Erf(op, **kwargs):
     @numba_basic.numba_njit(inline="always", fastmath=config.numba__fastmath)
     def erf(x):
@@ -289,7 +293,7 @@ def numba_funcify_Erf(op, **kwargs):
     return erf
 
 
-@numba_funcify.register(Erfc)
+@_numba_funcify.register(Erfc)
 def numba_funcify_Erfc(op, **kwargs):
     @numba_basic.numba_njit(inline="always", fastmath=config.numba__fastmath)
     def erfc(x):

--- a/aesara/link/numba/dispatch/scan.py
+++ b/aesara/link/numba/dispatch/scan.py
@@ -7,6 +7,7 @@ from numba.extending import overload
 
 from aesara.link.numba.dispatch import basic as numba_basic
 from aesara.link.numba.dispatch.basic import (
+    _numba_funcify,
     create_arg_string,
     create_tuple_string,
     numba_funcify,
@@ -45,7 +46,7 @@ def array0d_range(x):
         return range_arr
 
 
-@numba_funcify.register(Scan)
+@_numba_funcify.register(Scan)
 def numba_funcify_Scan(op, node, **kwargs):
     scan_inner_func = numba_basic.numba_njit(numba_funcify(op.fgraph))
 

--- a/aesara/link/numba/dispatch/tensor_basic.py
+++ b/aesara/link/numba/dispatch/tensor_basic.py
@@ -3,7 +3,7 @@ from textwrap import indent
 import numpy as np
 
 from aesara.link.numba.dispatch import basic as numba_basic
-from aesara.link.numba.dispatch.basic import create_tuple_string, numba_funcify
+from aesara.link.numba.dispatch.basic import _numba_funcify, create_tuple_string
 from aesara.link.utils import compile_function_src, unique_name_generator
 from aesara.tensor.basic import (
     Alloc,
@@ -21,7 +21,7 @@ from aesara.tensor.basic import (
 from aesara.tensor.shape import Unbroadcast
 
 
-@numba_funcify.register(AllocEmpty)
+@_numba_funcify.register(AllocEmpty)
 def numba_funcify_AllocEmpty(op, node, **kwargs):
 
     global_env = {
@@ -59,7 +59,7 @@ def allocempty({", ".join(shape_var_names)}):
     return numba_basic.numba_njit(alloc_fn)
 
 
-@numba_funcify.register(Alloc)
+@_numba_funcify.register(Alloc)
 def numba_funcify_Alloc(op, node, **kwargs):
 
     global_env = {"np": np, "to_scalar": numba_basic.to_scalar}
@@ -95,7 +95,7 @@ def alloc(val, {", ".join(shape_var_names)}):
     return numba_basic.numba_njit(alloc_fn)
 
 
-@numba_funcify.register(AllocDiag)
+@_numba_funcify.register(AllocDiag)
 def numba_funcify_AllocDiag(op, **kwargs):
     offset = op.offset
 
@@ -106,7 +106,7 @@ def numba_funcify_AllocDiag(op, **kwargs):
     return allocdiag
 
 
-@numba_funcify.register(ARange)
+@_numba_funcify.register(ARange)
 def numba_funcify_ARange(op, **kwargs):
     dtype = np.dtype(op.dtype)
 
@@ -122,7 +122,7 @@ def numba_funcify_ARange(op, **kwargs):
     return arange
 
 
-@numba_funcify.register(Join)
+@_numba_funcify.register(Join)
 def numba_funcify_Join(op, **kwargs):
     view = op.view
 
@@ -139,7 +139,7 @@ def numba_funcify_Join(op, **kwargs):
     return join
 
 
-@numba_funcify.register(Split)
+@_numba_funcify.register(Split)
 def numba_funcify_Split(op, **kwargs):
     @numba_basic.numba_njit
     def split(tensor, axis, indices):
@@ -151,7 +151,7 @@ def numba_funcify_Split(op, **kwargs):
     return split
 
 
-@numba_funcify.register(ExtractDiag)
+@_numba_funcify.register(ExtractDiag)
 def numba_funcify_ExtractDiag(op, **kwargs):
     offset = op.offset
     # axis1 = op.axis1
@@ -164,7 +164,7 @@ def numba_funcify_ExtractDiag(op, **kwargs):
     return extract_diag
 
 
-@numba_funcify.register(Eye)
+@_numba_funcify.register(Eye)
 def numba_funcify_Eye(op, **kwargs):
     dtype = np.dtype(op.dtype)
 
@@ -180,7 +180,7 @@ def numba_funcify_Eye(op, **kwargs):
     return eye
 
 
-@numba_funcify.register(MakeVector)
+@_numba_funcify.register(MakeVector)
 def numba_funcify_MakeVector(op, node, **kwargs):
     dtype = np.dtype(op.dtype)
 
@@ -208,7 +208,7 @@ def makevector({", ".join(input_names)}):
     return numba_basic.numba_njit(makevector_fn)
 
 
-@numba_funcify.register(Unbroadcast)
+@_numba_funcify.register(Unbroadcast)
 def numba_funcify_Unbroadcast(op, **kwargs):
     @numba_basic.numba_njit
     def unbroadcast(x):
@@ -217,7 +217,7 @@ def numba_funcify_Unbroadcast(op, **kwargs):
     return unbroadcast
 
 
-@numba_funcify.register(TensorFromScalar)
+@_numba_funcify.register(TensorFromScalar)
 def numba_funcify_TensorFromScalar(op, **kwargs):
     @numba_basic.numba_njit(inline="always")
     def tensor_from_scalar(x):
@@ -226,7 +226,7 @@ def numba_funcify_TensorFromScalar(op, **kwargs):
     return tensor_from_scalar
 
 
-@numba_funcify.register(ScalarFromTensor)
+@_numba_funcify.register(ScalarFromTensor)
 def numba_funcify_ScalarFromTensor(op, **kwargs):
     @numba_basic.numba_njit(inline="always")
     def scalar_from_tensor(x):

--- a/aesara/link/numba/linker.py
+++ b/aesara/link/numba/linker.py
@@ -35,13 +35,13 @@ class NumbaLinker(JITLinker):
     def create_thunk_inputs(self, storage_map):
         from numpy.random import RandomState
 
-        from aesara.link.numba.dispatch import numba_typify
+        from aesara.link.numba.dispatch import numba_const_convert
 
         thunk_inputs = []
         for n in self.fgraph.inputs:
             sinput = storage_map[n]
             if isinstance(sinput[0], RandomState):
-                new_value = numba_typify(
+                new_value = numba_const_convert(
                     sinput[0], dtype=getattr(sinput[0], "dtype", None)
                 )
                 # We need to remove the reference-based connection to the

--- a/aesara/link/numba/linker.py
+++ b/aesara/link/numba/linker.py
@@ -27,9 +27,9 @@ class NumbaLinker(JITLinker):
         return numba_funcify(fgraph, **kwargs)
 
     def jit_compile(self, fn):
-        import numba
+        from aesara.link.numba.dispatch import numba_njit
 
-        jitted_fn = numba.njit(fn)
+        jitted_fn = numba_njit(fn)
         return jitted_fn
 
     def create_thunk_inputs(self, storage_map):

--- a/aesara/link/utils.py
+++ b/aesara/link/utils.py
@@ -676,7 +676,7 @@ def fgraph_to_python(
     fgraph: FunctionGraph,
     op_conversion_fn: Callable,
     *,
-    type_conversion_fn: Callable = lambda x, **kwargs: x,
+    const_conversion_fn: Callable = lambda x, **kwargs: x,
     order: Optional[List[Apply]] = None,
     storage_map: Optional["StorageMapType"] = None,
     fgraph_name: str = "fgraph_to_python",
@@ -696,8 +696,8 @@ def fgraph_to_python(
         A callable used to convert nodes inside `fgraph` based on their `Op`
         types.  It must have the signature
         ``(op: Op, node: Apply=None, storage_map: Dict[Variable, List[Optional[Any]]]=None, **kwargs)``.
-    type_conversion_fn
-        A callable used to convert the values in `storage_map`.  It must have
+    const_conversion_fn
+        A callable used to convert the `Constant` values in `storage_map`.  It must have
         the signature
         ``(value: Optional[Any], variable: Variable=None, storage: List[Optional[Any]]=None, **kwargs)``.
     order
@@ -751,7 +751,7 @@ def fgraph_to_python(
             )
             if input_storage[0] is not None or isinstance(i, Constant):
                 # Constants need to be assigned locally and referenced
-                global_env[local_input_name] = type_conversion_fn(
+                global_env[local_input_name] = const_conversion_fn(
                     input_storage[0], variable=i, storage=input_storage, **kwargs
                 )
                 # TODO: We could attempt to use the storage arrays directly
@@ -774,7 +774,7 @@ def fgraph_to_python(
                 output_storage = storage_map.setdefault(
                     out, [None if not isinstance(out, Constant) else out.data]
                 )
-                global_env[local_output_name] = type_conversion_fn(
+                global_env[local_output_name] = const_conversion_fn(
                     output_storage[0],
                     variable=out,
                     storage=output_storage,

--- a/doc/extending/creating_a_numba_jax_op.rst
+++ b/doc/extending/creating_a_numba_jax_op.rst
@@ -83,7 +83,7 @@ Here's an example for :class:`IfElse`:
        return res if n_outs > 1 else res[0]
 
 
-Step 3: Register the function with the `jax_funcify` dispatcher
+Step 3: Register the function with the `_jax_funcify` dispatcher
 ---------------------------------------------------------------
 
 With the Aesara `Op` replicated in JAX, we’ll need to register the
@@ -91,7 +91,7 @@ function with the Aesara JAX `Linker`. This is done through the use of
 `singledispatch`. If you don't know how `singledispatch` works, see the
 `Python documentation <https://docs.python.org/3/library/functools.html#functools.singledispatch>`_.
 
-The relevant dispatch functions created by `singledispatch` are :func:`aesara.link.numba.dispatch.numba_funcify` and
+The relevant dispatch functions created by `singledispatch` are :func:`aesara.link.numba.dispatch.basic._numba_funcify` and
 :func:`aesara.link.jax.dispatch.jax_funcify`.
 
 Here’s an example for the `Eye`\ `Op`:

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -24,7 +24,7 @@ from aesara.graph.rewriting.db import RewriteDatabaseQuery
 from aesara.graph.type import Type
 from aesara.ifelse import ifelse
 from aesara.link.numba.dispatch import basic as numba_basic
-from aesara.link.numba.dispatch import numba_typify
+from aesara.link.numba.dispatch import numba_const_convert
 from aesara.link.numba.linker import NumbaLinker
 from aesara.raise_op import assert_op
 from aesara.tensor import blas
@@ -315,7 +315,7 @@ def test_create_numba_signature(v, expected, force_scalar):
     [
         (
             np.random.RandomState(1),
-            numba_typify,
+            numba_const_convert,
             lambda x, y: np.all(x.get_state()[1] == y.get_state()[1]),
         )
     ],

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -27,6 +27,7 @@ from aesara.link.numba.dispatch import basic as numba_basic
 from aesara.link.numba.dispatch import numba_const_convert
 from aesara.link.numba.linker import NumbaLinker
 from aesara.raise_op import assert_op
+from aesara.sparse.type import SparseTensorType
 from aesara.tensor import blas
 from aesara.tensor import subtensor as at_subtensor
 from aesara.tensor.elemwise import Elemwise
@@ -246,26 +247,21 @@ def compare_numba_and_py(
 
 
 @pytest.mark.parametrize(
-    "v, expected, force_scalar, not_implemented",
+    "v, expected, force_scalar",
     [
-        (MyType(), None, False, True),
-        (aes.float32, numba.types.float32, False, False),
-        (at.fscalar, numba.types.Array(numba.types.float32, 0, "A"), False, False),
-        (at.fscalar, numba.types.float32, True, False),
-        (at.lvector, numba.types.int64[:], False, False),
-        (at.dmatrix, numba.types.float64[:, :], False, False),
-        (at.dmatrix, numba.types.float64, True, False),
+        (MyType(), numba.types.pyobject, False),
+        (SparseTensorType("csc", dtype=np.float64), numba.types.pyobject, False),
+        (aes.float32, numba.types.float32, False),
+        (at.fscalar, numba.types.Array(numba.types.float32, 0, "A"), False),
+        (at.fscalar, numba.types.float32, True),
+        (at.lvector, numba.types.int64[:], False),
+        (at.dmatrix, numba.types.float64[:, :], False),
+        (at.dmatrix, numba.types.float64, True),
     ],
 )
-def test_get_numba_type(v, expected, force_scalar, not_implemented):
-    cm = (
-        contextlib.suppress()
-        if not not_implemented
-        else pytest.raises(NotImplementedError)
-    )
-    with cm:
-        res = numba_basic.get_numba_type(v, force_scalar=force_scalar)
-        assert res == expected
+def test_get_numba_type(v, expected, force_scalar):
+    res = numba_basic.get_numba_type(v, force_scalar=force_scalar)
+    assert res == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR clarifies some of the dispatch interfaces for the Numba transpilation code, by&mdash;for instance&mdash;making it possible to customize Numba signature construction based on Aesara `Type`s.  It also introduces some necessary updates for the use of more recent Numba versions.