### PR TITLE
Add GenGammaRV jax implementation

### DIFF
--- a/aesara/link/jax/dispatch/random.py
+++ b/aesara/link/jax/dispatch/random.py
@@ -406,3 +406,37 @@ def jax_sample_fn_geometric(op):
         return (rng, sample_ceil)
 
     return sample_fn
+
+
+@jax_sample_fn.register(aer.GenGammaRV)
+def jax_sample_fn_gengamma(op):
+    r"""Provide a JAX implementation of `GenGammaRV`.
+
+    Samples are obtained from inverse sampling using the following:
+
+    .. math::
+
+        F^{-1}(q; a, d, p) = a \left( G^{-1}(q) \right)^{1/p}
+
+    where :math:`G` is the CDF of a gamma distribution with
+    :math:`\alpha = d/p` and :math:`\beta = 1`.
+
+    .. note::
+
+        Here we use the parametrization :math:`\alpha = d/p`.
+
+    """
+
+    def sample_fn(rng, size, dtype, *parameters):
+        rng_key = rng["jax_state"]
+        rng_key, sampling_key = jax.random.split(rng_key, 2)
+
+        alpha, lam, p = parameters
+        d = alpha / p
+        samples = jax.random.gamma(sampling_key, d, size, dtype)
+        samples = lam * samples ** (1.0 / p)
+
+        rng["rng_state"] = rng_key
+        return (rng, samples)
+
+    return sample_fn

--- a/tests/link/jax/test_random.py
+++ b/tests/link/jax/test_random.py
@@ -342,6 +342,27 @@ def test_random_updates(rng_ctor):
             lambda *args: args,
             None,
         ),
+        (
+            aer.gengamma,
+            [
+                set_test_value(
+                    at.dvector(),
+                    np.array([1.0, 4.0], dtype=np.float64),
+                ),
+                set_test_value(
+                    at.dvector(),
+                    np.array([1.0, 2.0], dtype=np.float64),
+                ),
+                set_test_value(
+                    at.dvector(),
+                    np.array([2.0, 4.0], dtype=np.float64),
+                ),
+            ],
+            (2,),
+            "gengamma",
+            lambda alpha, d, p: (alpha / p, p, 0, d),
+            50_000,
+        ),
     ],
 )
 def test_random_RandomVariable(


### PR DESCRIPTION
Adding a jax implementation of `GenGammaRV`, closing #1333. Could do better with the test I've setup, but I don't think `stats.cramervonmises` can take a named `scale` argument. 

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [x] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
