### PR TITLE
Add JAX implementation for `InvGammaRV`

### DIFF
--- a/aesara/link/jax/dispatch/random.py
+++ b/aesara/link/jax/dispatch/random.py
@@ -453,3 +453,24 @@ def jax_sample_fn_gengamma(op):
         return (rng, samples)
 
     return sample_fn
+
+
+@jax_sample_fn.register(aer.InvGammaRV)
+def jax_sample_fn_invgamma(op):
+    """JAX implementation of `InvGammaRV`."""
+
+    def sample_fn(rng, size, dtype, *parameters):
+        rng_key = rng["jax_state"]
+        rng_key, sampling_key = jax.random.split(rng_key, 2)
+
+        (
+            shape,
+            scale,
+        ) = parameters
+        # InvGamma[shape, scale] <-> 1 / Gamma[shape, 1 / scale]
+        samples = 1 / (jax.random.gamma(sampling_key, shape, size, dtype) / scale)
+
+        rng["jax_state"] = rng_key
+        return (rng, samples)
+
+    return sample_fn

--- a/tests/link/jax/test_random.py
+++ b/tests/link/jax/test_random.py
@@ -467,6 +467,19 @@ def test_random_dirichlet(parameter, size):
     np.testing.assert_allclose(samples.mean(axis=0), 0.5, 1)
 
 
+@pytest.mark.parametrize(
+    "shape, scale",
+    [(3, 3), (2, 1), (2, 5)],
+)
+def test_random_invgamma(shape, scale):
+    rng = shared(np.random.RandomState(123))
+    g = at.random.invgamma(shape, scale, size=(100000,), rng=rng)
+    g_fn = function([], g, mode=jax_mode)
+    samples = g_fn()
+    # mean = scale / (shape - 1) only exists for shape > 1
+    np.testing.assert_allclose(samples.mean(), scale / (shape - 1), rtol=1e-01)
+
+
 def test_random_choice():
     # Elements are picked at equal frequency
     num_samples = 10000


### PR DESCRIPTION
This PR is a draft to close https://github.com/aesara-devs/aesara/issues/1368. Furthermore, I had to change the `.pre-commit-config.yaml` slightly to pass the `mypy` check. This bug has been discussed in https://github.com/aesara-devs/aesara/discussions/1474#discussioncomment-5362160.

@brandonwillard @rlouf let me know what you both think regarding the `types-setuptools` issue. If it hasn't affected anyone else then I would assume you wouldn't want the change to the `.pre-commit-config.yaml`. 


Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [x] There are tests covering the changes introduced in the PR.


*EDIT*: 

Something that I didn't realize in the beginning...from [wolfram](https://reference.wolfram.com/language/ref/InverseGammaDistribution.html): 

"the inverse gamma distribution with shape parameter $\alpha$ and scale parameter $\beta$ is the distribution followed by the inverse of a gamma distribution with shape parameter $\alpha$ and **scale parameter** $\color{red} 1 / \beta$."

Could be useful to say something like:

"the InvGamma(shape, scale) is equivalent to taking the reciprocal of samples from a Gamma(shape, 1 / scale) distribution" in the docs. 

