### PR TITLE
Adapt dev-builds settings for hatch-vcs

### DIFF
--- a/.github/workflows/dev-builds.yml
+++ b/.github/workflows/dev-builds.yml
@@ -25,8 +25,8 @@ jobs:
           # Modify pyproject.toml to set the nightly version in the form of
           # x.y.z.postN, where N is the number of commits since the last release
           /tmp/dasel put -f pyproject.toml project.name -v aesara-nightly
-          /tmp/dasel put -f pyproject.toml tool.setuptools_scm.version_scheme -v post-release
-          /tmp/dasel put -f pyproject.toml tool.setuptools_scm.local_scheme -v no-local-version
+          /tmp/dasel put -f pyproject.toml tool.hatch.version.raw-options.version_scheme -v post-release
+          /tmp/dasel put -f pyproject.toml tool.hatch.version.raw-options.local_scheme -v no-local-version
 
           # Install build prerequisites
           python -m pip install -U pip build


### PR DESCRIPTION
When switching from setuptools to Hatch, we switched from setuptools_scm to Hatch's "hatch-vcs" wrapper of setuptools_scm. The keys for passing raw options to setuptools_scm need to be adapted accordingly in the `pyproject.toml`.

Closes #1406 

**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [X] There is an informative high-level description of the changes.
+ [X] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [X] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [X] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
