### PR TITLE
Fix bad initial values shape assumptions in `save_mem_new_scan` rewrite

### DIFF
--- a/tests/scan/test_basic.py
+++ b/tests/scan/test_basic.py
@@ -2950,22 +2950,6 @@ class TestExamples:
         utt.assert_allclose(outs[2], v_w + 3)
         utt.assert_allclose(sh.get_value(), v_w + 4)
 
-    def test_seq_tap_bug_jeremiah(self):
-        inp = np.arange(10).reshape(-1, 1).astype(config.floatX)
-        exp_out = np.zeros((10, 1)).astype(config.floatX)
-        exp_out[4:] = inp[:-4]
-
-        def onestep(x, x_tm4):
-            return x, x_tm4
-
-        seq = matrix()
-        initial_value = shared(np.zeros((4, 1), dtype=config.floatX))
-        outputs_info = [OrderedDict([("initial", initial_value), ("taps", [-4])]), None]
-        results, updates = scan(fn=onestep, sequences=seq, outputs_info=outputs_info)
-
-        f = function([seq], results[1])
-        assert np.all(exp_out == f(inp))
-
     def test_shared_borrow(self):
         """
         This tests two things. The first is a bug occurring when scan wrongly


### PR DESCRIPTION
This PR closes #1499.  The underlying issue was that `save_mem_new_scan` always assumed that the output storage array graphs, which take the form `at.set_subtensor(at.empty[:tap_spread], initial_tap_values)`, would have non-scalar `initial_tap_values`; however, this isn't always the case.

In general, the logic in `save_mem_new_scan` is a bit convoluted and unclear about the assumptions it makes.  These changes don't completely fix that, but they do provide some refactoring that improves the situation a little.