### PR TITLE
Move aesara-cache into aesara.bin package

### DIFF
--- a/aesara/bin/aesara_cache.py
+++ b/aesara/bin/aesara_cache.py
@@ -1,0 +1,109 @@
+import logging
+import os
+import sys
+
+
+if sys.platform == "win32":
+    config_for_aesara_cache_script = "cxx=,device=cpu"
+    aesara_flags = os.environ["AESARA_FLAGS"] if "AESARA_FLAGS" in os.environ else ""
+    if aesara_flags:
+        aesara_flags += ","
+    aesara_flags += config_for_aesara_cache_script
+    os.environ["AESARA_FLAGS"] = aesara_flags
+
+import aesara
+import aesara.compile.compiledir
+from aesara import config
+from aesara.link.c.basic import get_module_cache
+
+
+_logger = logging.getLogger("aesara.bin.aesara-cache")
+
+
+def print_help(exit_status):
+    if exit_status:
+        print(f"command \"{' '.join(sys.argv)}\" not recognized")
+    print('Type "aesara-cache" to print the cache location')
+    print('Type "aesara-cache help" to print this help')
+    print('Type "aesara-cache clear" to erase the cache')
+    print('Type "aesara-cache list" to print the cache content')
+    print('Type "aesara-cache unlock" to unlock the cache directory')
+    print(
+        'Type "aesara-cache cleanup" to delete keys in the old ' "format/code version"
+    )
+    print('Type "aesara-cache purge" to force deletion of the cache directory')
+    print(
+        'Type "aesara-cache basecompiledir" '
+        "to print the parent of the cache directory"
+    )
+    print(
+        'Type "aesara-cache basecompiledir list" '
+        "to print the content of the base compile dir"
+    )
+    print(
+        'Type "aesara-cache basecompiledir purge" '
+        "to remove everything in the base compile dir, "
+        "that is, erase ALL cache directories"
+    )
+    sys.exit(exit_status)
+
+
+def main():
+    if len(sys.argv) == 1:
+        print(config.compiledir)
+    elif len(sys.argv) == 2:
+        if sys.argv[1] == "help":
+            print_help(exit_status=0)
+        if sys.argv[1] == "clear":
+            # We skip the refresh on module cache creation because the refresh will
+            # be done when calling clear afterwards.
+            cache = get_module_cache(init_args=dict(do_refresh=False))
+            cache.clear(
+                unversioned_min_age=-1, clear_base_files=True, delete_if_problem=True
+            )
+
+            # Print a warning if some cached modules were not removed, so that the
+            # user knows he should manually delete them, or call
+            # aesara-cache purge, # to properly clear the cache.
+            items = [
+                item
+                for item in sorted(os.listdir(cache.dirname))
+                if item.startswith("tmp")
+            ]
+            if items:
+                _logger.warning(
+                    "There remain elements in the cache dir that you may "
+                    "need to erase manually. The cache dir is:\n  %s\n"
+                    'You can also call "aesara-cache purge" to '
+                    "remove everything from that directory." % config.compiledir
+                )
+                _logger.debug(f"Remaining elements ({len(items)}): {', '.join(items)}")
+        elif sys.argv[1] == "list":
+            aesara.compile.compiledir.print_compiledir_content()
+        elif sys.argv[1] == "cleanup":
+            aesara.compile.compiledir.cleanup()
+            cache = get_module_cache(init_args=dict(do_refresh=False))
+            cache.clear_old()
+        elif sys.argv[1] == "unlock":
+            aesara.compile.compilelock.force_unlock(config.compiledir)
+            print("Lock successfully removed!")
+        elif sys.argv[1] == "purge":
+            aesara.compile.compiledir.compiledir_purge()
+        elif sys.argv[1] == "basecompiledir":
+            # Simply print the base_compiledir
+            print(aesara.config.base_compiledir)
+        else:
+            print_help(exit_status=1)
+    elif len(sys.argv) == 3 and sys.argv[1] == "basecompiledir":
+        if sys.argv[2] == "list":
+            aesara.compile.compiledir.basecompiledir_ls()
+        elif sys.argv[2] == "purge":
+            aesara.compile.compiledir.basecompiledir_purge()
+        else:
+            print_help(exit_status=1)
+    else:
+        print_help(exit_status=1)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/__init__.py
+++ b/bin/__init__.py
@@ -1,0 +1,8 @@
+import warnings
+
+warnings.warn(
+    message= "Importing 'bin.aesara_cache' is deprecated. Import from "
+    "'aesara.bin.aesara_cache' instead.",
+    category=DeprecationWarning,
+    stacklevel=2,  # Raise the warning on the import line
+)

--- a/bin/aesara-cache
+++ b/bin/aesara-cache
@@ -1,3 +1,12 @@
 #!/usr/bin/env python
-import aesara_cache
-aesara_cache.main()
+import warnings
+
+from aesara.bin.aesara_cache import main
+
+
+warnings.warn(
+    message= "Using this bin/aesara-cache script is deprecated. Use the plain "
+    "aesara-cache command which is installed along with aesara.",
+    category=DeprecationWarning,
+)
+main()

--- a/bin/aesara_cache.py
+++ b/bin/aesara_cache.py
@@ -1,111 +1,14 @@
 #!/usr/bin/env python
 
-import logging
-import os
-import sys
+import warnings
 
-
-if sys.platform == "win32":
-    config_for_aesara_cache_script = "cxx=,device=cpu"
-    aesara_flags = os.environ["AESARA_FLAGS"] if "AESARA_FLAGS" in os.environ else ""
-    if aesara_flags:
-        aesara_flags += ","
-    aesara_flags += config_for_aesara_cache_script
-    os.environ["AESARA_FLAGS"] = aesara_flags
-
-import aesara
-import aesara.compile.compiledir
-from aesara import config
-from aesara.link.c.basic import get_module_cache
-
-
-_logger = logging.getLogger("aesara.bin.aesara-cache")
-
-
-def print_help(exit_status):
-    if exit_status:
-        print(f"command \"{' '.join(sys.argv)}\" not recognized")
-    print('Type "aesara-cache" to print the cache location')
-    print('Type "aesara-cache help" to print this help')
-    print('Type "aesara-cache clear" to erase the cache')
-    print('Type "aesara-cache list" to print the cache content')
-    print('Type "aesara-cache unlock" to unlock the cache directory')
-    print(
-        'Type "aesara-cache cleanup" to delete keys in the old ' "format/code version"
-    )
-    print('Type "aesara-cache purge" to force deletion of the cache directory')
-    print(
-        'Type "aesara-cache basecompiledir" '
-        "to print the parent of the cache directory"
-    )
-    print(
-        'Type "aesara-cache basecompiledir list" '
-        "to print the content of the base compile dir"
-    )
-    print(
-        'Type "aesara-cache basecompiledir purge" '
-        "to remove everything in the base compile dir, "
-        "that is, erase ALL cache directories"
-    )
-    sys.exit(exit_status)
-
-
-def main():
-    if len(sys.argv) == 1:
-        print(config.compiledir)
-    elif len(sys.argv) == 2:
-        if sys.argv[1] == "help":
-            print_help(exit_status=0)
-        if sys.argv[1] == "clear":
-            # We skip the refresh on module cache creation because the refresh will
-            # be done when calling clear afterwards.
-            cache = get_module_cache(init_args=dict(do_refresh=False))
-            cache.clear(
-                unversioned_min_age=-1, clear_base_files=True, delete_if_problem=True
-            )
-
-            # Print a warning if some cached modules were not removed, so that the
-            # user knows he should manually delete them, or call
-            # aesara-cache purge, # to properly clear the cache.
-            items = [
-                item
-                for item in sorted(os.listdir(cache.dirname))
-                if item.startswith("tmp")
-            ]
-            if items:
-                _logger.warning(
-                    "There remain elements in the cache dir that you may "
-                    "need to erase manually. The cache dir is:\n  %s\n"
-                    'You can also call "aesara-cache purge" to '
-                    "remove everything from that directory." % config.compiledir
-                )
-                _logger.debug(f"Remaining elements ({len(items)}): {', '.join(items)}")
-        elif sys.argv[1] == "list":
-            aesara.compile.compiledir.print_compiledir_content()
-        elif sys.argv[1] == "cleanup":
-            aesara.compile.compiledir.cleanup()
-            cache = get_module_cache(init_args=dict(do_refresh=False))
-            cache.clear_old()
-        elif sys.argv[1] == "unlock":
-            aesara.compile.compilelock.force_unlock(config.compiledir)
-            print("Lock successfully removed!")
-        elif sys.argv[1] == "purge":
-            aesara.compile.compiledir.compiledir_purge()
-        elif sys.argv[1] == "basecompiledir":
-            # Simply print the base_compiledir
-            print(aesara.config.base_compiledir)
-        else:
-            print_help(exit_status=1)
-    elif len(sys.argv) == 3 and sys.argv[1] == "basecompiledir":
-        if sys.argv[2] == "list":
-            aesara.compile.compiledir.basecompiledir_ls()
-        elif sys.argv[2] == "purge":
-            aesara.compile.compiledir.basecompiledir_purge()
-        else:
-            print_help(exit_status=1)
-    else:
-        print_help(exit_status=1)
-
+from aesara.bin.aesara_cache import *
+from aesara.bin.aesara_cache import _logger
 
 if __name__ == "__main__":
+    warnings.warn(
+        message= "Running 'aesara_cache.py' is deprecated. Use the aesara-cache "
+        "script instead.",
+        category=DeprecationWarning,
+    )
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ file = "DESCRIPTION.txt"
 content-type = "text/x-rst"
 
 [project.scripts]
-aesara-cache = "bin.aesara_cache:main"
+aesara-cache = "aesara.bin.aesara_cache:main"
 
 [tool.setuptools]
 platforms = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,10 +130,10 @@ relative_files = true
 
 [tool.coverage.report]
 omit = [
+    "aesara/bin/aesara_cache.py",
     "aesara/_version.py",
     "tests/*",
     "bin/aesara_cache.py",
-    "aesara/bin/aesara_cache.py",
 ]
 exclude_lines = [
     "pragma: no cover",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,8 @@ relative_files = true
 omit = [
     "aesara/_version.py",
     "tests/*",
+    "bin/aesara_cache.py",
+    "aesara/bin/aesara_cache.py",
 ]
 exclude_lines = [
     "pragma: no cover",


### PR DESCRIPTION
As observed in https://github.com/aesara-devs/aesara/pull/1375#issuecomment-1368566714, 

> Additionally, I noticed that aesara-cache is being installed in a top-level module called bin. This seems very undesirable, as it should probably instead go under aesara.bin. I will make a subsequent PR to address this.

In order to hopefully avoid breaking existing stuff, the old scripts are still there, but now with deprecation warnings.

**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [X] There is an informative high-level description of the changes.
+ [X] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [X] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [X] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
