### PR TITLE
Downgrade flake8 pre-commit for py37 compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,10 +25,11 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    # NOTE: flake8 v6 requires python >=3.8.1 but
+    # Aesara still supports python 3.7.
+    rev: 5.0.4
     hooks:
       - id: flake8
-        language_version: python39
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:


### PR DESCRIPTION
Closes #1373

Aesara's minimum-supported Python version is 3.7, and it's probably really convenient to develop with that version in order to avoid using incompatible language features. Then of course you want to run pre-commit, but for that you either need a higher version of Python (>=3.8.1) or a lower (<=5.0.4) version of flake8.

It seems to me like the most straightforward solution is to revert flake8 to 5.0.4 (the second-most-recent release, August) until Aesara drops support for Python 3.7.


**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [X] There is an informative high-level description of the changes.
+ [X] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [X] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [X] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
