### PR TITLE
Removes pydot2 dependency

### DIFF
--- a/requirements-rtd.txt
+++ b/requirements-rtd.txt
@@ -8,7 +8,6 @@ pytest
 numpy
 gnumpy
 pydot
-pydot2
 pydot-ng
 Cython
 scipy>=0.13


### PR DESCRIPTION
This PR fixes #1488 

This PR removes dependency on pydot2 which throws error while installing using pip due to incompibility of setuptools (>v58) with `use_2to3` (ref [stackoverflow link](https://stackoverflow.com/questions/69100275/error-while-downloading-the-requirements-using-pip-install-setup-command-use-2)).

More details about the issue can be found in referenced issue #1488


PR Checklist
+ [X] There is an informative high-level description of the changes.
+ [X] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [X] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [X] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [X] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.

