### PR TITLE
Set nightly build project.name in pyproject.toml

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,6 @@
-name: Nightly
+name: Development builds
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
 
@@ -15,10 +16,16 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - name: Install dependencies
+      - name: Install dependencies and customize pyproject.toml
         run: |
-          python -m pip install -U pip
-          python -m pip install build
+          # Download dasel to modify pyproject.toml
+          curl -sSLf https://github.com/TomWright/dasel/releases/download/v2.0.2/dasel_linux_amd64 \
+            -L -o /tmp/dasel && chmod +x /tmp/dasel
+
+          /tmp/dasel put -f pyproject.toml project.name -v aesara-nightly
+
+          # Install build prerequisites
+          python -m pip install -U pip build
       - name: Build the sdist
         run: python -m build --sdist .
         env:

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,8 @@ import versioneer
 dist = Distribution()
 dist.parse_config_files()
 
-
-NAME: str = dist.get_name()  # type: ignore
-
 # Handle builds of nightly release
 if "BUILD_AESARA_NIGHTLY" in os.environ:
-    NAME += "-nightly"
-
     from versioneer import get_versions as original_get_versions
 
     def get_versions():
@@ -32,7 +27,6 @@ if "BUILD_AESARA_NIGHTLY" in os.environ:
 
 if __name__ == "__main__":
     setup(
-        name=NAME,
         version=versioneer.get_version(),
         cmdclass=versioneer.get_cmdclass(),
     )


### PR DESCRIPTION
Closes #1379

It seems that `python -m build .` ignores the project name from the `setuptools.setup` function when running `setup.py`. This commit moves the dynamic project name from `setup.py` to the `nightly.yml` workflow, using the `dasel` command-line tool to modify `project.name` in `pyproject.toml`.

I also add a `workflow_dispatch` trigger to `nightly.yml` for testing.

**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [X] There is an informative high-level description of the changes.
+ [X] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [X] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [X] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
