### PR TITLE
Give a CI error message when lazylinker_c.c missing

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -39,7 +39,8 @@ jobs:
           python -m venv venv-sdist
           venv-sdist/bin/python -m pip install ../dist/aesara-*.tar.gz
           venv-sdist/bin/python -c "import aesara;print(aesara.__version__)"
-          test -n "$(find . -name lazylinker_c.c)"
+          echo "Checking for lazylinker_c.c..."
+          test -n "$(find . -name lazylinker_c.c)" && echo "Found lazylinker_c.c"
       - name: Check the wheel installs and imports
         run: |
           mkdir -p test-wheel
@@ -47,7 +48,8 @@ jobs:
           python -m venv venv-wheel
           venv-wheel/bin/python -m pip install ../dist/aesara-*.whl
           venv-wheel/bin/python -c "import aesara;print(aesara.__version__)"
-          test -n "$(find . -name lazylinker_c.c)"
+          echo "Checking for lazylinker_c.c..."
+          test -n "$(find . -name lazylinker_c.c)" && echo "Found lazylinker_c.c"
       - uses: actions/upload-artifact@v2
         with:
           name: artifact


### PR DESCRIPTION
Without this, when `lazylinker_c.c` is missing, the CI suddenly errors without any message.

**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [X] There is an informative high-level description of the changes.
+ [X] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [X] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [X] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
