### PR TITLE
Support read-only Numba types

### DIFF
--- a/aesara/link/numba/dispatch/extra_ops.py
+++ b/aesara/link/numba/dispatch/extra_ops.py
@@ -184,7 +184,7 @@ def numba_funcify_Repeat(op, node, **kwargs):
             UserWarning,
         )
 
-        ret_sig = get_numba_type(node.outputs[0].type)
+        ret_sig = get_numba_type(node.outputs[0].type, node.outputs[0])
 
         @numba_basic.numba_njit
         def repeatop(x, repeats):
@@ -243,9 +243,11 @@ def numba_funcify_Unique(op, node, **kwargs):
         )
 
         if returns_multi:
-            ret_sig = numba.types.Tuple([get_numba_type(o.type) for o in node.outputs])
+            ret_sig = numba.types.Tuple(
+                [get_numba_type(o.type, o) for o in node.outputs]
+            )
         else:
-            ret_sig = get_numba_type(node.outputs[0].type)
+            ret_sig = get_numba_type(node.outputs[0].type, node.outputs[0])
 
         @numba_basic.numba_njit
         def unique(x):
@@ -308,7 +310,7 @@ def numba_funcify_Searchsorted(op, node, **kwargs):
             UserWarning,
         )
 
-        ret_sig = get_numba_type(node.outputs[0].type)
+        ret_sig = get_numba_type(node.outputs[0].type, node.outputs[0])
 
         @numba_basic.numba_njit
         def searchsorted(a, v, sorter):

--- a/aesara/link/numba/dispatch/nlinalg.py
+++ b/aesara/link/numba/dispatch/nlinalg.py
@@ -36,7 +36,7 @@ def numba_funcify_SVD(op, node, **kwargs):
             UserWarning,
         )
 
-        ret_sig = get_numba_type(node.outputs[0].type)
+        ret_sig = get_numba_type(node.outputs[0].type, node.outputs[0])
 
         @numba_basic.numba_njit
         def svd(x):
@@ -101,7 +101,10 @@ def numba_funcify_Eigh(op, node, **kwargs):
 
         out_dtypes = tuple(o.type.numpy_dtype for o in node.outputs)
         ret_sig = numba.types.Tuple(
-            [get_numba_type(node.outputs[0].type), get_numba_type(node.outputs[1].type)]
+            [
+                get_numba_type(node.outputs[0].type, node.outputs[0]),
+                get_numba_type(node.outputs[1].type, node.outputs[1]),
+            ]
         )
 
         @numba_basic.numba_njit
@@ -173,9 +176,11 @@ def numba_funcify_QRFull(op, node, **kwargs):
         )
 
         if len(node.outputs) > 1:
-            ret_sig = numba.types.Tuple([get_numba_type(o.type) for o in node.outputs])
+            ret_sig = numba.types.Tuple(
+                [get_numba_type(o.type, o) for o in node.outputs]
+            )
         else:
-            ret_sig = get_numba_type(node.outputs[0].type)
+            ret_sig = get_numba_type(node.outputs[0].type, node.outputs[0])
 
         @numba_basic.numba_njit
         def qr_full(x):

--- a/aesara/link/numba/dispatch/sparse.py
+++ b/aesara/link/numba/dispatch/sparse.py
@@ -214,7 +214,7 @@ def overload_sparse_copy(inst):
 
 
 @get_numba_type.register(SparseTensorType)
-def get_numba_type_SparseType(aesara_type, **kwargs):
+def get_numba_type_SparseType(aesara_type, var, **kwargs):
     dtype = from_dtype(np.dtype(aesara_type.dtype))
 
     if aesara_type.format == "csr":

--- a/aesara/scan/op.py
+++ b/aesara/scan/op.py
@@ -3427,7 +3427,7 @@ def profile_printer(
             )
 
 
-@op_debug_information.register(Scan)
+@op_debug_information.register(Scan)  # type: ignore[has-type]
 def _op_debug_information_Scan(op, node):
     from typing import Sequence
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -308,6 +308,9 @@ check_untyped_defs = False
 ignore_errors = True
 check_untyped_defs = False
 
+[mypy-aesara.scan.op]
+warn_unused_ignores = False
+
 [mypy-aesara.link.numba.dispatch.extra_ops]
 ignore_errors = True
 check_untyped_defs = False

--- a/tests/link/numba/test_basic.py
+++ b/tests/link/numba/test_basic.py
@@ -246,7 +246,7 @@ def compare_numba_and_py(
 
 
 @pytest.mark.parametrize(
-    "v, expected, force_scalar",
+    "typ, expected, force_scalar",
     [
         (MyType(), numba.types.pyobject, False),
         (
@@ -267,9 +267,17 @@ def compare_numba_and_py(
         (at.dmatrix, numba.types.float64, True),
     ],
 )
-def test_get_numba_type(v, expected, force_scalar):
-    res = numba_basic.get_numba_type(v, force_scalar=force_scalar)
+def test_get_numba_type(typ, expected, force_scalar):
+    res = numba_basic.get_numba_type(typ, typ(), force_scalar=force_scalar)
     assert res == expected
+
+
+def test_get_numba_type_readonly():
+    typ = at.dmatrix
+    var = typ()
+    var.tag.indestructible = True
+    res = numba_basic.get_numba_type(typ, var)
+    assert not res.mutable
 
 
 @pytest.mark.parametrize(

--- a/tests/link/numba/test_elemwise.py
+++ b/tests/link/numba/test_elemwise.py
@@ -507,3 +507,13 @@ def test_MaxAndArgmax(x, axes, exc):
                 if not isinstance(i, (SharedVariable, Constant))
             ],
         )
+
+
+def test_sum_broadcast_to():
+    """Make sure that we handle the writability of `BroadcastTo` results correctly."""
+
+    x = at.vector("x")
+    out = at.broadcast_to(x, (2, 2)).sum()
+
+    x_val = np.array([1, 2], dtype=config.floatX)
+    compare_numba_and_py(((x,), (out,)), [x_val])


### PR DESCRIPTION
This PR adds support for read-only types via our loosely established `Variable.tag.indestructible` flag.

This PR also closes #1221 by simply ignoring those errors and disabling `warn_unused_ignores` for that specific module.