### PR TITLE
Add `SharedVariable.default_update` graphs to `debugprint`

### DIFF
--- a/tests/graph/utils.py
+++ b/tests/graph/utils.py
@@ -13,7 +13,7 @@ def is_variable(x):
 
 
 class MyType(Type):
-    def filter(self, data):
+    def filter(self, data, **kwargs):
         return data
 
     def __eq__(self, other):
@@ -27,7 +27,7 @@ class MyType(Type):
 
 
 class MyType2(Type):
-    def filter(self, data):
+    def filter(self, data, **kwargs):
         return data
 
     def __eq__(self, other):


### PR DESCRIPTION
This PR adds a `print_default_updates` option to `debugprint` that shows all the
`SharedVariable.default_update`s in a graph.

``` python
import aesara
import aesara.tensor as at


srng = at.random.RandomStream(903902)

a = at.vector("a")
mu = 2 * a
sigma = srng.invgamma(0.5, 0.5, name="sigma")
X_rv = srng.normal(mu, at.sqrt(sigma), name="X")

aesara.dprint(X_rv, print_default_updates=True)
# normal_rv{0, (0, 0), floatX, False}.1 [id A] 'X'
#  |RandomGeneratorSharedVariable(<Generator(PCG64) at 0x7F2A98FAED60>) [id B] <- [id A]
#  |TensorConstant{[]} [id C]
#  |TensorConstant{11} [id D]
#  |Elemwise{mul,no_inplace} [id E]
#  | |InplaceDimShuffle{x} [id F]
#  | | |TensorConstant{2} [id G]
#  | |a [id H]
#  |Elemwise{sqrt,no_inplace} [id I]
#    |invgamma_rv{0, (0, 0), floatX, False}.1 [id J] 'sigma'
#      |RandomGeneratorSharedVariable(<Generator(PCG64) at 0x7F2A98FAEBA0>) [id K] <- [id J]
#      |TensorConstant{[]} [id L]
#      |TensorConstant{11} [id M]
#      |TensorConstant{0.5} [id N]
#      |TensorConstant{0.5} [id O]
#
# Default updates:
#
# normal_rv{0, (0, 0), floatX, False}.0 [id A]
#  |RandomGeneratorSharedVariable(<Generator(PCG64) at 0x7F2A98FAED60>) [id B] <- [id A]
#  |TensorConstant{[]} [id C]
#  |TensorConstant{11} [id D]
#  |Elemwise{mul,no_inplace} [id E]
#  |Elemwise{sqrt,no_inplace} [id I]
#
# invgamma_rv{0, (0, 0), floatX, False}.0 [id J]
#  |RandomGeneratorSharedVariable(<Generator(PCG64) at 0x7F2A98FAEBA0>) [id K] <- [id J]
#  |TensorConstant{[]} [id L]
#  |TensorConstant{11} [id M]
#  |TensorConstant{0.5} [id N]
#  |TensorConstant{0.5} [id O]
```