### PR TITLE
Add JAX implementation for `LogNormalRV`

### DIFF
--- a/aesara/link/jax/dispatch/random.py
+++ b/aesara/link/jax/dispatch/random.py
@@ -277,3 +277,18 @@ def jax_sample_fn_permutation(op):
         return (rng, sample)
 
     return sample_fn
+
+
+@jax_sample_fn.register(aer.LogNormalRV)
+def jax_sample_fn_lognormal(op):
+    """JAX implementation of `LogNormalRV`."""
+
+    def sample_fn(rng, size, dtype, *parameters):
+        rng_key = rng["jax_state"]
+        loc, scale = parameters
+        sample = loc + jax.random.normal(rng_key, size, dtype) * scale
+        sample_exp = jax.numpy.exp(sample)
+        rng["jax_state"] = jax.random.split(rng_key, num=1)[0]
+        return (rng, sample_exp)
+
+    return sample_fn

--- a/tests/link/jax/test_random.py
+++ b/tests/link/jax/test_random.py
@@ -166,6 +166,22 @@ def test_random_updates(rng_ctor):
             lambda *args: args,
         ),
         (
+            aer.lognormal,
+            [
+                set_test_value(
+                    at.lvector(),
+                    np.array([0, 0], dtype=np.int64),
+                ),
+                set_test_value(
+                    at.dscalar(),
+                    np.array(1.0, dtype=np.float64),
+                ),
+            ],
+            (2,),
+            "lognorm",
+            lambda *args: args,
+        ),
+        (
             aer.normal,
             [
                 set_test_value(


### PR DESCRIPTION
Closes: https://github.com/aesara-devs/aesara/issues/1325

References:

- https://stats.stackexchange.com/questions/110961/sampling-from-a-lognormal-distribution
- https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.lognorm.html