### PR TITLE
Use NumPy recommended approach to out-of-bounds integer conversion

### DIFF
--- a/aesara/misc/safe_asarray.py
+++ b/aesara/misc/safe_asarray.py
@@ -32,7 +32,7 @@ def _asarray(a, dtype, order=None):
     if str(dtype) == "floatX":
         dtype = config.floatX
     dtype = np.dtype(dtype)  # Convert into dtype object.
-    rval = np.asarray(a, dtype=dtype, order=order)
+    rval = np.asarray(a, order=order).astype(dtype)
     # Note that dtype comparison must be done by comparing their `num`
     # attribute. One cannot assume that two identical data types are pointers
     # towards the same object (e.g. under Windows this appears not to be the


### PR DESCRIPTION
This PR fixes new deprecation errors caused by certain types of conversions to out-of-bounds integers to integer arrays.

The error is as follows:

``` python
DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of 255 to int8 will fail in the future.
For the old behavior, usually:
    np.array(value).astype(dtype)`
will give the desired result (the cast overflows).
```