### PR TITLE
Adjust `RandomTypeSharedVariable.__str__`

### DIFF
--- a/aesara/tensor/random/var.py
+++ b/aesara/tensor/random/var.py
@@ -20,7 +20,7 @@ class RandomTypeSharedVariable(SharedVariable[RNGTypeType]):
     """A `Variable` type representing shared RNG states."""
 
     def __str__(self):
-        return self.name or f"{self.__class__}({repr(self.container)})"
+        return self.name or f"{self.__class__.__name__}({repr(self.container)})"
 
 
 class RandomStateSharedVariable(RandomTypeSharedVariable[RandomStateType]):

--- a/tests/tensor/random/test_var.py
+++ b/tests/tensor/random/test_var.py
@@ -100,3 +100,14 @@ def test_set_value_borrow(rng_ctor):
     rr = rng_ctor(33)
     s_rng.set_value(rr, borrow=True)
     assert rr is s_rng.container.storage[0]
+
+
+def test_RandomTypeSharedVariable_str():
+
+    s_rng = shared(np.random.RandomState(123))
+
+    assert str(s_rng).startswith("RandomStateSharedVariable(")
+
+    s_rng = shared(np.random.default_rng(123))
+
+    assert str(s_rng).startswith("RandomGeneratorSharedVariable(")


### PR DESCRIPTION
This PR fixes the string representation of `RandomTypeSharedVariable` so that it only displays the class name.