### PR TITLE
Use `jax.Array` for type checking in tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ pytest
 cython
 sympy
 versioneer
-jax
-jaxlib
+jax>=0.4.1
+jaxlib>=0.4.1
 numba>=0.55
 numba-scipy>=0.3.0
 diff-cover

--- a/tests/link/jax/test_basic.py
+++ b/tests/link/jax/test_basic.py
@@ -74,11 +74,9 @@ def compare_jax_and_py(
 
     if must_be_device_array:
         if isinstance(jax_res, list):
-            assert all(
-                isinstance(res, jax.interpreters.xla.DeviceArray) for res in jax_res
-            )
+            assert all(isinstance(res, jax.Array) for res in jax_res)
         else:
-            assert isinstance(jax_res, jax.interpreters.xla.DeviceArray)
+            assert isinstance(jax_res, jax.Array)
 
     aesara_py_fn = function(fn_inputs, fgraph.outputs, mode=py_mode)
     py_res = aesara_py_fn(*test_inputs)
@@ -149,13 +147,13 @@ def test_shared():
     aesara_jax_fn = function([], a, mode="JAX")
     jax_res = aesara_jax_fn()
 
-    assert isinstance(jax_res, jax.interpreters.xla.DeviceArray)
+    assert isinstance(jax_res, jax.Array)
     np.testing.assert_allclose(jax_res, a.get_value())
 
     aesara_jax_fn = function([], a * 2, mode="JAX")
     jax_res = aesara_jax_fn()
 
-    assert isinstance(jax_res, jax.interpreters.xla.DeviceArray)
+    assert isinstance(jax_res, jax.Array)
     np.testing.assert_allclose(jax_res, a.get_value() * 2)
 
     # Changed the shared value and make sure that the JAX-compiled
@@ -164,7 +162,7 @@ def test_shared():
     a.set_value(new_a_value)
 
     jax_res = aesara_jax_fn()
-    assert isinstance(jax_res, jax.interpreters.xla.DeviceArray)
+    assert isinstance(jax_res, jax.Array)
     np.testing.assert_allclose(jax_res, new_a_value * 2)
 
 


### PR DESCRIPTION
JAX's 0.4.1 release introduces `jax.Array` which [replaces `DeviceArray`](https://jax.readthedocs.io/en/latest/jax_array_migration.html). Tests were failing in CI because they are currently checking that the arrays returned by the compiled functions are `DeviceArray`. 

I updated the tests and added a constraint on the JAX version in `requirements.txt`.