### PR TITLE
Update setup-python action version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,6 @@ jobs:
         run: python -m build --sdist .
         env:
           BUILD_AESARA_NIGHTLY: true
-      - uses: pypa/gh-action-pypi-publish@v1.4.2
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.nightly_pypi_secret }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
       - name: Install dependencies

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - name: Build the sdist and the wheel

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -63,7 +63,6 @@ jobs:
         with:
           name: artifact
           path: dist
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.pypi_secret }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
     if: ${{ needs.changes.outputs.changes == 'true' }}
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.9'
     - uses: pre-commit/action@v3.0.0
@@ -221,7 +221,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 

--- a/aesara/tensor/math.py
+++ b/aesara/tensor/math.py
@@ -40,7 +40,7 @@ from aesara.tensor.type import (
 )
 from aesara.tensor.type_other import NoneConst
 from aesara.tensor.utils import as_list
-from aesara.tensor.var import TensorConstant, _tensor_py_operators
+from aesara.tensor.var import TensorConstant
 
 
 if TYPE_CHECKING:
@@ -1447,15 +1447,9 @@ def real(z):
     """Return real component of complex-valued tensor `z`"""
 
 
-_tensor_py_operators.real = property(real)
-
-
 @scalar_elemwise
 def imag(z):
     """Return imaginary component of complex-valued tensor `z`"""
-
-
-_tensor_py_operators.imag = property(imag)
 
 
 @scalar_elemwise

--- a/aesara/tensor/var.py
+++ b/aesara/tensor/var.py
@@ -814,6 +814,14 @@ class _tensor_py_operators:
         """Return selected slices only."""
         return at.extra_ops.compress(self, a, axis=axis)
 
+    @property
+    def real(self):
+        return at.math.real(self)
+
+    @property
+    def imag(self):
+        return at.math.imag(self)
+
 
 class TensorVariable(
     _tensor_py_operators, Variable[_TensorTypeType, OptionalApplyType]

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.7
+  - python=3.9
   - gcc_linux-64
   - gxx_linux-64
   - numpy

--- a/doc/library/tensor/basic.rst
+++ b/doc/library/tensor/basic.rst
@@ -667,12 +667,6 @@ dimensions, see :meth:`_tensor_py_operators.dimshuffle`.
     >>> aesara.tensor.shape_padaxis(tensor, axis=-1)
     InplaceDimShuffle{0,1,2,x}.0
 
-.. autofunction:: unbroadcast(x, *axes)
-
-.. autofunction:: addbroadcast(x, *axes)
-
-.. autofunction:: patternbroadcast(x, broadcastable)
-
 .. function:: flatten(x, ndim=1)
 
     Similar to :func:`reshape`, but the shape is inferred from the shape of `x`.


### PR DESCRIPTION
This PR updates the `setup-python` action in our workflows, which should remove a few of the deprecation warnings.

It looks like there are some [Python version issues in the docs build process](https://readthedocs.org/projects/aesara/builds/19033190/), so this PR includes some commits that address those issues.