### PR TITLE
Use different sample sizes for empirical JAX sampler tests

### DIFF
--- a/tests/tensor/random/test_basic.py
+++ b/tests/tensor/random/test_basic.py
@@ -62,6 +62,7 @@ from aesara.tensor.random.basic import (
 )
 from aesara.tensor.rewriting.shape import ShapeFeature
 from aesara.tensor.type import iscalar, scalar, tensor
+from tests import unittest_tools as utt
 from tests.unittest_tools import create_aesara_param
 
 
@@ -93,7 +94,7 @@ def compare_sample_values(rv, *params, rng=None, test_fn=None, **kwargs):
 
     """
     if rng is None:
-        rng = np.random.default_rng()
+        rng = np.random.default_rng(seed=utt.fetch_seed())
 
     if test_fn is None:
         name = getattr(rv, "name", None)


### PR DESCRIPTION
This PR increases the sample sizes for some empirical JAX sampler tests that use Cramér–von Mises.  More specifically, the Student-T and uniform sampler tests have their sample sizes increased.