### PR TITLE
Create a base type for shared RNG variables

### DIFF
--- a/aesara/compile/sharedvalue.py
+++ b/aesara/compile/sharedvalue.py
@@ -3,16 +3,12 @@
 import copy
 from contextlib import contextmanager
 from functools import singledispatch
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
 
-from aesara.graph.basic import Variable
+from aesara.graph.basic import Variable, _TypeType
 from aesara.graph.utils import add_tag_trace
 from aesara.link.basic import Container
 from aesara.link.c.type import generic
-
-
-if TYPE_CHECKING:
-    from aesara.graph.type import Type
 
 
 __SHARED_CONTEXT__: Optional[List[Variable]] = None
@@ -31,12 +27,12 @@ def collect_new_shareds():
         __SHARED_CONTEXT__ = old_context
 
 
-class SharedVariable(Variable):
+class SharedVariable(Variable[_TypeType, None]):
     """Variable that is shared between compiled functions."""
 
     def __init__(
         self,
-        type: "Type",
+        type: _TypeType,
         value,
         strict: bool,
         allow_downcast=None,
@@ -160,7 +156,7 @@ class SharedVariable(Variable):
         return self._default_update
 
     @default_update.setter
-    def default_update(self, value):
+    def default_update(self, value: Optional[Variable]):
         if value is not None:
             self._default_update = self.type.filter_variable(value, allow_convert=True)
         else:

--- a/aesara/tensor/random/var.py
+++ b/aesara/tensor/random/var.py
@@ -1,21 +1,34 @@
 import copy
+from typing import TypeVar
 
 import numpy as np
 
 from aesara.compile.sharedvalue import SharedVariable, shared_constructor
-from aesara.tensor.random.type import random_generator_type, random_state_type
+from aesara.tensor.random.type import (
+    RandomGeneratorType,
+    RandomStateType,
+    RandomType,
+    random_generator_type,
+    random_state_type,
+)
 
 
-class RandomStateSharedVariable(SharedVariable):
+RNGTypeType = TypeVar("RNGTypeType", bound=RandomType)
+
+
+class RandomTypeSharedVariable(SharedVariable[RNGTypeType]):
+    """A `Variable` type representing shared RNG states."""
+
     def __str__(self):
-        return self.name or "RandomStateSharedVariable({})".format(repr(self.container))
+        return self.name or f"{self.__class__}({repr(self.container)})"
 
 
-class RandomGeneratorSharedVariable(SharedVariable):
-    def __str__(self):
-        return self.name or "RandomGeneratorSharedVariable({})".format(
-            repr(self.container)
-        )
+class RandomStateSharedVariable(RandomTypeSharedVariable[RandomStateType]):
+    pass
+
+
+class RandomGeneratorSharedVariable(RandomTypeSharedVariable[RandomGeneratorType]):
+    pass
 
 
 @shared_constructor.register(np.random.RandomState)


### PR DESCRIPTION
This PR creates a base type for shared RNG variables (i.e. a base class for `RandomStateSharedVariable` and `RandomGeneratorSharedVariable`) and fills in some type hints for `SharedVariable` itself.