### PR TITLE
Add support for `SharedVariable.default_update`s in `OpFromGraph`

### DIFF
--- a/aesara/graph/fg.py
+++ b/aesara/graph/fg.py
@@ -72,7 +72,7 @@ class FunctionGraph(MetaObject):
         outputs: Optional[Sequence[Variable]] = None,
         features: Optional[Sequence[Feature]] = None,
         clone: bool = True,
-        update_mapping: Optional[Dict[Variable, Variable]] = None,
+        update_mapping: Optional[Dict[int, int]] = None,
         **clone_kwds,
     ):
         """
@@ -90,8 +90,8 @@ class FunctionGraph(MetaObject):
         clone
             If ``True``, the graph will be cloned.
         update_mapping
-            Mapping between the `inputs` with updates and the `outputs`
-            corresponding to their updates.
+            Mapping between the `outputs` indices of update graphs and the `inputs`
+            indices that are updated with the former's values.
         clone_kwds
             Keywords passed to `clone_get_equiv` when `clone` is ``True``.
         """
@@ -153,7 +153,15 @@ class FunctionGraph(MetaObject):
             self.add_output(output, reason="init")
 
         self.profile = None
-        self.update_mapping = update_mapping
+
+        self.update_mapping = {}
+        self.inv_update_mapping = {}
+
+        if update_mapping:
+            for k, v in update_mapping.items():
+                self.update_mapping[k] = v
+                # `update_mapping` should be bijective, making this reasonable
+                self.inv_update_mapping[v] = k
 
     def add_output(
         self, var: Variable, reason: Optional[str] = None, import_missing: bool = False

--- a/aesara/scan/op.py
+++ b/aesara/scan/op.py
@@ -750,7 +750,9 @@ class Scan(Op, ScanMethodsMixin, HasInnerGraph):
             If ``True``, all the shared variables used in the inner-graph must be provided.
 
         """
-        self.fgraph, shared_inputs, _, _ = construct_nominal_fgraph(inputs, outputs)
+        self.fgraph, shared_inputs = construct_nominal_fgraph(inputs, outputs)
+
+        assert not self.fgraph.update_mapping
 
         # The shared variables should have been removed, so, if there are
         # any, it's because the user didn't specify an input.

--- a/aesara/tensor/__init__.py
+++ b/aesara/tensor/__init__.py
@@ -1,14 +1,14 @@
 """Symbolic tensor types and constructor functions."""
 
 from functools import singledispatch
-from typing import TYPE_CHECKING, Any, Callable, NoReturn, Optional, Sequence, Union
+from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, Union
 
 from aesara.graph.basic import Constant, Variable
 from aesara.graph.op import Op
 
 
 if TYPE_CHECKING:
-    from numpy.typing import ArrayLike, NDArray
+    from numpy.typing import ArrayLike
 
 
 TensorLike = Union[Variable, Sequence[Variable], "ArrayLike"]
@@ -156,7 +156,7 @@ from aesara.tensor.math import DEPRECATED_NAMES as MATH_DEPRECATED_NAMES
 # isort: on
 
 
-DEPRECATED_NAMES = MATH_DEPRECATED_NAMES
+DEPRECATED_NAMES: List[Tuple[str, str, object]] = MATH_DEPRECATED_NAMES
 
 
 def __getattr__(name):

--- a/aesara/tensor/math.py
+++ b/aesara/tensor/math.py
@@ -1,6 +1,6 @@
 import builtins
 import warnings
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
 
@@ -3142,7 +3142,7 @@ __all__ = [
     "hyp2f1_der",
 ]
 
-DEPRECATED_NAMES = [
+DEPRECATED_NAMES: List[Tuple[str, str, object]] = [
     ("abs_", "`abs_` is deprecated; use `abs` instead.", abs),
     ("inv", "`inv` is deprecated; use `reciprocal` instead.", reciprocal),
     (

--- a/tests/compile/test_builders.py
+++ b/tests/compile/test_builders.py
@@ -7,9 +7,12 @@ import aesara.tensor as at
 from aesara.compile import shared
 from aesara.compile.builders import OpFromGraph
 from aesara.compile.function import function
+from aesara.compile.mode import get_mode
+from aesara.compile.ops import update_placeholder
+from aesara.compile.sharedvalue import SharedVariable
 from aesara.configdefaults import config
 from aesara.gradient import DisconnectedType, Rop, disconnected_type, grad
-from aesara.graph.basic import equal_computations
+from aesara.graph.basic import Constant, equal_computations
 from aesara.graph.fg import FunctionGraph
 from aesara.graph.null_type import NullType
 from aesara.graph.rewriting.utils import rewrite_graph
@@ -424,8 +427,8 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
         assert results == expect_result
 
     def test_infer_shape(self):
-        # test infer shape does not need to against inline case
-        # since the Op is remove during optimization phase
+        # N.B. this test does not need to be run against the inline case,
+        # because the `Op` is supposed to be removed during optimization phase.
         x = matrix("x")
         y = matrix("y")
         o1 = x + y
@@ -559,6 +562,121 @@ class TestOpFromGraph(unittest_tools.InferShapeTester):
 
         # The original `op.fgraph` outputs should stay the same, though
         assert equal_computations(op.inner_outputs, [x**2 / x], op.inner_inputs, [x])
+
+    def test_default_updates(self):
+        """Make sure that default updates on shared variables raise errors."""
+
+        srng = at.random.RandomStream(1290984)
+        x = srng.gamma(0.5, 0.5, name="x")
+
+        srng = at.random.RandomStream(239)
+        y = srng.normal(x, name="y")
+
+        y_shared_variable = y.owner.inputs[0]
+        assert y_shared_variable.default_update is not None
+
+        # We don't want to in-place the RNG updates; that would avoid the
+        # update logic we're testing
+        mode = get_mode("FAST_RUN").excluding("inplace")
+
+        ofg = OpFromGraph([x], [y], inline=False, mode=mode)
+
+        x_val = at.as_tensor(0.0, dtype=x.type.dtype)
+        z = ofg(x_val)
+
+        z_fn = function([], z, mode=mode)
+
+        # The `y`'s mean should no longer be `x`
+        assert isinstance(z_fn.maker.fgraph.outputs[0].owner.inputs[0], Constant)
+
+        # There should be placeholder default updates in the resulting graph
+        (shared_variable,) = [
+            v for v in z_fn.maker.fgraph.variables if isinstance(v, SharedVariable)
+        ]
+
+        placeholder_var = shared_variable.default_update
+        assert placeholder_var.owner.op == update_placeholder
+        assert placeholder_var.owner.inputs[0] is shared_variable
+
+        # Since this `OpFromGraph` wasn't inlined, we should've removed the
+        # placeholder update.
+        assert not z_fn.maker.fgraph.update_mapping
+
+        # The compiled inner-graph should be performing the RNG updates
+        ig_ofg = z_fn.maker.fgraph.outputs[0].owner.op
+        # `OpFromGraph`s are cloned
+        # TODO: It's always worth revisiting whether or not we should be doing
+        # this (and if/when we can go without it).
+        # assert ig_ofg is ofg
+        assert ig_ofg.fgraph.update_mapping == {1: 1}
+
+        srng_exp = at.random.RandomStream(239)
+        exp_fn = function([], srng_exp.normal(x_val, name="y"), mode=mode)
+
+        (exp_shared_variable,) = [
+            v for v in exp_fn.maker.fgraph.variables if isinstance(v, SharedVariable)
+        ]
+        assert exp_shared_variable.default_update is not None
+
+        z_res = z_fn()
+        exp_res = exp_fn()
+
+        assert np.array_equal(z_res, exp_res)
+
+        # Execute again to make sure that the RNG is updated correctly
+        z_res_next = z_fn()
+        exp_res_next = exp_fn()
+
+        # Make sure nothing weird is going on here
+        assert not np.array_equal(exp_res, exp_res_next)
+
+        assert np.array_equal(z_res_next, exp_res_next)
+
+    def test_default_updates_inlined(self):
+
+        srng = at.random.RandomStream(1290984)
+        x = srng.gamma(0.5, 0.5, name="x")
+
+        srng = at.random.RandomStream(239)
+        y = srng.normal(x, name="y")
+
+        y_shared_variable = y.owner.inputs[0]
+        assert y_shared_variable.default_update is not None
+
+        mode = get_mode("FAST_RUN").excluding("inplace")
+
+        ofg = OpFromGraph([x], [y], inline=True, mode=mode)
+
+        x_val = at.as_tensor(0.0, dtype=x.type.dtype)
+        z = ofg(x_val)
+
+        z_fn = function([], z, mode=mode)
+
+        assert not any(
+            isinstance(node.op, OpFromGraph) for node in z_fn.maker.fgraph.apply_nodes
+        )
+
+        srng_exp = at.random.RandomStream(239)
+        exp_fn = function([], srng_exp.normal(x_val, name="y"), mode=mode)
+
+        (exp_shared_variable,) = [
+            v for v in exp_fn.maker.fgraph.variables if isinstance(v, SharedVariable)
+        ]
+        assert exp_shared_variable.default_update is not None
+
+        z_res = z_fn()
+        exp_res = exp_fn()
+
+        assert np.array_equal(z_res, exp_res)
+
+        # Execute again to make sure that the RNG is updated correctly
+        z_res_next = z_fn()
+        exp_res_next = exp_fn()
+
+        # Make sure nothing weird is going on here
+        assert not np.array_equal(exp_res, exp_res_next)
+
+        assert np.array_equal(z_res_next, exp_res_next)
 
 
 @config.change_flags(floatX="float64")

--- a/tests/graph/test_fg.py
+++ b/tests/graph/test_fg.py
@@ -65,7 +65,8 @@ class TestFunctionGraph:
         assert fg.inputs == [var1, var2]
         assert fg.outputs == [var3, var4]
         assert fg.apply_nodes == {var3.owner, var4.owner}
-        assert fg.update_mapping is None
+        assert fg.update_mapping == {}
+        assert fg.inv_update_mapping == {}
         assert fg.check_integrity() is None
         assert fg.variables == {var1, var2, var3, var4}
         assert fg.get_clients(var1) == [(var3.owner, 0)]
@@ -431,7 +432,9 @@ class TestFunctionGraph:
         node2_out = op2(var2, node1_out)
         node3_out = op3(node2_out)
 
-        fg = FunctionGraph([var1, var2], [node2_out, node3_out], clone=False)
+        fg = FunctionGraph(
+            [var1, var2], [node2_out, node3_out], clone=False, update_mapping={1: 1}
+        )
 
         fg.remove_output(0)
         fg.check_integrity()
@@ -439,8 +442,12 @@ class TestFunctionGraph:
         assert fg.apply_nodes == {node1_out.owner, node2_out.owner, node3_out.owner}
         assert fg.inputs == [var1, var2]
         assert fg.outputs == [node3_out]
+        assert fg.update_mapping == {0: 1}
+        assert fg.inv_update_mapping == {1: 0}
 
-        fg = FunctionGraph([var1, var2], [node2_out, node3_out], clone=False)
+        fg = FunctionGraph(
+            [var1, var2], [node2_out, node3_out], clone=False, update_mapping={1: 0}
+        )
 
         fg.remove_output(1)
         fg.check_integrity()
@@ -448,6 +455,8 @@ class TestFunctionGraph:
         assert fg.apply_nodes == {node1_out.owner, node2_out.owner}
         assert fg.inputs == [var1, var2]
         assert fg.outputs == [node2_out]
+        assert fg.update_mapping == {}
+        assert fg.inv_update_mapping == {}
 
         fg = FunctionGraph([var1, var2], [node2_out, node3_out, var1], clone=False)
 
@@ -554,16 +563,19 @@ class TestFunctionGraph:
         out3 = out1
 
         fg = FunctionGraph(
-            [var0, var1, var2, var3, var4],
+            [var0, var1, var4, var2, var3],
             [out0, out1, out2, out3],
             clone=False,
+            update_mapping={0: 3, 3: 2},
         )
 
-        fg.remove_input(4)
+        fg.remove_input(2)
         fg.check_integrity()
 
         assert fg.inputs == [var0, var1, var2, var3]
         assert fg.outputs == [out0]
+        assert fg.update_mapping == {0: 2}
+        assert fg.inv_update_mapping == {2: 0}
 
     def test_remove_in_and_out(self):
         var1 = MyVariable("var1")

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -510,10 +510,12 @@ def test_debugprint_inner_graph_default_updates():
 
     from aesara.compile.builders import OpFromGraph
 
-    igo = OpFromGraph([igo_in_1], [igo_out_1])
+    igo = OpFromGraph([r1, r2, igo_in_1], [igo_out_1])
 
     r3 = MyVariable("3")
-    out = igo(r3)
+    r4 = MyVariable("4")
+    r5 = MyVariable("5")
+    out = igo(r3, r4, r5)
 
     s = StringIO()
     debugprint(out, file=s, print_default_updates=True)
@@ -523,20 +525,21 @@ def test_debugprint_inner_graph_default_updates():
         r"""
         OpFromGraph{inline=False} [id A]
          |3 [id B]
-         |s [id C] <- [id D]
+         |4 [id C]
+         |5 [id D]
+         |s [id E] <- [id F]
 
         Inner graphs:
 
         OpFromGraph{inline=False} [id A]
-         >op2 [id E] 'igo1'
-         > |*0-<MyType()> [id F]
-         > |*1-<MyType()> [id G]
+         >op2 [id G] 'igo1'
+         > |*2-<MyType()> [id H]
+         > |*3-<MyType()> [id I]
 
         Default updates:
 
-        op1 [id D] 'o1'
-         |1 [id H]
-         |2 [id I]
+        UpdatePlaceholder [id F]
+         |s [id E] <- [id F]
         """
     ).lstrip()
 


### PR DESCRIPTION
This PR adds support for `SharedVariable.default_update`s in `OpFromGraph`, and some miscellaneous fixes to issues discovered along the way.

These changes also provide a means of implementing general support for updates in `OpFromGraph` (i.e. #1316).
