### PR TITLE
Ensure git archives contains version info

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst


### PR DESCRIPTION
Using setuptools-scm to resolve the version of a source archive is not possible unless that information is exported during the archival process. This creates issues for downstream packagers as they must manually add version information in their packages or switch to another source.

See https://github.com/pypa/setuptools_scm/#git-archive for more information.