### PR TITLE
Don't build bin package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ exclude = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["aesara", "bin"]
+packages = ["aesara"]
 
 [tool.coverage.run]
 omit = [


### PR DESCRIPTION
This package has a high probability of conflicting with another package due to the generic name. It is also redundant since the executable now lives in aesara/bin/.
