### PR TITLE
Add `MultinomialRV` JAX implementation

### DIFF
--- a/aesara/link/jax/dispatch/random.py
+++ b/aesara/link/jax/dispatch/random.py
@@ -7,6 +7,7 @@ from numpy.random.bit_generator import (  # type: ignore[attr-defined]
 )
 
 import aesara.tensor.random.basic as aer
+from aesara.graph.basic import Constant
 from aesara.link.jax.dispatch.basic import jax_funcify, jax_typify
 from aesara.link.jax.dispatch.shape import JAXShapeTuple
 from aesara.tensor.shape import Shape, Shape_i
@@ -37,6 +38,10 @@ def assert_size_argument_jax_compatible(node):
 
     """
     size = node.inputs[1]
+
+    if isinstance(size, Constant):
+        return
+
     size_op = size.owner.op
     if not isinstance(size_op, (Shape, Shape_i, JAXShapeTuple)):
         raise NotImplementedError(SIZE_NOT_COMPATIBLE)


### PR DESCRIPTION
This draft PR is a work in progress and contains a JAX implementation of `MultinomialRV` for issue #1326. The implementation builds off the `Multinomial Distribution` [implementation](https://num.pyro.ai/en/v0.2.4/_modules/numpyro/distributions/util.html) in NumPyro. Likewise, the output is similar to that of the `numpy` [implementation](https://numpy.org/doc/stable/reference/random/generated/numpy.random.multinomial.html).  Below, you will find a brief outline of the functions used to construct the `MultinomialRV`. 

`def _categorical(key, p, shape)`

- returns the outcomes $k$ with probability $p$ for each trial / experiment $n$. 

`def _scatter_add_ones(operand, indices, update)` 

- returns the outcome counts by utilising the `jax.lax.scatter_add()` function
- `operand` is a zero filled array. 
- `indices` is the `outcomes` array with an added dimension and specifies the indices to which the update should be applied to. 
- `update` is an array filled with ones and can be thought of as a `cnt += 1` for each $K = k$ occurrence.
- In summary, the `operand` array is updated `+1` using the `update` array according to the outcomes in the `indices` array.

I still need to add a test for this. Thanks!

