### PR TITLE
Enable `pip` caching in CI

### DIFF
--- a/.github/workflows/dev-builds.yml
+++ b/.github/workflows/dev-builds.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
       - name: Install dependencies and customize pyproject.toml
         run: |
           # Download dasel to modify pyproject.toml

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
       - name: Build the sdist and the wheel
         run: |
           python -m pip install -U pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,11 +51,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.changes.outputs.changes == 'true' }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
-    - uses: pre-commit/action@v3.0.0
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
+      - uses: pre-commit/action@v3.0.0
 
   test:
     name: "Test py${{ matrix.python-version }}: ${{ matrix.part }}"
@@ -231,6 +233,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.7
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/update-pre-commit.yml
+++ b/.github/workflows/update-pre-commit.yml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v4
+        with:
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
 
       - uses: browniebroke/pre-commit-autoupdate-action@main
 


### PR DESCRIPTION
This PR sets the `cache` and `cache-dependency-path` argument of `actions/setup-python` to enable pip caching.