### PR TITLE
DOC: Remove redundant import of `TensorType` in tensor creation docs

### DIFF
--- a/doc/reference/tensor/create.rst
+++ b/doc/reference/tensor/create.rst
@@ -16,8 +16,7 @@ for a 0-dimensional `ndarray` of integers with the name ``'myvar'``:
 >>> x = at.scalar('myvar', dtype='int32')
 >>> x = at.iscalar('myvar')
 >>> x = at.tensor(dtype='int32', shape=(), name='myvar')
->>> from aesara.tensor.type import TensorType
->>> x = TensorType(dtype='int32', shape=())('myvar')
+>>> x = at.TensorType(dtype='int32', shape=())('myvar')
 
 Basic constructors
 ------------------


### PR DESCRIPTION
This PR removes a redundant import of `TensorType` in the tensor creation section of the docs.

**Thank you for opening a PR!**

Here are a few important guidelines and requirements to check before your PR can be merged:
+ [x] There is an informative high-level description of the changes.
+ [x] The description and/or commit message(s) references the relevant GitHub issue(s).
+ [x] [`pre-commit`](https://pre-commit.com/#installation) is installed and [set up](https://pre-commit.com/#3-install-the-git-hook-scripts).
+ [x] The commit messages follow [these guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+ [x] The commits correspond to [_relevant logical changes_](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes), and there are **no commits that fix changes introduced by other commits in the same branch/BR**.
+ [ ] There are tests covering the changes introduced in the PR.

Don't worry, your PR doesn't need to be in perfect order to submit it.  As development progresses and/or reviewers request changes, you can always [rewrite the history](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History#_rewriting_history) of your feature/PR branches.

If your PR is an ongoing effort and you would like to involve us in the process, simply make it a [draft PR](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
