### PR TITLE
Add `HalfNormalRV` JAX implementation

### DIFF
--- a/aesara/link/jax/dispatch/random.py
+++ b/aesara/link/jax/dispatch/random.py
@@ -260,6 +260,28 @@ def jax_sample_fn_t(op):
     return sample_fn
 
 
+@jax_sample_fn.register(aer.HalfNormalRV)
+def jax_sample_fn_halfnormal(op):
+    """JAX implementation of `HalfNormalRV`."""
+
+    def sample_fn(rng, size, dtype, *parameters):
+        rng_key = rng["jax_state"]
+        rng_key, sampling_key = jax.random.split(rng_key, 2)
+        (
+            loc,
+            scale,
+        ) = parameters
+        sample = (
+            loc
+            + jax.random.truncated_normal(sampling_key, 0.0, jax.numpy.inf, size, dtype)
+            * scale
+        )
+        rng["jax_state"] = rng_key
+        return (rng, sample)
+
+    return sample_fn
+
+
 @jax_sample_fn.register(aer.ChoiceRV)
 def jax_funcify_choice(op):
     """JAX implementation of `ChoiceRV`."""

--- a/tests/link/jax/test_random.py
+++ b/tests/link/jax/test_random.py
@@ -280,6 +280,22 @@ def test_random_updates(rng_ctor):
             "uniform",
             lambda *args: args,
         ),
+        (
+            aer.halfnormal,
+            [
+                set_test_value(
+                    at.dvector(),
+                    np.array([-1.0, 2.0], dtype=np.float64),
+                ),
+                set_test_value(
+                    at.dscalar(),
+                    np.array(1000.0, dtype=np.float64),
+                ),
+            ],
+            (2,),
+            "halfnorm",
+            lambda *args: args,
+        ),
     ],
 )
 def test_random_RandomVariable(rv_op, dist_params, base_size, cdf_name, params_conv):


### PR DESCRIPTION
This for #1335. The distribution does not exist exactly in `jax.random`, but it can be easily transformed. I chose `loc + jax.random.truncated_normal(rng_key, 0.0, jax.numpy.inf, size, dtype) * scale`, but you could equally choose `loc + jax.numpy.abs(jax.random.normal(rng_key, size, dtype)) * scale`. It's up to the maintainers to decide which they prefer. The tests work but I'm happy to implement more tests if desired.

Might also need to consider key splitting order #1345.

Side note: I'm more familiar with the numpyro/tfp-style HalfNormal distributions, which have a single `scale` parameter are centred at zero. 

--------

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [ ] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [x] There are tests covering the changes introduced in the PR.


