### PR TITLE
Add `random` alias to `aesara.tensor.random.basic`

### DIFF
--- a/aesara/tensor/random/basic.py
+++ b/aesara/tensor/random/basic.py
@@ -2086,6 +2086,9 @@ class PermutationRV(RandomVariable):
 permutation = PermutationRV()
 
 
+random = uniform
+
+
 __all__ = [
     "permutation",
     "choice",
@@ -2126,4 +2129,5 @@ __all__ = [
     "negative_binomial",
     "gengamma",
     "t",
+    "random",
 ]

--- a/tests/tensor/random/test_basic.py
+++ b/tests/tensor/random/test_basic.py
@@ -47,6 +47,7 @@ from aesara.tensor.random.basic import (
     permutation,
     poisson,
     randint,
+    random,
     standard_normal,
     t,
     triangular,
@@ -301,6 +302,10 @@ def test_normal_samples(mean, sigma, size):
 
 def test_normal_default_args():
     compare_sample_values(standard_normal)
+
+
+def test_random_default_args():
+    compare_sample_values(random)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION

Close #1353 

This PR will add random() function in RandomStream.
For the testsuite I just copy that as standard_normal() does, look for some feedback.