### PR TITLE
Add GHA workflow to autoupdate GHA workflows

### DIFF
--- a/.github/workflows/update-gha.yml
+++ b/.github/workflows/update-gha.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}
-          committer_username: 'Aesara Bot'
-          committer_email: 'aesarabot@users.noreply.github.com'
+          committer_username: 'aesara-machine-user'
+          committer_email: 'aesara-machine-user@users.noreply.github.com'
           update_version_with: 'release-tag'
           release_types: "major, minor, patch"

--- a/.github/workflows/update-gha.yml
+++ b/.github/workflows/update-gha.yml
@@ -1,0 +1,30 @@
+name: GitHub Actions Version Updater
+# <https://github.com/marketplace/actions/github-actions-version-updater>
+
+# Controls when the action will run.
+on:
+  # can be used to run workflow manually
+  workflow_dispatch:
+  schedule:
+    # Automatically run on 07:26 UTC every Monday
+    - cron:  '26 7 * * 1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # [Required] Access token with `workflow` scope.
+          token: ${{ secrets.WORKFLOW_SECRET }}
+
+      - name: Run GitHub Actions Version Updater
+        uses: saadmk11/github-actions-version-updater@v0.7.2
+        with:
+          # [Required] Access token with `workflow` scope.
+          token: ${{ secrets.WORKFLOW_SECRET }}
+          committer_username: 'Aesara Bot'
+          committer_email: 'aesarabot@users.noreply.github.com'
+          update_version_with: 'release-tag'
+          release_types: "major, minor, patch"


### PR DESCRIPTION
Here's an example of what we'd need to autoupdate the GHA workflow versions.

GitHub security based on the `GITHUB_TOKEN` secret prohibits workflows from modifying workflow files. Thus unfortunately this **requires** a personal access token with `repo` and `workflow` scope. (See https://github.com/marketplace/actions/github-actions-version-updater#important-note, and to confirm, I've independently seen this restriction cause issues with Conda-Forge infrastructure.)

**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [X] There is an informative high-level description of the changes.
+ [X] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [X] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [X] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
